### PR TITLE
Recalculate the text size after all fonts are loaded

### DIFF
--- a/.changeset/sharp-mice-doubt.md
+++ b/.changeset/sharp-mice-doubt.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+Recalculate the text size after all fonts are loaded.

--- a/src/AppContainer.tsx
+++ b/src/AppContainer.tsx
@@ -27,6 +27,7 @@ import { GuidedTourProvider } from './components/GuidedTour';
 import { LayoutStateProvider } from './components/Layout';
 import { DraggableStyles } from './components/Whiteboard';
 import { WhiteboardHotkeysProvider } from './components/WhiteboardHotkeysProvider';
+import { FontsLoadedContextProvider } from './lib';
 import { WhiteboardManager, WhiteboardManagerProvider } from './state';
 import { StoreType } from './store';
 
@@ -56,13 +57,15 @@ export const AppContainer = ({
                 type: 'net.nordeck.whiteboard:pad',
               }}
             >
-              <LayoutStateProvider>
-                <WhiteboardHotkeysProvider>
-                  <GuidedTourProvider>
-                    <App />
-                  </GuidedTourProvider>
-                </WhiteboardHotkeysProvider>
-              </LayoutStateProvider>
+              <FontsLoadedContextProvider>
+                <LayoutStateProvider>
+                  <WhiteboardHotkeysProvider>
+                    <GuidedTourProvider>
+                      <App />
+                    </GuidedTourProvider>
+                  </WhiteboardHotkeysProvider>
+                </LayoutStateProvider>
+              </FontsLoadedContextProvider>
             </MuiWidgetApiProvider>
           </Suspense>
         </MuiThemeProvider>

--- a/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
+++ b/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
@@ -25,6 +25,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { useFontsLoaded } from '../../../../lib';
 import {
   HOTKEY_SCOPE_WHITEBOARD,
   usePauseHotkeysScope,
@@ -184,6 +185,8 @@ export function TextEditor({
     }
   }, [textRef, editable]);
 
+  const fontsLoaded = useFontsLoaded();
+
   useLayoutEffect(() => {
     // Every time content or the shape changes, re-calculate the perfect font size
     if (textRef.current) {
@@ -192,9 +195,10 @@ export function TextEditor({
   }, [
     textRef,
     content,
-    // Width and height are used to trigger calculating the size
+    // Width, height, and fontsLoaded are used to trigger calculating the size
     width,
     height,
+    fontsLoaded,
   ]);
 
   return (

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -15,5 +15,6 @@
  */
 
 export { isDefined } from './isDefined';
+export { FontsLoadedContextProvider, useFontsLoaded } from './useFontsLoaded';
 export { useLatestValue } from './useLatestValue';
 export { getUserColor } from './userColor';

--- a/src/lib/useFontsLoaded.test.tsx
+++ b/src/lib/useFontsLoaded.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { ComponentType, PropsWithChildren } from 'react';
+import { FontsLoadedContextProvider, useFontsLoaded } from './useFontsLoaded';
+
+describe('useFontsLoaded', () => {
+  let Wrapper: ComponentType<PropsWithChildren<{}>>;
+
+  beforeEach(() => {
+    Wrapper = ({ children }: PropsWithChildren<{}>) => (
+      <FontsLoadedContextProvider>{children}</FontsLoadedContextProvider>
+    );
+  });
+
+  it('should return false if the fonts were not loaded', () => {
+    const { result } = renderHook(() => useFontsLoaded(), { wrapper: Wrapper });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('should return true after the fonts were loaded', async () => {
+    let resolveFontFace: () => void = () => {};
+
+    Object.defineProperty(document, 'fonts', {
+      value: {
+        ready: Promise.resolve([
+          {
+            loaded: new Promise<void>((resolve) => {
+              resolveFontFace = resolve;
+            }),
+          },
+        ]),
+      },
+    });
+
+    const { result } = renderHook(() => useFontsLoaded(), { wrapper: Wrapper });
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      resolveFontFace();
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+});

--- a/src/lib/useFontsLoaded.tsx
+++ b/src/lib/useFontsLoaded.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createContext,
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import { from, mergeAll, switchMap } from 'rxjs';
+
+export const FontsLoadedContext = createContext<boolean>(false);
+
+export function FontsLoadedContextProvider({
+  children,
+}: PropsWithChildren<{}>) {
+  const [fontsLoaded, setFontsLoaded] = useState(false);
+
+  useEffect(() => {
+    // 1. wait until the fontFaceSet is ready (i.e. we known which fonts we are waiting for).
+    // 2. wait until the first font is loaded. Not all fonts will resolve because they might not be used (yet).
+    const subscription = from(document.fonts.ready)
+      .pipe(
+        switchMap((fontFaceSet) =>
+          [...fontFaceSet].map((fontFace) => fontFace.loaded)
+        ),
+        mergeAll()
+      )
+      .subscribe(() => {
+        setFontsLoaded(true);
+      });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  return (
+    <FontsLoadedContext.Provider value={fontsLoaded}>
+      {children}
+    </FontsLoadedContext.Provider>
+  );
+}
+
+/**
+ * @returns if true, all relevant fonts are loaded
+ */
+export function useFontsLoaded(): boolean {
+  return useContext(FontsLoadedContext);
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -56,6 +56,12 @@ Object.defineProperty(window, 'location', {
   ),
 });
 
+// Provide a mock for the CSS Font Loading API
+Object.defineProperty(document, 'fonts', {
+  value: { ready: new Promise(() => {}) },
+  configurable: true,
+});
+
 setLocale('en');
 
 // Polyfills required for jsdom


### PR DESCRIPTION
Fixes the problem that the text sizes are wrong when loading the widget.

The hook only waits for the first font to resolve (at the moment this will only be the regular `Inter` font).

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
