### PR TITLE
PB-1049: Extract render configuration and improve performance

### DIFF
--- a/src/components/Whiteboard/ElementBehaviors/ContextMenu/ElementContextMenu.test.tsx
+++ b/src/components/Whiteboard/ElementBehaviors/ContextMenu/ElementContextMenu.test.tsx
@@ -127,22 +127,6 @@ describe('<ElementContextMenu/>', () => {
     ).toBeInTheDocument();
   });
 
-  it('should not open the context menu when readonly', async () => {
-    render(<ElementContextMenu elementId="element-1" readOnly />, {
-      wrapper: Wrapper,
-    });
-
-    const contextMenuTarget = screen.getByTestId(
-      'element-context-menu-container'
-    );
-    await userEvent.pointer({
-      keys: '[MouseRight]',
-      target: contextMenuTarget,
-    });
-
-    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
-  });
-
   it('should have no accessibility violations', async () => {
     const { container } = render(<ElementContextMenu elementId="id" />, {
       wrapper: Wrapper,

--- a/src/components/Whiteboard/ElementBehaviors/ContextMenu/ElementContextMenu.tsx
+++ b/src/components/Whiteboard/ElementBehaviors/ContextMenu/ElementContextMenu.tsx
@@ -41,8 +41,7 @@ type ContextMenuState =
 export function ElementContextMenu({
   children,
   elementId,
-  readOnly,
-}: PropsWithChildren<{ elementId: string; readOnly?: boolean }>) {
+}: PropsWithChildren<{ elementId: string }>) {
   const { t } = useTranslation();
   const isLocked = useSlideIsLocked();
   const [state, setState] = useState<ContextMenuState>();
@@ -135,7 +134,7 @@ export function ElementContextMenu({
           dense: true,
           sx: { minWidth: '242px' },
         }}
-        open={open && !isLocked && !readOnly}
+        open={open && !isLocked}
         onClose={handleClose}
         anchorReference="anchorPosition"
         anchorPosition={state?.position}

--- a/src/components/Whiteboard/ElementBehaviors/Moveable/MoveableElement.tsx
+++ b/src/components/Whiteboard/ElementBehaviors/Moveable/MoveableElement.tsx
@@ -33,16 +33,13 @@ import { snapToGrid } from '../../Grid';
 import { useSvgCanvasContext } from '../../SvgCanvas';
 import { addUserSelectStyles, removeUserSelectStyles } from './DraggableStyles';
 
-const DraggableGroup = styled('g', {
-  shouldForwardProp: (p) => p !== 'readOnly',
-})<{ readOnly: boolean }>(({ readOnly }) => ({
-  cursor: readOnly ? 'inherit' : 'move',
-}));
+const DraggableGroup = styled('g')({
+  cursor: 'move',
+});
 
 export type MoveableElementProps = PropsWithChildren<
   Element & {
     elementId: string;
-    readOnly: boolean;
     customWidth: number;
     customHeight: number;
   }
@@ -51,7 +48,6 @@ export type MoveableElementProps = PropsWithChildren<
 export function MoveableElement({
   children,
   elementId,
-  readOnly,
   customWidth,
   customHeight,
   ...element
@@ -136,7 +132,6 @@ export function MoveableElement({
 
   return (
     <DraggableCore
-      disabled={readOnly}
       // disable the hack since we already added it via <DraggableStyles>.
       enableUserSelectHack={false}
       nodeRef={nodeRef as unknown as RefObject<HTMLElement>}
@@ -145,9 +140,7 @@ export function MoveableElement({
       onStart={handleStart}
       scale={scale}
     >
-      <DraggableGroup readOnly={readOnly} ref={nodeRef}>
-        {children}
-      </DraggableGroup>
+      <DraggableGroup ref={nodeRef}>{children}</DraggableGroup>
     </DraggableCore>
   );
 }

--- a/src/components/Whiteboard/ElementBehaviors/Selection/SelectableElement.tsx
+++ b/src/components/Whiteboard/ElementBehaviors/Selection/SelectableElement.tsx
@@ -24,7 +24,6 @@ export type SelectableElementProps = PropsWithChildren<WithSelectionProps>;
 export function SelectableElement({
   children,
   elementId,
-  readOnly,
 }: SelectableElementProps) {
   const slideInstance = useWhiteboardSlideInstance();
   const { activeTool } = useLayoutState();
@@ -37,5 +36,5 @@ export function SelectableElement({
     }
   }
 
-  return <g onMouseDown={readOnly ? undefined : handleMouseDown}>{children}</g>;
+  return <g onMouseDown={handleMouseDown}>{children}</g>;
 }

--- a/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
+++ b/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
@@ -106,7 +106,7 @@ export function TextEditor({
 }: TextEditorProps) {
   const textRef = useRef<HTMLDivElement>(null);
   const [isEditMode, setEditMode] = useState(editModeOnMount);
-  usePauseHotkeysScope(HOTKEY_SCOPE_WHITEBOARD, isEditMode);
+  usePauseHotkeysScope(HOTKEY_SCOPE_WHITEBOARD, isEditMode && editable);
 
   useEffect(() => {
     if (!editable && isEditMode) {

--- a/src/components/Whiteboard/ElementBehaviors/Text/TextElement.tsx
+++ b/src/components/Whiteboard/ElementBehaviors/Text/TextElement.tsx
@@ -18,8 +18,7 @@ import { styled } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 import { useUnmount } from 'react-use';
 import tinycolor2 from 'tinycolor2';
-import { ShapeElement, useWhiteboardSlideInstance } from '../../../../state';
-import { useMeasure } from '../../SvgCanvas';
+import { useWhiteboardSlideInstance } from '../../../../state';
 import { TextEditor } from './TextEditor';
 
 function findForegroundColor(backgroundColor: string) {
@@ -42,59 +41,57 @@ const ForeignObjectNoInteraction = styled('foreignObject')({
   pointerEvents: 'none',
 });
 
-export type TextElementProps = ShapeElement & {
+export type TextElementProps = {
   active?: boolean;
-  paddingLeft?: number;
-  paddingRight?: number;
-  paddingTop?: number;
-  paddingBottom?: number;
+  text: string;
+
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+
+  fillColor: string;
   elementId: string;
 };
 
 export const TextElement = ({
-  paddingTop = 0,
-  paddingLeft = 0,
-  paddingBottom = 0,
-  paddingRight = 0,
   active,
+  text,
+  x,
+  y,
+  width,
+  height,
+  fillColor,
   elementId,
-  ...shape
 }: TextElementProps) => {
-  const [ref, { width, height }] = useMeasure<SVGForeignObjectElement>();
   const slideInstance = useWhiteboardSlideInstance();
-  const [unsubmittedText, setUnsubmittedText] = useState<string>(shape.text);
+  const [unsubmittedText, setUnsubmittedText] = useState(text);
   const activeElement = slideInstance.getElement(elementId);
 
   useEffect(() => {
-    setUnsubmittedText(shape.text);
-  }, [shape.text]);
+    setUnsubmittedText(text);
+  }, [text]);
 
   const handleTextChange = useCallback((text: string) => {
     setUnsubmittedText(text);
   }, []);
 
   const handleBlur = useCallback(() => {
-    if (unsubmittedText !== shape.text) {
+    if (unsubmittedText !== text) {
       // TODO: Implement concurrent editing of text
       slideInstance.updateElement(elementId, {
         text: unsubmittedText,
       });
     }
-  }, [elementId, shape.text, slideInstance, unsubmittedText]);
+  }, [elementId, slideInstance, text, unsubmittedText]);
 
   // If text editing is exited before the blur is received force a submit
   useUnmount(handleBlur);
 
   return (
-    <ForeignObjectNoInteraction
-      ref={ref}
-      x={paddingLeft}
-      y={paddingTop}
-      height={shape.height - paddingTop - paddingBottom}
-      width={shape.width - paddingLeft - paddingRight}
-    >
+    <ForeignObjectNoInteraction x={x} y={y} height={height} width={width}>
       <TextEditor
-        color={findForegroundColor(shape.fillColor)}
+        color={findForegroundColor(fillColor)}
         content={unsubmittedText}
         editModeOnMount={
           activeElement?.type === 'shape' &&

--- a/src/components/Whiteboard/SvgCanvas/SvgCanvas.tsx
+++ b/src/components/Whiteboard/SvgCanvas/SvgCanvas.tsx
@@ -20,9 +20,8 @@ import {
   PropsWithChildren,
   ReactNode,
   useCallback,
-  useLayoutEffect,
+  useMemo,
   useRef,
-  useState,
 } from 'react';
 import { Point } from '../../../state';
 import { SvgCanvasContext, SvgCanvasContextType } from './context';
@@ -71,25 +70,18 @@ export function SvgCanvas({
     },
     [svgRef]
   );
-  const [value, setValue] = useState<SvgCanvasContextType>({
-    width,
-    height,
-    viewportWidth,
-    viewportHeight,
-    scale: calculateScale(width, height, viewportWidth, viewportHeight),
-    calculateSvgCoords: calculateSvgCoordsFunc,
-  });
 
-  useLayoutEffect(() => {
-    setValue({
+  const value = useMemo<SvgCanvasContextType>(
+    () => ({
       width,
       height,
       viewportWidth,
       viewportHeight,
       scale: calculateScale(width, height, viewportWidth, viewportHeight),
       calculateSvgCoords: calculateSvgCoordsFunc,
-    });
-  }, [viewportWidth, viewportHeight, calculateSvgCoordsFunc, width, height]);
+    }),
+    [calculateSvgCoordsFunc, height, viewportHeight, viewportWidth, width]
+  );
 
   const aspectRatio = `${viewportWidth} / ${viewportHeight}`;
 

--- a/src/components/Whiteboard/types.ts
+++ b/src/components/Whiteboard/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Nordeck IT + Consulting GmbH
+ * Copyright 2023 Nordeck IT + Consulting GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,20 @@
  * limitations under the License.
  */
 
-export { gridCellSize, whiteboardHeight, whiteboardWidth } from './constants';
-export * from './Draft';
-export * from './ElementBehaviors';
-export * from './Grid';
-export { SlidePreview } from './SlidePreview';
-export type { ElementRenderProperties } from './types';
-export { WhiteboardHostConnected as WhiteboardHost } from './WhiteboardHost';
+/** Common properties of elements that describes the rendering */
+export type ElementRenderProperties = {
+  /** The color of the stroke */
+  strokeColor?: string;
+  /** The width of the stroke */
+  strokeWidth: number;
+
+  /**
+   * Properties for the text field is displayed on top of the element. Positions
+   * are absolute coordinates in the canvas.
+   */
+  text?: {
+    position: { x: number; y: number };
+    width: number;
+    height: number;
+  };
+};

--- a/src/components/elements/ellipse/Display.tsx
+++ b/src/components/elements/ellipse/Display.tsx
@@ -23,6 +23,7 @@ import {
   TextElement,
   WithSelectionProps,
 } from '../../Whiteboard';
+import { getRenderProperties } from './getRenderProperties';
 
 export type EllipseElementProps = ShapeElement & WithSelectionProps;
 
@@ -32,8 +33,6 @@ const EllipseDisplay = ({
   elementId,
   ...shape
 }: EllipseElementProps) => {
-  const strokeWidth = 2;
-  const strokeColor = shape.fillColor;
   const width = shape.width;
   const height = shape.height;
 
@@ -42,12 +41,7 @@ const EllipseDisplay = ({
   const rx = width / 2;
   const ry = height / 2;
 
-  // Based on http://mathcentral.uregina.ca/QQ/database/QQ.09.04/bob1.html
-  // just for both axis individually
-  const fitSquareLengthX = Math.sqrt(width ** 2 / 2);
-  const fitSquareLengthY = Math.sqrt(height ** 2 / 2);
-  const horizontalPadding = (width - fitSquareLengthX) / 2;
-  const verticalPadding = (height - fitSquareLengthY) / 2;
+  const { strokeColor, strokeWidth, text } = getRenderProperties(shape);
 
   return (
     <SelectableElement
@@ -63,25 +57,29 @@ const EllipseDisplay = ({
         {...shape}
       >
         <ElementContextMenu elementId={elementId} readOnly={readOnly}>
-          <g transform={`translate(${shape.position.x} ${shape.position.y})`}>
+          <g>
             <ellipse
-              cx={cx}
-              cy={cy}
+              cx={shape.position.x + cx}
+              cy={shape.position.y + cy}
               fill={shape.fillColor}
               rx={rx}
               ry={ry}
               stroke={strokeColor}
               strokeWidth={strokeWidth}
             />
-            <TextElement
-              elementId={elementId}
-              active={active}
-              paddingBottom={verticalPadding}
-              paddingLeft={horizontalPadding}
-              paddingRight={horizontalPadding}
-              paddingTop={verticalPadding}
-              {...shape}
-            />
+
+            {text && (
+              <TextElement
+                active={active}
+                text={shape.text}
+                elementId={elementId}
+                x={text.position.x}
+                y={text.position.y}
+                width={text.width}
+                height={text.height}
+                fillColor={shape.fillColor}
+              />
+            )}
           </g>
         </ElementContextMenu>
       </MoveableElement>

--- a/src/components/elements/ellipse/Display.tsx
+++ b/src/components/elements/ellipse/Display.tsx
@@ -83,11 +83,10 @@ const EllipseDisplay = ({
       <MoveableElement
         customHeight={shape.height}
         customWidth={shape.width}
-        readOnly={readOnly}
         elementId={elementId}
         {...shape}
       >
-        <ElementContextMenu elementId={elementId} readOnly={readOnly}>
+        <ElementContextMenu elementId={elementId}>
           {renderedChild}
         </ElementContextMenu>
       </MoveableElement>

--- a/src/components/elements/ellipse/Display.tsx
+++ b/src/components/elements/ellipse/Display.tsx
@@ -43,6 +43,37 @@ const EllipseDisplay = ({
 
   const { strokeColor, strokeWidth, text } = getRenderProperties(shape);
 
+  const renderedChild = (
+    <g>
+      <ellipse
+        cx={shape.position.x + cx}
+        cy={shape.position.y + cy}
+        fill={shape.fillColor}
+        rx={rx}
+        ry={ry}
+        stroke={strokeColor}
+        strokeWidth={strokeWidth}
+      />
+
+      {text && (
+        <TextElement
+          active={active}
+          text={shape.text}
+          elementId={elementId}
+          x={text.position.x}
+          y={text.position.y}
+          width={text.width}
+          height={text.height}
+          fillColor={shape.fillColor}
+        />
+      )}
+    </g>
+  );
+
+  if (readOnly) {
+    return renderedChild;
+  }
+
   return (
     <SelectableElement
       active={active}
@@ -57,30 +88,7 @@ const EllipseDisplay = ({
         {...shape}
       >
         <ElementContextMenu elementId={elementId} readOnly={readOnly}>
-          <g>
-            <ellipse
-              cx={shape.position.x + cx}
-              cy={shape.position.y + cy}
-              fill={shape.fillColor}
-              rx={rx}
-              ry={ry}
-              stroke={strokeColor}
-              strokeWidth={strokeWidth}
-            />
-
-            {text && (
-              <TextElement
-                active={active}
-                text={shape.text}
-                elementId={elementId}
-                x={text.position.x}
-                y={text.position.y}
-                width={text.width}
-                height={text.height}
-                fillColor={shape.fillColor}
-              />
-            )}
-          </g>
+          {renderedChild}
         </ElementContextMenu>
       </MoveableElement>
     </SelectableElement>

--- a/src/components/elements/ellipse/getRenderProperties.test.ts
+++ b/src/components/elements/ellipse/getRenderProperties.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getRenderProperties } from './getRenderProperties';
+
+describe('getRenderProperties', () => {
+  it('should provide the properties for an ellipse element', () => {
+    const view = getRenderProperties({
+      type: 'shape',
+      kind: 'ellipse',
+      position: { x: 10, y: 15 },
+      fillColor: '#00ffff',
+      width: 100,
+      height: 50,
+      text: 'My Text',
+    });
+
+    expect(view).toEqual({
+      strokeColor: '#00ffff',
+      strokeWidth: 2,
+
+      text: {
+        position: { x: expect.any(Number), y: expect.any(Number) },
+        width: expect.any(Number),
+        height: expect.any(Number),
+      },
+    });
+
+    expect(view.text?.position.x).toBeCloseTo(24.6, 1);
+    expect(view.text?.position.y).toBeCloseTo(22.3, 1);
+    expect(view.text?.width).toBeCloseTo(70.7, 1);
+    expect(view.text?.height).toBeCloseTo(35.35, 1);
+  });
+});

--- a/src/components/elements/ellipse/getRenderProperties.ts
+++ b/src/components/elements/ellipse/getRenderProperties.ts
@@ -39,8 +39,8 @@ export function getRenderProperties(
         x: shape.position.x + horizontalPadding,
         y: shape.position.y + verticalPadding,
       },
-      width: width - horizontalPadding * 2,
-      height: height - verticalPadding * 2,
+      width: fitSquareLengthX,
+      height: fitSquareLengthY,
     },
   };
 }

--- a/src/components/elements/ellipse/getRenderProperties.ts
+++ b/src/components/elements/ellipse/getRenderProperties.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ShapeElement } from '../../../state';
+import { ElementRenderProperties } from '../../Whiteboard';
+
+export function getRenderProperties(
+  shape: ShapeElement
+): ElementRenderProperties {
+  const width = shape.width;
+  const height = shape.height;
+
+  // Based on http://mathcentral.uregina.ca/QQ/database/QQ.09.04/bob1.html
+  // just for both axis individually
+  const fitSquareLengthX = Math.sqrt(width ** 2 / 2);
+  const fitSquareLengthY = Math.sqrt(height ** 2 / 2);
+  const horizontalPadding = (width - fitSquareLengthX) / 2;
+  const verticalPadding = (height - fitSquareLengthY) / 2;
+
+  return {
+    strokeColor: shape.fillColor,
+    strokeWidth: 2,
+
+    text: {
+      position: {
+        x: shape.position.x + horizontalPadding,
+        y: shape.position.y + verticalPadding,
+      },
+      width: width - horizontalPadding * 2,
+      height: height - verticalPadding * 2,
+    },
+  };
+}

--- a/src/components/elements/line/Display.tsx
+++ b/src/components/elements/line/Display.tsx
@@ -39,6 +39,24 @@ const LineDisplay = ({
     box,
   } = getRenderProperties(element);
 
+  const renderedChild = (
+    <g transform={`translate(${element.position.x} ${element.position.y})`}>
+      <line
+        fill="none"
+        stroke={strokeColor}
+        strokeWidth={strokeWidth}
+        x1={start.x}
+        x2={end.x}
+        y1={start.y}
+        y2={end.y}
+      />
+    </g>
+  );
+
+  if (readOnly) {
+    return renderedChild;
+  }
+
   return (
     <SelectableElement
       active={active}
@@ -53,19 +71,7 @@ const LineDisplay = ({
         {...element}
       >
         <ElementContextMenu elementId={elementId} readOnly={readOnly}>
-          <g
-            transform={`translate(${element.position.x} ${element.position.y})`}
-          >
-            <line
-              fill="none"
-              stroke={strokeColor}
-              strokeWidth={strokeWidth}
-              x1={start.x}
-              x2={end.x}
-              y1={start.y}
-              y2={end.y}
-            />
-          </g>
+          {renderedChild}
         </ElementContextMenu>
       </MoveableElement>
     </SelectableElement>

--- a/src/components/elements/line/Display.tsx
+++ b/src/components/elements/line/Display.tsx
@@ -40,7 +40,7 @@ const LineDisplay = ({
   } = getRenderProperties(element);
 
   const renderedChild = (
-    <g transform={`translate(${element.position.x} ${element.position.y})`}>
+    <g>
       <line
         fill="none"
         stroke={strokeColor}

--- a/src/components/elements/line/Display.tsx
+++ b/src/components/elements/line/Display.tsx
@@ -15,13 +15,14 @@
  */
 
 import React from 'react';
-import { calculateBoundingRectForPoints, PathElement } from '../../../state';
+import { PathElement } from '../../../state';
 import {
   ElementContextMenu,
   MoveableElement,
   SelectableElement,
   WithSelectionProps,
 } from '../../Whiteboard';
+import { getRenderProperties } from './getRenderProperties';
 
 export type LineElementProps = PathElement & WithSelectionProps;
 
@@ -31,11 +32,12 @@ const LineDisplay = ({
   elementId,
   ...element
 }: LineElementProps) => {
-  const strokeWidth = 4;
-  const { width, height } = calculateBoundingRectForPoints(element.points);
-
-  const start = element.points[0];
-  const end = element.points[element.points.length - 1];
+  const {
+    strokeColor,
+    strokeWidth,
+    points: { start, end },
+    box,
+  } = getRenderProperties(element);
 
   return (
     <SelectableElement
@@ -44,8 +46,8 @@ const LineDisplay = ({
       elementId={elementId}
     >
       <MoveableElement
-        customHeight={height}
-        customWidth={width}
+        customHeight={box.height}
+        customWidth={box.width}
         readOnly={readOnly}
         elementId={elementId}
         {...element}
@@ -56,7 +58,7 @@ const LineDisplay = ({
           >
             <line
               fill="none"
-              stroke={element.strokeColor}
+              stroke={strokeColor}
               strokeWidth={strokeWidth}
               x1={start.x}
               x2={end.x}

--- a/src/components/elements/line/Display.tsx
+++ b/src/components/elements/line/Display.tsx
@@ -66,11 +66,10 @@ const LineDisplay = ({
       <MoveableElement
         customHeight={box.height}
         customWidth={box.width}
-        readOnly={readOnly}
         elementId={elementId}
         {...element}
       >
-        <ElementContextMenu elementId={elementId} readOnly={readOnly}>
+        <ElementContextMenu elementId={elementId}>
           {renderedChild}
         </ElementContextMenu>
       </MoveableElement>

--- a/src/components/elements/line/getRenderProperties.test.ts
+++ b/src/components/elements/line/getRenderProperties.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getRenderProperties } from './getRenderProperties';
+
+describe('getRenderProperties', () => {
+  it('should provide the properties for a line element', () => {
+    expect(
+      getRenderProperties({
+        type: 'path',
+        kind: 'line',
+        position: { x: 10, y: 15 },
+        strokeColor: '#00ffff',
+        points: [
+          { x: 0, y: 1 },
+          { x: 2, y: 3 },
+        ],
+      })
+    ).toEqual({
+      strokeColor: '#00ffff',
+      strokeWidth: 4,
+
+      points: {
+        start: { x: 10, y: 16 },
+        end: { x: 12, y: 18 },
+      },
+
+      box: {
+        height: 2,
+        width: 2,
+      },
+    });
+  });
+});

--- a/src/components/elements/line/getRenderProperties.ts
+++ b/src/components/elements/line/getRenderProperties.ts
@@ -38,7 +38,16 @@ export function getRenderProperties(
     strokeColor: element.strokeColor,
     strokeWidth: 4,
 
-    points: { start, end },
+    points: {
+      start: {
+        x: element.position.x + start.x,
+        y: element.position.y + start.y,
+      },
+      end: {
+        x: element.position.x + end.x,
+        y: element.position.y + end.y,
+      },
+    },
     box: { width, height },
   };
 }

--- a/src/components/elements/line/getRenderProperties.ts
+++ b/src/components/elements/line/getRenderProperties.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  calculateBoundingRectForPoints,
+  PathElement,
+  Point,
+} from '../../../state';
+import { ElementRenderProperties } from '../../Whiteboard';
+
+type PolylineRenderProperties = {
+  points: { start: Point; end: Point };
+  box: { width: number; height: number };
+};
+
+export function getRenderProperties(
+  element: PathElement
+): ElementRenderProperties & PolylineRenderProperties {
+  const { width, height } = calculateBoundingRectForPoints(element.points);
+
+  const start = element.points[0];
+  const end = element.points[element.points.length - 1];
+
+  return {
+    strokeColor: element.strokeColor,
+    strokeWidth: 4,
+
+    points: { start, end },
+    box: { width, height },
+  };
+}

--- a/src/components/elements/polyline/Display.tsx
+++ b/src/components/elements/polyline/Display.tsx
@@ -60,11 +60,10 @@ const PolylineDisplay = ({
       <MoveableElement
         customHeight={box.height}
         customWidth={box.width}
-        readOnly={readOnly}
         elementId={elementId}
         {...element}
       >
-        <ElementContextMenu elementId={elementId} readOnly={readOnly}>
+        <ElementContextMenu elementId={elementId}>
           {renderedChild}
         </ElementContextMenu>
       </MoveableElement>

--- a/src/components/elements/polyline/Display.tsx
+++ b/src/components/elements/polyline/Display.tsx
@@ -15,13 +15,14 @@
  */
 
 import React from 'react';
-import { calculateBoundingRectForPoints, PathElement } from '../../../state';
+import { PathElement } from '../../../state';
 import {
   ElementContextMenu,
   MoveableElement,
   SelectableElement,
   WithSelectionProps,
 } from '../../Whiteboard';
+import { getRenderProperties } from './getRenderProperties';
 
 export type PolylineElementProps = PathElement & WithSelectionProps;
 
@@ -31,8 +32,8 @@ const PolylineDisplay = ({
   elementId,
   ...element
 }: PolylineElementProps) => {
-  const strokeWidth = 4;
-  const { width, height } = calculateBoundingRectForPoints(element.points);
+  const { strokeColor, strokeWidth, points, box } =
+    getRenderProperties(element);
 
   return (
     <SelectableElement
@@ -41,8 +42,8 @@ const PolylineDisplay = ({
       elementId={elementId}
     >
       <MoveableElement
-        customHeight={height}
-        customWidth={width}
+        customHeight={box.height}
+        customWidth={box.width}
         readOnly={readOnly}
         elementId={elementId}
         {...element}
@@ -53,8 +54,8 @@ const PolylineDisplay = ({
           >
             <polyline
               fill="none"
-              points={element.points.map(({ x, y }) => `${x},${y}`).join(' ')}
-              stroke={element.strokeColor}
+              points={points.map(({ x, y }) => `${x},${y}`).join(' ')}
+              stroke={strokeColor}
               strokeLinejoin="round"
               strokeWidth={strokeWidth}
             />

--- a/src/components/elements/polyline/Display.tsx
+++ b/src/components/elements/polyline/Display.tsx
@@ -36,7 +36,7 @@ const PolylineDisplay = ({
     getRenderProperties(element);
 
   const renderedChild = (
-    <g transform={`translate(${element.position.x} ${element.position.y})`}>
+    <g>
       <polyline
         fill="none"
         points={points.map(({ x, y }) => `${x},${y}`).join(' ')}

--- a/src/components/elements/polyline/Display.tsx
+++ b/src/components/elements/polyline/Display.tsx
@@ -35,6 +35,22 @@ const PolylineDisplay = ({
   const { strokeColor, strokeWidth, points, box } =
     getRenderProperties(element);
 
+  const renderedChild = (
+    <g transform={`translate(${element.position.x} ${element.position.y})`}>
+      <polyline
+        fill="none"
+        points={points.map(({ x, y }) => `${x},${y}`).join(' ')}
+        stroke={strokeColor}
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth}
+      />
+    </g>
+  );
+
+  if (readOnly) {
+    return renderedChild;
+  }
+
   return (
     <SelectableElement
       active={active}
@@ -49,17 +65,7 @@ const PolylineDisplay = ({
         {...element}
       >
         <ElementContextMenu elementId={elementId} readOnly={readOnly}>
-          <g
-            transform={`translate(${element.position.x} ${element.position.y})`}
-          >
-            <polyline
-              fill="none"
-              points={points.map(({ x, y }) => `${x},${y}`).join(' ')}
-              stroke={strokeColor}
-              strokeLinejoin="round"
-              strokeWidth={strokeWidth}
-            />
-          </g>
+          {renderedChild}
         </ElementContextMenu>
       </MoveableElement>
     </SelectableElement>

--- a/src/components/elements/polyline/getRenderProperties.test.ts
+++ b/src/components/elements/polyline/getRenderProperties.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getRenderProperties } from './getRenderProperties';
+
+describe('getRenderProperties', () => {
+  it('should provide the properties for a polyline element', () => {
+    expect(
+      getRenderProperties({
+        type: 'path',
+        kind: 'polyline',
+        position: { x: 10, y: 15 },
+        strokeColor: '#00ffff',
+        points: [
+          { x: 0, y: 1 },
+          { x: 2, y: 3 },
+          { x: 5, y: 10 },
+        ],
+      })
+    ).toEqual({
+      strokeColor: '#00ffff',
+      strokeWidth: 4,
+
+      points: [
+        { x: 10, y: 16 },
+        { x: 12, y: 18 },
+        { x: 15, y: 25 },
+      ],
+      box: {
+        height: 9,
+        width: 5,
+      },
+    });
+  });
+});

--- a/src/components/elements/polyline/getRenderProperties.ts
+++ b/src/components/elements/polyline/getRenderProperties.ts
@@ -35,7 +35,10 @@ export function getRenderProperties(
     strokeColor: element.strokeColor,
     strokeWidth: 4,
 
-    points: element.points,
+    points: element.points.map(({ x, y }) => ({
+      x: element.position.x + x,
+      y: element.position.y + y,
+    })),
     box: { width, height },
   };
 }

--- a/src/components/elements/polyline/getRenderProperties.ts
+++ b/src/components/elements/polyline/getRenderProperties.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  calculateBoundingRectForPoints,
+  PathElement,
+  Point,
+} from '../../../state';
+import { ElementRenderProperties } from '../../Whiteboard';
+
+type PolylineRenderProperties = {
+  points: Point[];
+  box: { width: number; height: number };
+};
+
+export function getRenderProperties(
+  element: PathElement
+): ElementRenderProperties & PolylineRenderProperties {
+  const { width, height } = calculateBoundingRectForPoints(element.points);
+
+  return {
+    strokeColor: element.strokeColor,
+    strokeWidth: 4,
+
+    points: element.points,
+    box: { width, height },
+  };
+}

--- a/src/components/elements/rectangle/Display.tsx
+++ b/src/components/elements/rectangle/Display.tsx
@@ -23,6 +23,7 @@ import {
   TextElement,
   WithSelectionProps,
 } from '../../Whiteboard';
+import { getRenderProperties } from './getRenderProperties';
 
 export type RectangleElementProps = ShapeElement & WithSelectionProps;
 
@@ -32,9 +33,7 @@ const RectangleDisplay = ({
   elementId,
   ...shape
 }: RectangleElementProps) => {
-  const strokeWidth = 2;
-  const strokeColor = shape.fillColor;
-  const padding = 10;
+  const { strokeColor, strokeWidth, text } = getRenderProperties(shape);
 
   return (
     <SelectableElement
@@ -50,24 +49,29 @@ const RectangleDisplay = ({
         {...shape}
       >
         <ElementContextMenu elementId={elementId} readOnly={readOnly}>
-          <g transform={`translate(${shape.position.x} ${shape.position.y})`}>
+          <g>
             <rect
+              x={shape.position.x}
+              y={shape.position.y}
               fill={shape.fillColor}
               height={shape.height}
               stroke={strokeColor}
               strokeWidth={strokeWidth}
-              transform={`rotate(0 ${shape.position.x} ${shape.position.y})`}
               width={shape.width}
             />
-            <TextElement
-              active={active}
-              elementId={elementId}
-              paddingBottom={padding}
-              paddingLeft={padding}
-              paddingRight={padding}
-              paddingTop={padding}
-              {...shape}
-            />
+
+            {text && (
+              <TextElement
+                active={active}
+                text={shape.text}
+                elementId={elementId}
+                x={text.position.x}
+                y={text.position.y}
+                width={text.width}
+                height={text.height}
+                fillColor={shape.fillColor}
+              />
+            )}
           </g>
         </ElementContextMenu>
       </MoveableElement>

--- a/src/components/elements/rectangle/Display.tsx
+++ b/src/components/elements/rectangle/Display.tsx
@@ -75,11 +75,10 @@ const RectangleDisplay = ({
       <MoveableElement
         customHeight={shape.height}
         customWidth={shape.width}
-        readOnly={readOnly}
         elementId={elementId}
         {...shape}
       >
-        <ElementContextMenu elementId={elementId} readOnly={readOnly}>
+        <ElementContextMenu elementId={elementId}>
           {renderedChild}
         </ElementContextMenu>
       </MoveableElement>

--- a/src/components/elements/rectangle/Display.tsx
+++ b/src/components/elements/rectangle/Display.tsx
@@ -35,6 +35,37 @@ const RectangleDisplay = ({
 }: RectangleElementProps) => {
   const { strokeColor, strokeWidth, text } = getRenderProperties(shape);
 
+  const renderedChild = (
+    <g>
+      <rect
+        x={shape.position.x}
+        y={shape.position.y}
+        fill={shape.fillColor}
+        height={shape.height}
+        stroke={strokeColor}
+        strokeWidth={strokeWidth}
+        width={shape.width}
+      />
+
+      {text && (
+        <TextElement
+          active={active}
+          text={shape.text}
+          elementId={elementId}
+          x={text.position.x}
+          y={text.position.y}
+          width={text.width}
+          height={text.height}
+          fillColor={shape.fillColor}
+        />
+      )}
+    </g>
+  );
+
+  if (readOnly) {
+    return renderedChild;
+  }
+
   return (
     <SelectableElement
       active={active}
@@ -49,30 +80,7 @@ const RectangleDisplay = ({
         {...shape}
       >
         <ElementContextMenu elementId={elementId} readOnly={readOnly}>
-          <g>
-            <rect
-              x={shape.position.x}
-              y={shape.position.y}
-              fill={shape.fillColor}
-              height={shape.height}
-              stroke={strokeColor}
-              strokeWidth={strokeWidth}
-              width={shape.width}
-            />
-
-            {text && (
-              <TextElement
-                active={active}
-                text={shape.text}
-                elementId={elementId}
-                x={text.position.x}
-                y={text.position.y}
-                width={text.width}
-                height={text.height}
-                fillColor={shape.fillColor}
-              />
-            )}
-          </g>
+          {renderedChild}
         </ElementContextMenu>
       </MoveableElement>
     </SelectableElement>

--- a/src/components/elements/rectangle/getRenderProperties.test.ts
+++ b/src/components/elements/rectangle/getRenderProperties.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getRenderProperties } from './getRenderProperties';
+
+describe('getRenderProperties', () => {
+  it('should provide the properties for a rectangle element', () => {
+    const view = getRenderProperties({
+      type: 'shape',
+      kind: 'rectangle',
+      position: { x: 10, y: 15 },
+      fillColor: '#00ffff',
+      width: 100,
+      height: 50,
+      text: 'My Text',
+    });
+
+    expect(view).toEqual({
+      strokeColor: '#00ffff',
+      strokeWidth: 2,
+
+      text: {
+        position: { x: 20, y: 25 },
+        width: 80,
+        height: 30,
+      },
+    });
+  });
+});

--- a/src/components/elements/rectangle/getRenderProperties.ts
+++ b/src/components/elements/rectangle/getRenderProperties.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ShapeElement } from '../../../state';
+import { ElementRenderProperties } from '../../Whiteboard';
+
+export function getRenderProperties(
+  shape: ShapeElement
+): ElementRenderProperties {
+  const padding = 10;
+
+  const width = shape.width;
+  const height = shape.height;
+
+  return {
+    strokeColor: shape.fillColor,
+    strokeWidth: 2,
+
+    text: {
+      position: {
+        x: shape.position.x + padding,
+        y: shape.position.y + padding,
+      },
+      width: width - padding * 2,
+      height: height - padding * 2,
+    },
+  };
+}

--- a/src/components/elements/triangle/Display.tsx
+++ b/src/components/elements/triangle/Display.tsx
@@ -78,11 +78,10 @@ const TriangleDisplay = ({
       <MoveableElement
         customHeight={shape.height}
         customWidth={shape.width}
-        readOnly={readOnly}
         elementId={elementId}
         {...shape}
       >
-        <ElementContextMenu elementId={elementId} readOnly={readOnly}>
+        <ElementContextMenu elementId={elementId}>
           {renderedChild}
         </ElementContextMenu>
       </MoveableElement>

--- a/src/components/elements/triangle/Display.tsx
+++ b/src/components/elements/triangle/Display.tsx
@@ -40,6 +40,35 @@ const TriangleDisplay = ({
     points: { p0X, p0Y, p1X, p1Y, p2X, p2Y },
   } = getRenderProperties(shape);
 
+  const renderedChild = (
+    <g>
+      <polygon
+        fill={shape.fillColor}
+        points={`${p0X},${p0Y} ${p1X},${p1Y} ${p2X},${p2Y}`}
+        stroke={strokeColor}
+        strokeWidth={strokeWidth}
+        transform={`translate(${shape.position.x} ${shape.position.y})`}
+      />
+
+      {text && (
+        <TextElement
+          active={active}
+          text={shape.text}
+          elementId={elementId}
+          x={text.position.x}
+          y={text.position.y}
+          width={text.width}
+          height={text.height}
+          fillColor={shape.fillColor}
+        />
+      )}
+    </g>
+  );
+
+  if (readOnly) {
+    return renderedChild;
+  }
+
   return (
     <SelectableElement
       active={active}
@@ -54,28 +83,7 @@ const TriangleDisplay = ({
         {...shape}
       >
         <ElementContextMenu elementId={elementId} readOnly={readOnly}>
-          <g>
-            <polygon
-              fill={shape.fillColor}
-              points={`${p0X},${p0Y} ${p1X},${p1Y} ${p2X},${p2Y}`}
-              stroke={strokeColor}
-              strokeWidth={strokeWidth}
-              transform={`translate(${shape.position.x} ${shape.position.y})`}
-            />
-
-            {text && (
-              <TextElement
-                active={active}
-                text={shape.text}
-                elementId={elementId}
-                x={text.position.x}
-                y={text.position.y}
-                width={text.width}
-                height={text.height}
-                fillColor={shape.fillColor}
-              />
-            )}
-          </g>
+          {renderedChild}
         </ElementContextMenu>
       </MoveableElement>
     </SelectableElement>

--- a/src/components/elements/triangle/Display.tsx
+++ b/src/components/elements/triangle/Display.tsx
@@ -47,7 +47,6 @@ const TriangleDisplay = ({
         points={`${p0X},${p0Y} ${p1X},${p1Y} ${p2X},${p2Y}`}
         stroke={strokeColor}
         strokeWidth={strokeWidth}
-        transform={`translate(${shape.position.x} ${shape.position.y})`}
       />
 
       {text && (

--- a/src/components/elements/triangle/Display.tsx
+++ b/src/components/elements/triangle/Display.tsx
@@ -23,6 +23,7 @@ import {
   TextElement,
   WithSelectionProps,
 } from '../../Whiteboard';
+import { getRenderProperties } from './getRenderProperties';
 
 export type TriangleElementProps = ShapeElement & WithSelectionProps;
 
@@ -32,23 +33,12 @@ const TriangleDisplay = ({
   elementId,
   ...shape
 }: TriangleElementProps) => {
-  const strokeWidth = 2;
-  const strokeColor = shape.fillColor;
-  const width = shape.width;
-  const height = shape.height;
-
-  const p0X = 0;
-  const p0Y = height;
-  const p1X = width / 2;
-  const p1Y = 0;
-  const p2X = width;
-  const p2Y = height;
-
-  // Based on https://puzzling.stackexchange.com/a/40221
-  const fitSquareLength = (width * height) / (width + height);
-  const defaultPadding = 10;
-  const paddingTop = height - fitSquareLength;
-  const horizontalPadding = (width - fitSquareLength) / 2;
+  const {
+    strokeColor,
+    strokeWidth,
+    text,
+    points: { p0X, p0Y, p1X, p1Y, p2X, p2Y },
+  } = getRenderProperties(shape);
 
   return (
     <SelectableElement
@@ -64,23 +54,27 @@ const TriangleDisplay = ({
         {...shape}
       >
         <ElementContextMenu elementId={elementId} readOnly={readOnly}>
-          <g transform={`translate(${shape.position.x} ${shape.position.y})`}>
+          <g>
             <polygon
               fill={shape.fillColor}
               points={`${p0X},${p0Y} ${p1X},${p1Y} ${p2X},${p2Y}`}
               stroke={strokeColor}
               strokeWidth={strokeWidth}
+              transform={`translate(${shape.position.x} ${shape.position.y})`}
             />
 
-            <TextElement
-              active={active}
-              elementId={elementId}
-              paddingBottom={defaultPadding}
-              paddingLeft={horizontalPadding}
-              paddingRight={horizontalPadding}
-              paddingTop={paddingTop}
-              {...shape}
-            />
+            {text && (
+              <TextElement
+                active={active}
+                text={shape.text}
+                elementId={elementId}
+                x={text.position.x}
+                y={text.position.y}
+                width={text.width}
+                height={text.height}
+                fillColor={shape.fillColor}
+              />
+            )}
           </g>
         </ElementContextMenu>
       </MoveableElement>

--- a/src/components/elements/triangle/getRenderProperties.test.ts
+++ b/src/components/elements/triangle/getRenderProperties.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getRenderProperties } from './getRenderProperties';
+
+describe('getRenderProperties', () => {
+  it('should provide the properties for a triangle element', () => {
+    const view = getRenderProperties({
+      type: 'shape',
+      kind: 'triangle',
+      position: { x: 10, y: 15 },
+      fillColor: '#00ffff',
+      width: 100,
+      height: 50,
+      text: 'My Text',
+    });
+
+    expect(view).toEqual({
+      strokeColor: '#00ffff',
+      strokeWidth: 2,
+
+      text: {
+        position: { x: expect.any(Number), y: expect.any(Number) },
+        width: expect.any(Number),
+        height: expect.any(Number),
+      },
+
+      points: {
+        p0X: 10,
+        p0Y: 65,
+        p1X: 60,
+        p1Y: 15,
+        p2X: 110,
+        p2Y: 65,
+      },
+    });
+
+    expect(view.text?.position.x).toBeCloseTo(43.33, 1);
+    expect(view.text?.position.y).toBeCloseTo(31.66, 1);
+    expect(view.text?.width).toBeCloseTo(33.33, 1);
+    expect(view.text?.height).toBeCloseTo(23.33, 1);
+  });
+});

--- a/src/components/elements/triangle/getRenderProperties.ts
+++ b/src/components/elements/triangle/getRenderProperties.ts
@@ -54,12 +54,12 @@ export function getRenderProperties(
     },
 
     points: {
-      p0X: 0,
-      p0Y: height,
-      p1X: width / 2,
-      p1Y: 0,
-      p2X: width,
-      p2Y: height,
+      p0X: shape.position.x + 0,
+      p0Y: shape.position.y + height,
+      p1X: shape.position.x + width / 2,
+      p1Y: shape.position.y + 0,
+      p2X: shape.position.x + width,
+      p2Y: shape.position.y + height,
     },
   };
 }

--- a/src/components/elements/triangle/getRenderProperties.ts
+++ b/src/components/elements/triangle/getRenderProperties.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ShapeElement } from '../../../state';
+import { ElementRenderProperties } from '../../Whiteboard';
+
+type TriangleRenderProperties = {
+  points: {
+    p0X: number;
+    p0Y: number;
+    p1X: number;
+    p1Y: number;
+    p2X: number;
+    p2Y: number;
+  };
+};
+
+export function getRenderProperties(
+  shape: ShapeElement
+): ElementRenderProperties & TriangleRenderProperties {
+  const width = shape.width;
+  const height = shape.height;
+
+  // Based on https://puzzling.stackexchange.com/a/40221
+  const fitSquareLength = (width * height) / (width + height);
+  const paddingTop = height - fitSquareLength;
+  const horizontalPadding = (width - fitSquareLength) / 2;
+  const paddingBottom = 10;
+
+  return {
+    strokeColor: shape.fillColor,
+    strokeWidth: 2,
+
+    text: {
+      position: {
+        x: shape.position.x + horizontalPadding,
+        y: shape.position.y + paddingTop,
+      },
+      width: width - horizontalPadding * 2,
+      height: height - paddingTop - paddingBottom,
+    },
+
+    points: {
+      p0X: 0,
+      p0Y: height,
+      p1X: width / 2,
+      p1Y: 0,
+      p2X: width,
+      p2Y: height,
+    },
+  };
+}

--- a/src/lib/useLatestValue.test.tsx
+++ b/src/lib/useLatestValue.test.tsx
@@ -81,4 +81,31 @@ describe('useLatestValue', () => {
 
     expect(result.current).toBe(value);
   });
+
+  it('should only rerender when a new value is available after the observable emits', () => {
+    const value = { a: 1 };
+    const valueProvider = jest
+      .fn()
+      .mockReturnValueOnce(1)
+      .mockReturnValueOnce(1)
+      .mockReturnValue(value);
+
+    const renderSubject = new Subject<void>();
+
+    let renderCounter = 0;
+    const { result } = renderHook(() => {
+      renderCounter++;
+      return useLatestValue(valueProvider, renderSubject);
+    });
+
+    expect(result.current).toBe(1);
+
+    act(() => renderSubject.next());
+
+    act(() => renderSubject.next());
+
+    expect(result.current).toBe(value);
+
+    expect(renderCounter).toBe(2);
+  });
 });


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

Preparation for the PDF export:

1. Split the calculation of the render properties for each element into a reusable function to be able to reuse it in different renderers.
2. Reduce the dom-tree for readonly slides. This reduces the computation time for the sidebar to ~50%.
3. Other performance improvements.

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
