### PR TITLE
Allow moderator and admin to end presentation

### DIFF
--- a/.changeset/four-cows-fry.md
+++ b/.changeset/four-cows-fry.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-widget': minor
+---
+
+Allow admin and moderator to end a presentation mode

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -166,6 +166,7 @@
   "presentBar": {
     "disableEditing": "Bearbeitung sperren",
     "enableEditing": "Bearbeitung freigeben",
+    "endPresentation": "Ende der Präsentation",
     "startPresentation": "Präsentation starten",
     "stopPresentation": "Präsentation beenden",
     "title": "Präsentieren"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -166,6 +166,7 @@
   "presentBar": {
     "disableEditing": "Disable editing",
     "enableEditing": "Enable editing",
+    "endPresentation": "End presentation",
     "startPresentation": "Start presentation",
     "stopPresentation": "Stop presentation",
     "title": "Present"

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -23,6 +23,7 @@ import {
   useIsWhiteboardLoading,
   usePresentationMode,
 } from '../../state';
+import { usePowerLevels } from '../../store/api/usePowerLevels';
 import { BoardBar } from '../BoardBar';
 import { CollaborationBar } from '../CollaborationBar';
 import { DeveloperTools } from '../DeveloperTools/DeveloperTools';
@@ -116,6 +117,7 @@ function ContentArea() {
   const isViewingPresentation = presentationState.type === 'presentation';
   const isViewingPresentationInEditMode =
     isViewingPresentation && presentationState.isEditMode;
+  const { canStopPresentation } = usePowerLevels();
 
   return (
     <>
@@ -128,7 +130,7 @@ function ContentArea() {
       >
         {!isViewingPresentation && <BoardBar />}
         <CollaborationBar />
-        {!isViewingPresentation && <PresentBar />}
+        {(!isViewingPresentation || canStopPresentation) && <PresentBar />}
       </ToolbarContainer>
 
       <WhiteboardHost />

--- a/src/components/PresentBar/PresentBar.test.tsx
+++ b/src/components/PresentBar/PresentBar.test.tsx
@@ -15,16 +15,21 @@
  */
 
 import { MockedWidgetApi, mockWidgetApi } from '@matrix-widget-toolkit/testing';
-import { render, screen, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { ComponentType, PropsWithChildren } from 'react';
+import { Subject } from 'rxjs';
 import {
   WhiteboardTestingContextProvider,
   mockWhiteboardManager,
 } from '../../lib/testUtils/documentTestUtils';
-import { mockRoomMember } from '../../lib/testUtils/matrixTestUtils';
+import {
+  mockPowerLevelsEvent,
+  mockRoomMember,
+} from '../../lib/testUtils/matrixTestUtils';
 import { WhiteboardInstance, WhiteboardManager } from '../../state';
+import { Message } from '../../state/communication';
 import { PresentBar } from './PresentBar';
 
 let widgetApi: MockedWidgetApi;
@@ -36,17 +41,19 @@ beforeEach(() => (widgetApi = mockWidgetApi()));
 describe('<PresentBar/>', () => {
   let Wrapper: ComponentType<PropsWithChildren<{}>>;
   let whiteboardManager: jest.Mocked<WhiteboardManager>;
+  let messageSubject: Subject<Message>;
   let activeWhiteboardInstance: WhiteboardInstance;
   let setPresentationMode: (enable: boolean) => void;
 
   beforeEach(() => {
-    ({ whiteboardManager, setPresentationMode } = mockWhiteboardManager({
-      slides: [
-        ['slide-0', []],
-        ['slide-1', []],
-        ['slide-2', []],
-      ],
-    }));
+    ({ whiteboardManager, messageSubject, setPresentationMode } =
+      mockWhiteboardManager({
+        slides: [
+          ['slide-0', []],
+          ['slide-1', []],
+          ['slide-2', []],
+        ],
+      }));
 
     activeWhiteboardInstance = whiteboardManager.getActiveWhiteboardInstance()!;
     activeWhiteboardInstance.setActiveSlideId('slide-1');
@@ -265,5 +272,89 @@ describe('<PresentBar/>', () => {
         checked: false,
       }),
     ).toBeInTheDocument();
+  });
+
+  it('should be able to end presentation of another user if can moderate', async () => {
+    render(<PresentBar />, { wrapper: Wrapper });
+
+    const toolbar = screen.getByRole('toolbar', { name: 'Present' });
+
+    act(() => {
+      messageSubject.next({
+        senderUserId: '@user-alice',
+        senderSessionId: 'other',
+        type: 'net.nordeck.whiteboard.present_slide',
+        content: {
+          view: { isEditMode: false, slideId: 'slide-0' },
+        },
+      });
+    });
+
+    widgetApi.mockSendStateEvent(
+      mockPowerLevelsEvent({
+        content: {
+          users: { '@user-id': 50 },
+          users_default: 0,
+        },
+      }),
+    );
+
+    const endPresentationButton = await within(toolbar).findByRole('button', {
+      name: 'End presentation',
+    });
+
+    await userEvent.click(endPresentationButton);
+
+    expect(endPresentationButton).not.toBeInTheDocument();
+
+    expect(
+      within(toolbar).getByRole('checkbox', {
+        name: 'Start presentation',
+        checked: false,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should not be able to end presentation of another user if cannot moderate', async () => {
+    render(<PresentBar />, { wrapper: Wrapper });
+
+    const toolbar = screen.getByRole('toolbar', { name: 'Present' });
+
+    act(() => {
+      messageSubject.next({
+        senderUserId: '@user-alice',
+        senderSessionId: 'other',
+        type: 'net.nordeck.whiteboard.present_slide',
+        content: {
+          view: { isEditMode: false, slideId: 'slide-0' },
+        },
+      });
+    });
+
+    widgetApi.mockSendStateEvent(
+      mockPowerLevelsEvent({
+        content: {
+          users: { '@user-id': 50 },
+          users_default: 0,
+        },
+      }),
+    );
+
+    const endPresentationButton = await within(toolbar).findByRole('button', {
+      name: 'End presentation',
+    });
+
+    widgetApi.mockSendStateEvent(
+      mockPowerLevelsEvent({
+        content: {
+          users: { '@user-id': 0 },
+          users_default: 0,
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(endPresentationButton).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/PresentBar/PresentBar.tsx
+++ b/src/components/PresentBar/PresentBar.tsx
@@ -16,6 +16,7 @@
 
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import CancelPresentationIcon from '@mui/icons-material/CancelPresentation';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
 import PresentToAllIcon from '@mui/icons-material/PresentToAll';
 import { useCallback } from 'react';
@@ -25,6 +26,7 @@ import {
   useActiveWhiteboardInstance,
   usePresentationMode,
 } from '../../state';
+import { usePowerLevels } from '../../store/api/usePowerLevels';
 import { Toolbar, ToolbarButton, ToolbarToggle } from '../common/Toolbar';
 
 export function PresentBar() {
@@ -33,6 +35,7 @@ export function PresentBar() {
   const { activeSlideId, isFirstSlideActive, isLastSlideActive } =
     useActiveSlide();
   const { state, toggleEditMode, togglePresentation } = usePresentationMode();
+  const { canStopPresentation } = usePowerLevels();
 
   const handleToNextSlideClick = useCallback(() => {
     if (activeSlideId) {
@@ -69,12 +72,26 @@ export function PresentBar() {
     ? t('presentBar.disableEditing', 'Disable editing')
     : t('presentBar.enableEditing', 'Enable editing');
 
+  const endPresentationTitle = t(
+    'presentBar.endPresentation',
+    'End presentation',
+  );
+
   return (
     <Toolbar
       aria-label={presentBarTitle}
       sx={{ pointerEvents: 'initial' }}
       orientation="vertical"
     >
+      {state.type === 'presentation' && canStopPresentation && (
+        <ToolbarButton
+          aria-label={endPresentationTitle}
+          onClick={togglePresentation}
+          placement="bottom"
+        >
+          <CancelPresentationIcon color="error" />
+        </ToolbarButton>
+      )}
       {state.type !== 'presentation' && (
         <ToolbarToggle
           inputProps={{ 'aria-label': buttonTitle }}

--- a/src/components/common/Toolbar/ToolbarAvatar.tsx
+++ b/src/components/common/Toolbar/ToolbarAvatar.tsx
@@ -82,7 +82,7 @@ export function ToolbarAvatar({
         (theme) => ({
           background: theme.palette.background.default,
           borderRadius: '50%',
-          paddingY: '6px',
+          paddingY: '5px',
 
           '&:hover': {
             background: theme.palette.background.default,

--- a/src/state/usePresentationMode.ts
+++ b/src/state/usePresentationMode.ts
@@ -47,7 +47,10 @@ export function usePresentationMode(): UsePresentationMode {
       togglePresentation: () => {
         if (presentationState.type === 'idle') {
           activeWhiteboardInstance.getPresentationManager().startPresentation();
-        } else if (presentationState.type === 'presenting') {
+        } else if (
+          presentationState.type === 'presenting' ||
+          presentationState.type === 'presentation'
+        ) {
           activeWhiteboardInstance.getPresentationManager().stopPresentation();
         }
       },

--- a/src/store/api/usePowerLevels.test.tsx
+++ b/src/store/api/usePowerLevels.test.tsx
@@ -56,7 +56,7 @@ describe('usePowerLevels', () => {
     });
   });
 
-  it('should return true if user is an admin', async () => {
+  it('should have power if user is an admin', async () => {
     widgetApi.mockSendStateEvent(
       mockPowerLevelsEvent({
         content: {
@@ -81,11 +81,12 @@ describe('usePowerLevels', () => {
     await waitFor(() => {
       expect(result.current).toEqual({
         canImportWhiteboard: true,
+        canStopPresentation: true,
       });
     });
   });
 
-  it('should return true if user is a moderator', async () => {
+  it('should have power if user is a moderator', async () => {
     widgetApi.mockSendStateEvent(
       mockPowerLevelsEvent({
         content: {
@@ -107,11 +108,12 @@ describe('usePowerLevels', () => {
     await waitFor(() => {
       expect(result.current).toEqual({
         canImportWhiteboard: true,
+        canStopPresentation: true,
       });
     });
   });
 
-  it('should return false if user is not admin or moderator', async () => {
+  it('should have no power if user is not admin or moderator', async () => {
     widgetApi.mockSendStateEvent(
       mockPowerLevelsEvent({
         content: {
@@ -133,6 +135,7 @@ describe('usePowerLevels', () => {
     await waitFor(() => {
       expect(result.current).toEqual({
         canImportWhiteboard: false,
+        canStopPresentation: false,
       });
     });
   });

--- a/src/store/api/usePowerLevels.ts
+++ b/src/store/api/usePowerLevels.ts
@@ -20,6 +20,7 @@ import { useGetPowerLevelsQuery } from './powerLevelsApi';
 
 export type PowerLevels = {
   canImportWhiteboard: boolean | undefined;
+  canStopPresentation: boolean | undefined;
 };
 
 export function usePowerLevels({
@@ -30,16 +31,20 @@ export function usePowerLevels({
   userId ??= widgetApi.widgetParameters.userId;
 
   let canImportWhiteboard: boolean | undefined = undefined;
+  let canStopPresentation: boolean | undefined = undefined;
 
   if (!isLoading && powerLevels) {
     const userPowerLevel =
       getUserPowerLevel(userId, powerLevels.event?.content) ?? 0;
-    canImportWhiteboard = userPowerLevel >= 50;
-    //TODO implement the other right and rolls cases
+    const canModerate = userPowerLevel >= 50;
+
+    canImportWhiteboard = canModerate;
+    canStopPresentation = canModerate;
   }
 
   return {
     canImportWhiteboard,
+    canStopPresentation,
   };
 }
 


### PR DESCRIPTION
This PR provides  moderator and administrators possibility to end other user presentation

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
