### PR TITLE
Add env variable to enable React devtools connection

### DIFF
--- a/.changeset/fresh-crabs-approve.md
+++ b/.changeset/fresh-crabs-approve.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-widget': minor
+---
+
+Connection to React devtools can now be enabled with the REACT_APP_DEVTOOLS environment variable

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,4 +16,8 @@ REACT_APP_HELP_CENTER_URL="https://github.com/nordeck/matrix-neoboard"
 
 # optional - enables multiselect
 REACT_APP_MULTISELECT=false
+
+# optional - enable connection to React standalone devtools
+# Does only work in development mode.
+REACT_APP_DEVTOOLS=true
 ```

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,10 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>NeoBoard</title>
 
+    <% if (process.env.NODE_ENV==='development' &&
+    process.env.REACT_APP_DEVTOOLS==='true' ) { %>
+    <script src="http://localhost:8097"></script>
+    <% } %>
     <!--#echo var="__INJECT_SCRIPT_TAG__" encoding="none"-->
   </head>
 


### PR DESCRIPTION
- Can be enabled with the `REACT_APP_DEVTOOLS` environment variable
- Only works in development mode

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [x] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
