### PR TITLE
Fix issues when adding and removing slides

### DIFF
--- a/.changeset/fresh-snails-hammer.md
+++ b/.changeset/fresh-snails-hammer.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+Successive deletion of slides no longer causes the remote board to crash


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**Notes about the solution:**

The issue was, that removed slides are removed from the model before publishing the slide ID changes (see [here](https://github.com/nordeck/matrix-neoboard/blob/c7696799ef6bcdf07b9c2c39e7426e15dba795e9/src/state/whiteboardInstanceImpl.ts#L153)). If the components then try to access a slide whose ID still exists, it crashes.

This PR changes it to be done in two steps:

- First update the slide IDs
- Then actually remove the slides from the model

Take 2: Without delay

**Bug description:**

Precondition: 

    User A create at least two additional slides

    User B is on the same board

    both users have the slide overview open

Steps to reproduce: 

    user A delete two slides

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
