### PR TITLE
Fix whiteboard initialization when whiteboards loading is slower

### DIFF
--- a/.changeset/shiny-beans-invite.md
+++ b/.changeset/shiny-beans-invite.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+Fix whiteboard initialization when whiteboards loading is slower.

--- a/src/state/useOwnedWhiteboard.tsx
+++ b/src/state/useOwnedWhiteboard.tsx
@@ -71,7 +71,7 @@ export function useOwnedWhiteboard(): UseOwnedWhiteboardResponse {
     loading,
     error,
   } = useAsync(async () => {
-    if (canInitializeWhiteboard && !whiteboard) {
+    if (canInitializeWhiteboard && !whiteboard && !isLoading && !isError) {
       try {
         // TODO: We only set the power level once, if it's later changed we can't
         // handle it. It would be better to show a UI to a moderator to repair
@@ -99,7 +99,14 @@ export function useOwnedWhiteboard(): UseOwnedWhiteboardResponse {
     }
 
     return whiteboard;
-  }, [dispatch, widgetApi.widgetId, whiteboard, !!canInitializeWhiteboard]);
+  }, [
+    dispatch,
+    widgetApi.widgetId,
+    whiteboard,
+    isLoading,
+    isError,
+    !!canInitializeWhiteboard,
+  ]);
 
   if (isError) {
     throw new Error('could not load whiteboards');


### PR DESCRIPTION
If loading of whiteboards taking some more time, this could make whiteboard initialization to work wrong, this PR fixes the issue.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [x] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
