### PR TITLE
Fix flaky document statistics test

### DIFF
--- a/.changeset/eighty-pandas-pretend.md
+++ b/.changeset/eighty-pandas-pretend.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+Fixed flaky document statistics test in Document.test.ts

--- a/.changeset/eighty-pandas-pretend.md
+++ b/.changeset/eighty-pandas-pretend.md
@@ -1,5 +1,0 @@
----
-'@nordeck/matrix-neoboard-widget': patch
----
-
-Fixed flaky document statistics test in Document.test.ts

--- a/src/state/crdt/y/yDocument.test.ts
+++ b/src/state/crdt/y/yDocument.test.ts
@@ -232,11 +232,10 @@ describe('YDocument', () => {
     expect(first.contentSizeInBytes).toBe(19);
     expect(first.documentSizeInBytes).toBe(26);
     expect(second.contentSizeInBytes).toBe(24);
-    // documentSizeInBytes is not fully deterministic, therefore we do a bounds
-    // check. The size depends on the clientID generated for the current
-    // session, that might be encoded with a variable length.
-    expect(second.documentSizeInBytes).toBeGreaterThanOrEqual(42);
-    expect(second.documentSizeInBytes).toBeLessThanOrEqual(43);
+    // Sanity check: The size of the document should have been increased.
+    expect(second.documentSizeInBytes).toBeGreaterThan(26);
+    // The last statistics should be the current document size.
+    expect(second.documentSizeInBytes).toBe(yDoc.store().length);
   });
 
   it('should clone the document', () => {


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

Previous test code already mentioned „may be non-deterministic“.
The solution with the range seems not to cover everything.

I've switched the test to check that the size increased and equals the actual document size.

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
