### PR TITLE
Implement move multiple elements by dragging inside the selection

### DIFF
--- a/.changeset/breezy-garlics-pump.md
+++ b/.changeset/breezy-garlics-pump.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-widget': minor
+---
+
+Multiple selected elements can now be moved around by dragging anywhere inside the selection

--- a/src/components/Whiteboard/ElementBehaviors/Moveable/MoveableElement.tsx
+++ b/src/components/Whiteboard/ElementBehaviors/Moveable/MoveableElement.tsx
@@ -45,7 +45,7 @@ const DraggableGroup = styled('g')({
 });
 
 export type MoveableElementProps = PropsWithChildren<{
-  elementId: string;
+  elementId?: string;
 }>;
 
 export function MoveableElement({ children, elementId }: MoveableElementProps) {
@@ -63,7 +63,10 @@ export function MoveableElement({ children, elementId }: MoveableElementProps) {
   useUnmount(() => {
     if (isDragging.current) {
       removeUserSelectStyles();
-      setElementOverride(createResetElementOverrides([elementId]));
+
+      if (elementId !== undefined) {
+        setElementOverride(createResetElementOverrides([elementId]));
+      }
     }
   });
 

--- a/src/components/Whiteboard/ElementBehaviors/Selection/ElementBorder.tsx
+++ b/src/components/Whiteboard/ElementBehaviors/Selection/ElementBorder.tsx
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-import { styled, useTheme } from '@mui/material';
+import { useTheme } from '@mui/material';
 import { calculateBoundingRectForElements } from '../../../../state';
 import { useElementOverrides } from '../../../ElementOverridesProvider';
 import { useLayoutState } from '../../../Layout';
 import { getRenderProperties } from '../../../elements/line/getRenderProperties';
 import { useSvgCanvasContext } from '../../SvgCanvas';
-
-const NoInteraction = styled('g')({
-  pointerEvents: 'none',
-});
 
 function SelectionAnchor({
   x,
@@ -91,7 +87,7 @@ export function ElementBorder({ elementIds, padding = 1 }: ElementBorderProps) {
   return (
     <>
       {isInSelectionMode && (
-        <NoInteraction>
+        <g>
           {!lineRenderProperties && (
             <rect
               data-testid={`${elementIds[0]}-border`}
@@ -141,7 +137,7 @@ export function ElementBorder({ elementIds, padding = 1 }: ElementBorderProps) {
               />
             </>
           )}
-        </NoInteraction>
+        </g>
       )}
     </>
   );

--- a/src/components/Whiteboard/ElementBehaviors/Selection/ElementOutline.tsx
+++ b/src/components/Whiteboard/ElementBehaviors/Selection/ElementOutline.tsx
@@ -28,7 +28,7 @@ export function ElementOutline({ elementIds }: ElementOutlineProps) {
 
   return elements.length > 1 ? (
     <g pointerEvents="none">
-      {elements.map((element) => {
+      {elements.map((element, index) => {
         let width;
         let height;
 
@@ -44,6 +44,7 @@ export function ElementOutline({ elementIds }: ElementOutlineProps) {
 
         return (
           <rect
+            key={`element-${elementIds[index]}-outline`}
             fill="transparent"
             height={height}
             stroke={theme.palette.primary.main}

--- a/src/components/Whiteboard/WhiteboardHost.tsx
+++ b/src/components/Whiteboard/WhiteboardHost.tsx
@@ -32,6 +32,7 @@ import {
   ElementBarWrapper,
   ElementBorder,
   ElementOutline,
+  MoveableElement,
   ResizeElement,
   UnSelectElementHandler,
 } from './ElementBehaviors';
@@ -91,6 +92,12 @@ const WhiteboardHost = ({
         {!hideDotGrid && <DotGrid />}
         {!readOnly && <UnSelectElementHandler />}
 
+        {!readOnly && activeElementIds.length > 0 && (
+          <MoveableElement>
+            <ElementBorder elementIds={activeElementIds} />
+          </MoveableElement>
+        )}
+
         {elementIds.map((e) => (
           <ConnectedElement id={e} key={e} readOnly={readOnly} />
         ))}
@@ -101,7 +108,6 @@ const WhiteboardHost = ({
 
         {!readOnly && activeElementIds.length > 0 && (
           <>
-            <ElementBorder elementIds={activeElementIds} />
             <ElementOutline elementIds={activeElementIds} />
             {dragSelectStartCoords === undefined && (
               <ResizeElement elementId={activeElementIds[0]} />


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

The basic idea was to make `MoveableElement` work without being bound to one element. Then add another `MoveableElement` with the `ElementBorder` when multiple elements are selected.

The items on `WhiteboardHost` have been re-arranged so that this is possible but it also does not disturb any other functionality.

![move-many](https://github.com/nordeck/matrix-neoboard/assets/6216686/82c45687-a0d5-45f1-8829-20b7999bf326)

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
