### PR TITLE
Use userId from widget api

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useWidgetApi } from '@matrix-widget-toolkit/react';
 import { useTranslation } from 'react-i18next';
 import { Layout } from './components/Layout';
 import { PageLoader } from './components/common/PageLoader';
@@ -23,9 +24,14 @@ export const App = () => {
   const { t } = useTranslation();
   const { value, loading } = useOwnedWhiteboard();
   const whiteboardManager = useWhiteboardManager();
+  const ownUserId = useWidgetApi().widgetParameters.userId;
+
+  if (!ownUserId) {
+    throw new Error('Unknown user id');
+  }
 
   if (!loading && value.type === 'whiteboard' && value.event) {
-    whiteboardManager.selectActiveWhiteboardInstance(value.event);
+    whiteboardManager.selectActiveWhiteboardInstance(value.event, ownUserId);
   }
 
   if (

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -49,13 +49,6 @@ log.setLevel('silent');
 // Add support for jest-axe
 expect.extend(toHaveNoViolations);
 
-// Provide a mock location to make extractWidgetApiParameters work
-Object.defineProperty(window, 'location', {
-  value: new URL(
-    'http://widget.local/?parentUrl=http://element.local&widgetId=widget-id#/?matrix_user_id=@user-id',
-  ),
-});
-
 // Provide a mock for the CSS Font Loading API
 Object.defineProperty(document, 'fonts', {
   value: { ready: Promise.resolve([]) },

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -30,7 +30,10 @@ import { WhiteboardDocumentExport } from './export';
 /** Creates and holds the currently selected {@link WhiteboardInstance} based on a whiteboard state event */
 export type WhiteboardManager = {
   /** Create an instance of the whiteboard */
-  selectActiveWhiteboardInstance(whiteboardEvent: StateEvent<Whiteboard>): void;
+  selectActiveWhiteboardInstance(
+    whiteboardEvent: StateEvent<Whiteboard>,
+    userId: string,
+  ): void;
   /** Get the active whiteboard instance */
   getActiveWhiteboardInstance(): WhiteboardInstance | undefined;
 };

--- a/src/state/whiteboardInstanceImpl.ts
+++ b/src/state/whiteboardInstanceImpl.ts
@@ -14,24 +14,20 @@
  * limitations under the License.
  */
 
-import {
-  extractWidgetParameters,
-  StateEvent,
-  WidgetApi,
-} from '@matrix-widget-toolkit/api';
+import { StateEvent, WidgetApi } from '@matrix-widget-toolkit/api';
 import { cloneDeep, isEqual } from 'lodash';
 import {
   BehaviorSubject,
+  Observable,
+  Subject,
   concat,
   defer,
   distinctUntilChanged,
   filter,
   map,
-  Observable,
   of,
   pairwise,
   shareReplay,
-  Subject,
   takeUntil,
   tap,
 } from 'rxjs';
@@ -41,12 +37,13 @@ import {
   CommunicationChannel,
   FOCUS_ON_MESSAGE,
   FocusOn,
-  isValidFocusOnMessage,
   SessionManager,
   SignalingChannel,
   WebRtcCommunicationChannel,
+  isValidFocusOnMessage,
 } from './communication';
 import {
+  WhiteboardDocument,
   createWhiteboardDocument,
   generateAddSlide,
   generateDuplicateSlide,
@@ -56,23 +53,22 @@ import {
   getSlide,
   isValidWhiteboardDocument,
   isValidWhiteboardDocumentSnapshot,
-  WhiteboardDocument,
 } from './crdt';
 import {
-  convertWhiteboardToExportFormat,
   WhiteboardDocumentExport,
+  convertWhiteboardToExportFormat,
 } from './export';
 import { generateLoadWhiteboardFromExport } from './export/loadWhiteboardFromExport';
 import { PresentationManagerImpl } from './presentationManagerImpl';
 import { LocalForageDocumentStorage } from './storage';
 import { SynchronizedDocumentImpl } from './synchronizedDocumentImpl';
 import {
-  isWhiteboardUndoManagerContext,
   PresentationManager,
   SynchronizedDocument,
   WhiteboardInstance,
   WhiteboardSlideInstance,
   WhiteboardStatistics,
+  isWhiteboardUndoManagerContext,
 } from './types';
 import { WhiteboardSlideInstanceImpl } from './whiteboardSlideInstanceImpl';
 
@@ -192,6 +188,7 @@ export class WhiteboardInstanceImpl implements WhiteboardInstance {
     sessionManager: SessionManager,
     signalingChannel: SignalingChannel,
     whiteboardEvent: StateEvent<Whiteboard>,
+    userId: string,
   ): WhiteboardInstanceImpl {
     const enableObserveVisibilityStateSubject = new BehaviorSubject(true);
     const communicationChannel = new WebRtcCommunicationChannel(
@@ -214,11 +211,6 @@ export class WhiteboardInstanceImpl implements WhiteboardInstance {
         snapshotValidator: isValidWhiteboardDocumentSnapshot,
       },
     );
-
-    const userId = extractWidgetParameters().userId;
-    if (!userId) {
-      throw new Error('The userId must be defined');
-    }
 
     return new WhiteboardInstanceImpl(
       document,

--- a/src/state/whiteboardManagerImpl.test.ts
+++ b/src/state/whiteboardManagerImpl.test.ts
@@ -46,7 +46,7 @@ describe('WhiteboardManagerImpl', () => {
 
     const event = widgetApi.mockSendStateEvent(mockWhiteboard());
 
-    whiteboardManager.selectActiveWhiteboardInstance(event);
+    whiteboardManager.selectActiveWhiteboardInstance(event, '@user-id');
 
     expect(whiteboardManager.getActiveWhiteboardInstance()).toBeInstanceOf(
       WhiteboardInstanceImpl,
@@ -65,7 +65,7 @@ describe('WhiteboardManagerImpl', () => {
       mockWhiteboard({ event_id: '$event-id-1', state_key: 'whiteboard-1' }),
     );
 
-    whiteboardManager.selectActiveWhiteboardInstance(event0);
+    whiteboardManager.selectActiveWhiteboardInstance(event0, '@user-id');
 
     const destroySpy = jest.spyOn(
       whiteboardManager.getActiveWhiteboardInstance() as WhiteboardInstanceImpl,
@@ -73,10 +73,10 @@ describe('WhiteboardManagerImpl', () => {
     );
 
     // send same event
-    whiteboardManager.selectActiveWhiteboardInstance(event0);
+    whiteboardManager.selectActiveWhiteboardInstance(event0, '@user-id');
     expect(destroySpy).not.toBeCalled();
 
-    whiteboardManager.selectActiveWhiteboardInstance(event1);
+    whiteboardManager.selectActiveWhiteboardInstance(event1, '@user-id');
 
     expect(destroySpy).toBeCalled();
   });

--- a/src/state/whiteboardManagerImpl.ts
+++ b/src/state/whiteboardManagerImpl.ts
@@ -36,7 +36,10 @@ export class WhiteboardManagerImpl implements WhiteboardManager {
     private readonly signalingChannel: SignalingChannel,
   ) {}
 
-  selectActiveWhiteboardInstance(whiteboardEvent: StateEvent<Whiteboard>) {
+  selectActiveWhiteboardInstance(
+    whiteboardEvent: StateEvent<Whiteboard>,
+    userId: string,
+  ) {
     if (this.activeWhiteboard?.getWhiteboardId() !== whiteboardEvent.event_id) {
       this.activeWhiteboard?.destroy();
       this.activeWhiteboard = WhiteboardInstanceImpl.create(
@@ -45,6 +48,7 @@ export class WhiteboardManagerImpl implements WhiteboardManager {
         this.sessionManager,
         this.signalingChannel,
         whiteboardEvent,
+        userId,
       );
     }
   }


### PR DESCRIPTION
Internal change to use `userId` from `widgetApi` instead of `extractWidgetParameters`.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
