### PR TITLE
Fix depcheck to not complain about build directory

### DIFF
--- a/matrix-neoboard-widget/package.json
+++ b/matrix-neoboard-widget/package.json
@@ -54,7 +54,7 @@
     "tsc": "tsc",
     "test": "jest --watch",
     "test:all": "jest --coverage --watchAll=false",
-    "depcheck": "depcheck --ignores=babel-plugin-transform-import-meta",
+    "depcheck": "depcheck --ignores=babel-plugin-transform-import-meta --ignore-dirs=build",
     "lint": "eslint .",
     "translate": "i18next \"src/**/*.{ts,tsx}\"",
     "prettier:check": "prettier --check .",


### PR DESCRIPTION
Adds a missing parameter to avoid complains in the build directory

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
