### PR TITLE
Fix deploy to the Github Page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
           REACT_APP_HELP_CENTER_URL="https://github.com/nordeck/matrix-neoboard"
           EOF
 
-          sed -i 's,"homepage": "/","homepage": "/matrix-neoboard",' package.json
+          sed -i 's,"homepage": "/","homepage": "/matrix-neoboard",' matrix-neoboard-widget/package.json
 
       - name: build
         run: yarn build

--- a/matrix-neoboard-widget/package.json
+++ b/matrix-neoboard-widget/package.json
@@ -73,6 +73,7 @@
       "last 1 safari version"
     ]
   },
+  "homepage": "/",
   "repository": {
     "type": "git",
     "url": "https://github.com/nordeck/matrix-neoboard.git",


### PR DESCRIPTION
Fixes deployment to the Github page after changing repository to the monorepo.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
