### PR TITLE
Fix element bar position glitch after React 18 update

### DIFF
--- a/packages/react-sdk/src/components/Whiteboard/SvgCanvas/useMeasure.ts
+++ b/packages/react-sdk/src/components/Whiteboard/SvgCanvas/useMeasure.ts
@@ -15,8 +15,8 @@
  */
 
 import { RefObject } from 'react';
-import { useMeasure as useMeasureInternal } from 'react-use';
 import { UseMeasureResult } from 'react-use/lib/useMeasure';
+import { useMeasure as useMeasureInternal } from '../../../lib';
 
 export function useMeasure<
   E extends HTMLElement | SVGElement = HTMLElement,

--- a/packages/react-sdk/src/lib/index.ts
+++ b/packages/react-sdk/src/lib/index.ts
@@ -22,4 +22,5 @@ export { setLocale } from './locale';
 export * from './matrix';
 export { FontsLoadedContextProvider, useFontsLoaded } from './useFontsLoaded';
 export { useLatestValue } from './useLatestValue';
+export { useMeasure } from './useMeasure';
 export { getUserColor } from './userColor';

--- a/packages/react-sdk/src/lib/useMeasure.ts
+++ b/packages/react-sdk/src/lib/useMeasure.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { noop } from 'lodash';
+import { useMemo, useState } from 'react';
+import { flushSync } from 'react-dom';
+import { useIsomorphicLayoutEffect } from 'react-use';
+import { UseMeasureRect, UseMeasureResult } from 'react-use/lib/useMeasure';
+
+const defaultState: UseMeasureRect = {
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 0,
+  top: 0,
+  left: 0,
+  bottom: 0,
+  right: 0,
+};
+
+/**
+ * Copy of https://github.com/streamich/react-use/blob/master/src/useMeasure.ts
+ * but with flushSync to fix glitches after React 18 update.
+ */
+function useBrowserMeasure<E extends Element = Element>(): UseMeasureResult<E> {
+  const [element, ref] = useState<E | null>(null);
+  const [rect, setRect] = useState<UseMeasureRect>(defaultState);
+
+  const observer = useMemo(
+    () =>
+      new ResizeObserver((entries) => {
+        // Wrap in flushSync to first update all components and then measure them.
+        // If not doing this there will be visual glitches.
+        flushSync(() => {
+          if (entries[0]) {
+            const { x, y, width, height, top, left, bottom, right } =
+              entries[0].contentRect;
+            setRect({ x, y, width, height, top, left, bottom, right });
+          }
+        });
+      }),
+    [],
+  );
+
+  useIsomorphicLayoutEffect(() => {
+    if (!element) return;
+    observer.observe(element);
+    return () => {
+      observer.disconnect();
+    };
+  }, [element]);
+
+  return [ref, rect];
+}
+
+export const useMeasure =
+  window?.ResizeObserver === undefined
+    ? <E extends Element = Element>(): UseMeasureResult<E> => [
+        noop,
+        defaultState,
+      ]
+    : useBrowserMeasure;


### PR DESCRIPTION
Problem was that the update cycles changed with React 18.

It looks like that a measurement of the bar was taken, then it was positioned, then there was another update and the bar did a  small jump.

[Like suggested in some issues](https://github.com/streamich/react-use/issues/2522) there is now a `useMeasure` with `flushSync` to get a measurement with all pending updates.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
