### PR TITLE
Use early return to simplify ElementBarWrapper

### DIFF
--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/ElementBarWrapper.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/ElementBarWrapper.tsx
@@ -35,6 +35,16 @@ export function ElementBarWrapper({
     width: canvasWidth,
     height: canvasHeight,
   } = useSvgCanvasContext();
+
+  if (
+    // no elements selected
+    elementIds.length === 0 ||
+    // modifications are locked
+    isLocked
+  ) {
+    return null;
+  }
+
   const {
     offsetX: x,
     offsetY: y,
@@ -45,9 +55,6 @@ export function ElementBarWrapper({
   const offset = 10;
 
   function calculateTopPosition() {
-    if (elements.length === 0) {
-      return 0;
-    }
     const position = y * scale;
     const positionAbove = position - elementBarHeight - offset;
     const positionBelow = position + height * scale + offset;
@@ -63,28 +70,19 @@ export function ElementBarWrapper({
   }
 
   function calculateLeftPosition() {
-    if (elements.length === 0) {
-      return 0;
-    }
-
     const position = (x + width / 2) * scale - elementBarWidth / 2;
-
     return clamp(position, 0, canvasWidth - elementBarWidth);
   }
 
   return (
-    <>
-      {elements.length !== 0 && !isLocked && (
-        <Box
-          ref={sizeRef}
-          position="absolute"
-          zIndex={(theme) => theme.zIndex.appBar}
-          left={calculateLeftPosition()}
-          top={calculateTopPosition()}
-        >
-          {children}
-        </Box>
-      )}
-    </>
+    <Box
+      ref={sizeRef}
+      position="absolute"
+      zIndex={(theme) => theme.zIndex.appBar}
+      left={calculateLeftPosition()}
+      top={calculateTopPosition()}
+    >
+      {children}
+    </Box>
   );
 }


### PR DESCRIPTION
While working on the element bar glitch fix reading the component was hard.
It always looked like that the values could be wrong.

Using an early return simplifies the code and makes clear that nothing happens if the conditions are not met.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
