### PR TITLE
Add disabled attribute to the image upload button

### DIFF
--- a/.changeset/friendly-taxis-film.md
+++ b/.changeset/friendly-taxis-film.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+Upload image button becomes disabled when the slide is locked

--- a/packages/react-sdk/src/components/ToolsBar/ToolsBar.test.tsx
+++ b/packages/react-sdk/src/components/ToolsBar/ToolsBar.test.tsx
@@ -95,7 +95,6 @@ describe('<ToolsBar/>', () => {
     expect(
       within(radiogroup).getByRole('radio', { name: 'Arrow' }),
     ).not.toBeChecked();
-
     expect(
       screen.queryByRole('presentation', { name: 'Upload image' }),
     ).not.toBeInTheDocument();
@@ -122,6 +121,10 @@ describe('<ToolsBar/>', () => {
   });
 
   it('should disable all buttons if the slide is locked and not active', () => {
+    mocked(getEnvironment).mockImplementation((name) => {
+      return name === 'REACT_APP_IMAGES' ? 'true' : 'false';
+    });
+
     whiteboardManager
       .getActiveWhiteboardInstance()
       ?.getSlide('slide-0')
@@ -137,6 +140,9 @@ describe('<ToolsBar/>', () => {
     expect(screen.getByRole('radio', { name: 'Triangle' })).toBeDisabled();
     expect(screen.getByRole('radio', { name: 'Line' })).toBeDisabled();
     expect(screen.getByRole('radio', { name: 'Arrow' })).toBeDisabled();
+    expect(
+      screen.getByRole('presentation', { name: 'Upload image' }),
+    ).toBeDisabled();
 
     expect(screen.getByRole('radio', { name: 'Select' })).not.toBeChecked();
     expect(screen.getByRole('radio', { name: 'Text' })).not.toBeChecked();

--- a/packages/react-sdk/src/components/ToolsBar/ToolsBar.tsx
+++ b/packages/react-sdk/src/components/ToolsBar/ToolsBar.tsx
@@ -117,6 +117,7 @@ export function ToolsBar() {
         {imageUploadEnabled && (
           <ToolbarButton
             aria-label={t('toolsBar.imageUploadTool', 'Upload image')}
+            disabled={isLocked}
             {...getRootProps()}
           >
             <input {...getInputProps()} onClick={undefined} />


### PR DESCRIPTION
This PR adds the disabled attribute to the Image Upload toolbar button so it is enabled or disabled based on the slide's locked state.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

Before:
<img width="998" alt="locked-image-upload-button" src="https://github.com/user-attachments/assets/1680a8dc-cb7f-456c-b734-4a6fee6f6645">

After:
<img width="917" alt="Screenshot 2024-07-17 at 16 16 10" src="https://github.com/user-attachments/assets/45a39f85-b271-47a2-94ce-9e5b7da2975e">


<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [X] Tests for new functionality and regression tests for bug fixes.
- [X] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
