### PR TITLE
PDF export now includes images

### DIFF
--- a/.changeset/selfish-elephants-beam.md
+++ b/.changeset/selfish-elephants-beam.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+PDF export now includes images

--- a/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialogDownloadPdf.test.tsx
+++ b/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialogDownloadPdf.test.tsx
@@ -36,7 +36,11 @@ let widgetApi: MockedWidgetApi;
 
 afterEach(() => widgetApi.stop());
 
-beforeEach(() => (widgetApi = mockWidgetApi()));
+beforeEach(() => {
+  widgetApi = mockWidgetApi();
+  // @ts-ignore forcefully set for tests
+  widgetApi.widgetParameters.baseUrl = 'https://example.com';
+});
 
 describe('<ExportWhiteboardDialogDownloadPdf />', () => {
   let Wrapper: ComponentType<PropsWithChildren<{}>>;
@@ -151,6 +155,7 @@ describe('<ExportWhiteboardDialogDownloadPdf />', () => {
       expect(createWhiteboardPdf).toBeCalledWith({
         authorName: '@user-id',
         roomName: 'NeoBoard',
+        baseUrl: 'https://example.com',
         whiteboardInstance: whiteboardManager.getActiveWhiteboardInstance(),
       });
     });

--- a/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialogDownloadPdf.tsx
+++ b/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialogDownloadPdf.tsx
@@ -102,11 +102,13 @@ function useGeneratePdf(
     const authorName = widgetApi.widgetParameters.userId
       ? getUserDisplayName(widgetApi.widgetParameters.userId)
       : '';
+    const baseUrl = widgetApi.widgetParameters.baseUrl ?? '';
 
     const subscription = createWhiteboardPdf({
       whiteboardInstance,
       roomName,
       authorName,
+      baseUrl,
     }).subscribe({
       next: (blob) => {
         url = URL.createObjectURL(blob);
@@ -135,6 +137,7 @@ function useGeneratePdf(
     roomName,
     whiteboardInstance,
     widgetApi.widgetParameters.userId,
+    widgetApi.widgetParameters.baseUrl,
   ]);
 
   return downloadUrl;

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdf.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdf.ts
@@ -22,6 +22,7 @@ export function createWhiteboardPdf(params: {
   whiteboardInstance: WhiteboardInstance;
   roomName: string;
   authorName: string;
+  baseUrl: string;
 }): Observable<Blob> {
   const contentObservable = from(createWhiteboardPdfDefinition(params));
 

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfContentSlide.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfContentSlide.ts
@@ -16,11 +16,14 @@
 
 import { Content } from 'pdfmake/interfaces';
 import { WhiteboardSlideInstance } from '../../../state';
+import { WhiteboardFileExport } from '../../../state/export/whiteboardDocumentExport';
+import { createWhiteboardPdfElementImage } from './createWhiteboardPdfElementImage';
 import { createWhiteboardPdfElementPath } from './createWhiteboardPdfElementPath';
 import { createWhiteboardPdfElementShape } from './createWhiteboardPdfElementShape';
 
 export function createWhiteboardPdfContentSlide(
   slideInstance: WhiteboardSlideInstance,
+  files?: Array<WhiteboardFileExport>,
 ): Content {
   return slideInstance.getElementIds().map((elementId) => {
     const element = slideInstance.getElement(elementId);
@@ -32,7 +35,15 @@ export function createWhiteboardPdfContentSlide(
       case 'path':
         return createWhiteboardPdfElementPath(element);
 
+      case 'image':
+        if (!files) {
+          console.error('No files provided for image element', element);
+          return [];
+        }
+        return createWhiteboardPdfElementImage(element, files!);
+
       default:
+        console.error('Unknown element type', element);
         return [];
     }
   });

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfDefinition.test.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfDefinition.test.ts
@@ -91,6 +91,7 @@ describe('createWhiteboardPdfDefinition', () => {
         whiteboardInstance,
         roomName: 'My Room',
         authorName: 'Alice',
+        baseUrl: 'https://example.com',
       }),
     ).toMatchSnapshot();
   });
@@ -105,6 +106,7 @@ describe('createWhiteboardPdfDefinition', () => {
       whiteboardInstance,
       roomName: 'My Room',
       authorName: 'Alice',
+      baseUrl: 'https://example.com',
     });
 
     expect(spy).toBeCalledWith('Noto Emoji');

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfDefinition.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfDefinition.ts
@@ -26,13 +26,16 @@ export async function createWhiteboardPdfDefinition({
   whiteboardInstance,
   roomName,
   authorName,
+  baseUrl,
 }: {
   whiteboardInstance: WhiteboardInstance;
   roomName: string;
   authorName: string;
+  baseUrl: string;
 }): Promise<TDocumentDefinitions> {
   // make sure the font is loaded so the text size calculations are correct
   await forceLoadFontFamily('Noto Emoji');
+  const whiteboardExport = await whiteboardInstance.export(baseUrl);
 
   return {
     pageMargins: 0,
@@ -44,7 +47,12 @@ export async function createWhiteboardPdfDefinition({
 
         if (slide) {
           return {
-            stack: [createWhiteboardPdfContentSlide(slide)],
+            stack: [
+              createWhiteboardPdfContentSlide(
+                slide,
+                whiteboardExport.whiteboard.files,
+              ),
+            ],
             pageBreak: idx > 0 ? 'before' : undefined,
           };
         }

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfElementImage.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfElementImage.ts
@@ -17,16 +17,23 @@
 import { Content } from 'pdfmake/interfaces';
 import { ImageElement } from '../../../state';
 import { WhiteboardFileExport } from '../../../state/export/whiteboardDocumentExport';
-import { image } from './utils';
+import { conv2png, image } from './utils';
 
-// TODO: check for mimeType, only png & jpeg are supported
 export function createWhiteboardPdfElementImage(
   element: ImageElement,
   files: WhiteboardFileExport[],
 ): Content {
   const file = files.find((f) => f.mxc === element.mxc);
   if (file) {
-    return image(element, file.data);
+    // pdfmake only supports png and jpeg images,
+    // so we use a canvas to convert other image types to png
+    // ref: https://pdfmake.github.io/docs/0.1/document-definition-object/images/
+    if (element.mimeType === 'image/png' || element.mimeType === 'image/jpeg') {
+      return image(element, file.data);
+    } else {
+      const data = conv2png(element, file.data);
+      return image(element, data);
+    }
   }
 
   console.error('Could not get image url', element);

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfElementImage.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfElementImage.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Content } from 'pdfmake/interfaces';
+import { ImageElement } from '../../../state';
+import { WhiteboardFileExport } from '../../../state/export/whiteboardDocumentExport';
+import { image } from './utils';
+
+// TODO: check for mimeType, only png & jpeg are supported
+export function createWhiteboardPdfElementImage(
+  element: ImageElement,
+  files: WhiteboardFileExport[],
+): Content {
+  const file = files.find((f) => f.mxc === element.mxc);
+  if (file) {
+    return image(element, file.data);
+  }
+
+  console.error('Could not get image url', element);
+  return [];
+}

--- a/packages/react-sdk/src/components/BoardBar/pdf/utils.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/utils.ts
@@ -40,6 +40,19 @@ export function image(element: ImageElement, base64content: string): Content {
   };
 }
 
+export function conv2png(element: ImageElement, base64content: string): string {
+  const img = new Image();
+  img.src = 'data:' + element.mimeType + ';base64,' + base64content;
+
+  const canvas = document.createElement('canvas');
+  [canvas.width, canvas.height] = [element.width, element.height];
+
+  const ctx = canvas.getContext('2d') ?? new CanvasRenderingContext2D();
+  ctx.drawImage(img, 0, 0, element.width, element.height);
+
+  return canvas.toDataURL('image/png').split(',')[1];
+}
+
 export function textContent(
   element: ShapeElement,
   textProperties: NonNullable<ElementRenderProperties['text']>,

--- a/packages/react-sdk/src/components/BoardBar/pdf/utils.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/utils.ts
@@ -18,7 +18,7 @@ import emojiRegex from 'emoji-regex';
 import { get } from 'lodash';
 import { CanvasElement, Content, ContentText } from 'pdfmake/interfaces';
 import tinycolor2 from 'tinycolor2';
-import { ShapeElement } from '../../../state';
+import { ImageElement, ShapeElement } from '../../../state';
 import { ElementRenderProperties } from '../../Whiteboard';
 import { getTextSize } from '../../Whiteboard/ElementBehaviors/Text/fitText';
 
@@ -27,6 +27,16 @@ export function canvas(element: CanvasElement): Content {
     canvas: [element],
     unbreakable: true,
     absolutePosition: { x: 0, y: 0 },
+  };
+}
+
+export function image(element: ImageElement, base64content: string): Content {
+  const dataURL = 'data:' + element.mimeType + ';base64,' + base64content;
+  return {
+    image: dataURL,
+    width: element.width,
+    height: element.height,
+    absolutePosition: { x: element.position.x, y: element.position.y },
   };
 }
 


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

To include images in the PDF export, this PR uses the existing `WhiteboardInstance` **export** method done previously for the `.nwb` file export.

As **pdfmake** only allows for `jpeg` and `png` images when generating PDFs, other formats are converted to png using a canvas based approach.

Not sure on how to add more relevant testing here, as it's not trivial to check for the resulting output (and the [pdf library doesn't support jest](https://github.com/nordeck/matrix-neoboard/blob/main/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialogDownloadPdf.test.tsx#L32)...). 

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [X] (Some) tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
