### PR TITLE
Add insert slide action

### DIFF
--- a/.changeset/forty-experts-crash.md
+++ b/.changeset/forty-experts-crash.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': minor
+'@nordeck/matrix-neoboard-widget': minor
+---
+
+Slides can be added at a specific position the a new slide context menu item „Insert slide“

--- a/packages/react-sdk/src/components/SlideOverviewBar/withContextMenu.tsx
+++ b/packages/react-sdk/src/components/SlideOverviewBar/withContextMenu.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import AddIcon from '@mui/icons-material/Add';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
@@ -98,6 +99,12 @@ export const withContextMenu = <P extends object>(
       handleClose();
     }, [handleClose, slideId, whiteboardInstance]);
 
+    const handleInsertSlide = useCallback(() => {
+      const slideId = whiteboardInstance.addSlide(slideIndex - 1);
+      whiteboardInstance.setActiveSlideId(slideId);
+      handleClose();
+    }, [handleClose, slideIndex, whiteboardInstance]);
+
     const handleContextMenu = useCallback(
       (event: MouseEvent<HTMLButtonElement>) => {
         event.preventDefault();
@@ -164,6 +171,14 @@ export const withContextMenu = <P extends object>(
                 'slideOverviewBar.contextMenu.duplicateSlide',
                 'Duplicate slide',
               )}
+            </ListItemText>
+          </MenuItem>
+          <MenuItem onClick={handleInsertSlide}>
+            <ListItemIcon sx={{ color: 'text.primary' }}>
+              <AddIcon />
+            </ListItemIcon>
+            <ListItemText>
+              {t('slideOverviewBar.contextMenu.insertSlide', 'Insert slide')}
             </ListItemText>
           </MenuItem>
           <MenuItem divider onClick={handleClickBringEveryoneToSlide}>

--- a/packages/react-sdk/src/components/SlideOverviewBar/withContextMenu.tsx
+++ b/packages/react-sdk/src/components/SlideOverviewBar/withContextMenu.tsx
@@ -100,8 +100,8 @@ export const withContextMenu = <P extends object>(
     }, [handleClose, slideId, whiteboardInstance]);
 
     const handleInsertSlide = useCallback(() => {
-      const slideId = whiteboardInstance.addSlide(slideIndex - 1);
-      whiteboardInstance.setActiveSlideId(slideId);
+      const newSlideId = whiteboardInstance.addSlide(slideIndex + 1);
+      whiteboardInstance.setActiveSlideId(newSlideId);
       handleClose();
     }, [handleClose, slideIndex, whiteboardInstance]);
 

--- a/packages/react-sdk/src/locales/de/translation.json
+++ b/packages/react-sdk/src/locales/de/translation.json
@@ -208,6 +208,7 @@
       "bringEveryoneToSlide": "Bring alle hierhin",
       "deleteSlide": "Löschen",
       "duplicateSlide": "Folie duplizieren",
+      "insertSlide": "Folie einfügen",
       "lockSlide": "Sperren",
       "title": "Folie {{index}}"
     },

--- a/packages/react-sdk/src/locales/en/translation.json
+++ b/packages/react-sdk/src/locales/en/translation.json
@@ -208,6 +208,7 @@
       "bringEveryoneToSlide": "Bring all here",
       "deleteSlide": "Delete",
       "duplicateSlide": "Duplicate slide",
+      "insertSlide": "Insert slide",
       "lockSlide": "Lock",
       "title": "Slide {{index}}"
     },

--- a/packages/react-sdk/src/state/types.ts
+++ b/packages/react-sdk/src/state/types.ts
@@ -54,10 +54,13 @@ export type WhiteboardInstance = {
   /** Returns the id of the whiteboard. */
   getWhiteboardId(): string;
   /**
-   * Add a new slide at the end of the whiteboard.
+   * Add a new slide to the whiteboard.
+   *
+   * @param index - If provided, add the slide at the index.
+   *                Else add the slide to the end.
    * @returns the id of the created slide.
    */
-  addSlide(): string;
+  addSlide(index?: number): string;
   /**
    * Creates a copy of the selected slide directly after it.
    * @throws if the slide does not exist

--- a/packages/react-sdk/src/state/whiteboardInstanceImpl.test.ts
+++ b/packages/react-sdk/src/state/whiteboardInstanceImpl.test.ts
@@ -283,6 +283,20 @@ describe('WhiteboardInstanceImpl', () => {
     expect(whiteboardInstance.getSlide(slide1)).toBeDefined();
   });
 
+  it('should add a new slide at index', async () => {
+    const whiteboardInstance = new WhiteboardInstanceImpl(
+      synchronizedDocument,
+      communicationChannel,
+      mockWhiteboard(),
+      '@user-id',
+    );
+
+    const slide1 = whiteboardInstance.addSlide();
+    const slide2 = whiteboardInstance.addSlide(1);
+
+    expect(whiteboardInstance.getSlideIds()).toEqual([slide0, slide2, slide1]);
+  });
+
   it('should duplicate a slide', async () => {
     const whiteboardInstance = new WhiteboardInstanceImpl(
       synchronizedDocument,

--- a/packages/react-sdk/src/state/whiteboardInstanceImpl.test.ts
+++ b/packages/react-sdk/src/state/whiteboardInstanceImpl.test.ts
@@ -297,6 +297,28 @@ describe('WhiteboardInstanceImpl', () => {
     expect(whiteboardInstance.getSlideIds()).toEqual([slide0, slide2, slide1]);
   });
 
+  it('should add new slides between existing slides', async () => {
+    const whiteboardInstance = new WhiteboardInstanceImpl(
+      synchronizedDocument,
+      communicationChannel,
+      mockWhiteboard(),
+      '@user-id',
+    );
+
+    const slide1 = whiteboardInstance.addSlide();
+    const slide2 = whiteboardInstance.addSlide();
+    const newSlide1 = whiteboardInstance.addSlide(1);
+    const newSlide3 = whiteboardInstance.addSlide(3);
+
+    expect(whiteboardInstance.getSlideIds()).toEqual([
+      slide0,
+      newSlide1,
+      slide1,
+      newSlide3,
+      slide2,
+    ]);
+  });
+
   it('should duplicate a slide', async () => {
     const whiteboardInstance = new WhiteboardInstanceImpl(
       synchronizedDocument,

--- a/packages/react-sdk/src/state/whiteboardInstanceImpl.ts
+++ b/packages/react-sdk/src/state/whiteboardInstanceImpl.ts
@@ -301,9 +301,15 @@ export class WhiteboardInstanceImpl implements WhiteboardInstance {
       .subscribe();
   }
 
-  addSlide(): string {
+  addSlide(index?: number): string {
     const [changeFn, slideId] = generateAddSlide();
-    this.synchronizedDocument.getDocument().performChange(changeFn);
+    this.synchronizedDocument.getDocument().performChange((doc) => {
+      changeFn(doc);
+
+      if (index !== undefined) {
+        generateMoveSlide(slideId, index)(doc);
+      }
+    });
 
     return slideId;
   }


### PR DESCRIPTION
Adds a new context menu item „Insert slide“, that inserts a slide after the clicked slide.

![insert-slide](https://github.com/user-attachments/assets/99953adc-13aa-442f-87c0-ef2c80f8597e)

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
