### PR TITLE
Revert the resize handles not on top fix.

### DIFF
--- a/.changeset/tricky-numbers-invite.md
+++ b/.changeset/tricky-numbers-invite.md
@@ -1,5 +1,0 @@
----
-'@nordeck/matrix-neoboard-react-sdk': patch
----
-
-paint element border/resize handles on top of all elements

--- a/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
@@ -94,6 +94,12 @@ const WhiteboardHost = ({
         {!hideDotGrid && <DotGrid />}
         {!readOnly && <UnSelectElementHandler />}
 
+        {!readOnly && activeElementIds.length > 0 && (
+          <MoveableElement overrides={overrides}>
+            <ElementBorder elementIds={activeElementIds} />
+          </MoveableElement>
+        )}
+
         {elementIds.map((e) => (
           <ConnectedElement
             id={e}
@@ -105,12 +111,6 @@ const WhiteboardHost = ({
         ))}
 
         {!readOnly && <DraftPicker />}
-
-        {!readOnly && activeElementIds.length > 0 && (
-          <MoveableElement overrides={overrides}>
-            <ElementBorder elementIds={activeElementIds} />
-          </MoveableElement>
-        )}
 
         {dragSelectStartCoords && <DragSelect />}
 


### PR DESCRIPTION
The other fix changed the order of elements.
That lead to the issue, that text can't be added to a shape any more, because the selection was on top of the shape.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
