### PR TITLE
Render the resize handles on top

### DIFF
--- a/.changeset/tricky-numbers-invite.md
+++ b/.changeset/tricky-numbers-invite.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+paint element border/resize handles on top of all elements

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/ElementBorder.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/ElementBorder.test.tsx
@@ -97,7 +97,9 @@ describe('<ElementBorder />', () => {
 
     render(<ElementBorder elementIds={[id]} />, { wrapper: Wrapper });
 
-    expect(screen.getByTestId(`${id}-border`)).toBeInTheDocument();
+    for (const side of ['top', 'right', 'bottom', 'left']) {
+      expect(screen.getByTestId(`${id}-border-${side}`)).toBeInTheDocument();
+    }
   });
 
   it('should not render a border for an active line element', () => {
@@ -105,6 +107,10 @@ describe('<ElementBorder />', () => {
 
     render(<ElementBorder elementIds={['element-2']} />, { wrapper: Wrapper });
 
-    expect(screen.queryByTestId('element-2-border')).not.toBeInTheDocument();
+    for (const side of ['top', 'right', 'bottom', 'left']) {
+      expect(
+        screen.queryByTestId(`element-2-border-${side}`),
+      ).not.toBeInTheDocument();
+    }
   });
 });

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/ElementBorder.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/ElementBorder.tsx
@@ -89,16 +89,48 @@ export function ElementBorder({ elementIds, padding = 1 }: ElementBorderProps) {
       {isInSelectionMode && (
         <g>
           {!lineRenderProperties && (
-            <rect
-              data-testid={`${elementIds[0]}-border`}
-              fill="transparent"
-              height={selectionHeight}
-              stroke={theme.palette.primary.main}
-              strokeWidth={selectionBorderWidth}
-              width={selectionWidth}
-              x={selectionX}
-              y={selectionY}
-            />
+            <>
+              <line
+                key={`element-${elementIds[0]}-border-south`}
+                fill="none"
+                stroke={theme.palette.primary.main}
+                strokeWidth={selectionBorderWidth}
+                x1={selectionX}
+                x2={selectionX + selectionWidth}
+                y1={selectionY}
+                y2={selectionY}
+              />
+              <line
+                key={`element-${elementIds[0]}-border-east`}
+                fill="none"
+                stroke={theme.palette.primary.main}
+                strokeWidth={selectionBorderWidth}
+                x1={selectionX + selectionWidth}
+                x2={selectionX + selectionWidth}
+                y1={selectionY}
+                y2={selectionY + selectionHeight}
+              />
+              <line
+                key={`element-${elementIds[0]}-border-north`}
+                fill="none"
+                stroke={theme.palette.primary.main}
+                strokeWidth={selectionBorderWidth}
+                x1={selectionX + selectionWidth}
+                x2={selectionX}
+                y1={selectionY + selectionHeight}
+                y2={selectionY + selectionHeight}
+              />
+              <line
+                key={`element-${elementIds[0]}-border-west`}
+                fill="none"
+                stroke={theme.palette.primary.main}
+                strokeWidth={selectionBorderWidth}
+                x1={selectionX}
+                x2={selectionX}
+                y1={selectionY + selectionHeight}
+                y2={selectionY}
+              />
+            </>
           )}
           {lineRenderProperties ? (
             <>

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/ElementBorder.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/ElementBorder.tsx
@@ -91,7 +91,7 @@ export function ElementBorder({ elementIds, padding = 1 }: ElementBorderProps) {
           {!lineRenderProperties && (
             <>
               <line
-                key={`element-${elementIds[0]}-border-south`}
+                data-testid={`${elementIds[0]}-border-top`}
                 fill="none"
                 stroke={theme.palette.primary.main}
                 strokeWidth={selectionBorderWidth}
@@ -101,7 +101,7 @@ export function ElementBorder({ elementIds, padding = 1 }: ElementBorderProps) {
                 y2={selectionY}
               />
               <line
-                key={`element-${elementIds[0]}-border-east`}
+                data-testid={`${elementIds[0]}-border-right`}
                 fill="none"
                 stroke={theme.palette.primary.main}
                 strokeWidth={selectionBorderWidth}
@@ -111,7 +111,7 @@ export function ElementBorder({ elementIds, padding = 1 }: ElementBorderProps) {
                 y2={selectionY + selectionHeight}
               />
               <line
-                key={`element-${elementIds[0]}-border-north`}
+                data-testid={`${elementIds[0]}-border-bottom`}
                 fill="none"
                 stroke={theme.palette.primary.main}
                 strokeWidth={selectionBorderWidth}
@@ -121,7 +121,7 @@ export function ElementBorder({ elementIds, padding = 1 }: ElementBorderProps) {
                 y2={selectionY + selectionHeight}
               />
               <line
-                key={`element-${elementIds[0]}-border-west`}
+                data-testid={`${elementIds[0]}-border-left`}
                 fill="none"
                 stroke={theme.palette.primary.main}
                 strokeWidth={selectionBorderWidth}

--- a/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.test.tsx
@@ -154,7 +154,11 @@ describe('<WhiteboardHost/>', () => {
     activeSlide.setActiveElementIds(['element-0']);
     render(<WhiteboardHost />, { wrapper: Wrapper });
 
-    expect(screen.getByTestId('element-0-border')).toBeInTheDocument();
+    for (const side of ['top', 'right', 'bottom', 'left']) {
+      expect(
+        screen.getByTestId(`element-0-border-${side}`),
+      ).toBeInTheDocument();
+    }
   });
 
   it('should move multiple selected elements by dragging the border', () => {
@@ -162,7 +166,7 @@ describe('<WhiteboardHost/>', () => {
     render(<WhiteboardHost />, { wrapper: Wrapper });
 
     // move 150px on x and 250px on y axis
-    const border = screen.getByTestId('element-0-border');
+    const border = screen.getByTestId('element-0-border-top');
     fireEvent.mouseDown(border, {
       clientX: 150,
       clientY: 150,
@@ -186,7 +190,11 @@ describe('<WhiteboardHost/>', () => {
   it('should not contain an element border if no element is selected', () => {
     render(<WhiteboardHost />, { wrapper: Wrapper });
 
-    expect(screen.queryByTestId('element-0-border')).not.toBeInTheDocument();
+    for (const side of ['top', 'right', 'bottom', 'left']) {
+      expect(
+        screen.queryByTestId(`element-0-border-${side}`),
+      ).not.toBeInTheDocument();
+    }
   });
 
   it('should show the grid for the presenter in presentation mode if it is enabled', () => {

--- a/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
@@ -94,12 +94,6 @@ const WhiteboardHost = ({
         {!hideDotGrid && <DotGrid />}
         {!readOnly && <UnSelectElementHandler />}
 
-        {!readOnly && activeElementIds.length > 0 && (
-          <MoveableElement overrides={overrides}>
-            <ElementBorder elementIds={activeElementIds} />
-          </MoveableElement>
-        )}
-
         {elementIds.map((e) => (
           <ConnectedElement
             id={e}
@@ -111,6 +105,12 @@ const WhiteboardHost = ({
         ))}
 
         {!readOnly && <DraftPicker />}
+
+        {!readOnly && activeElementIds.length > 0 && (
+          <MoveableElement overrides={overrides}>
+            <ElementBorder elementIds={activeElementIds} />
+          </MoveableElement>
+        )}
 
         {dragSelectStartCoords && <DragSelect />}
 


### PR DESCRIPTION
fixes the regression while keeping the original fix instead of reverting as proposed in #487.

painting the borders individually prevents the shape's (invisible) volume blocking the needed click-space; the latter caused the regression.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
  - see #485
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
  - see #485
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
