### PR TITLE
Ensure compat with vitest

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -7,6 +7,7 @@
   "private": true,
   "source": "./src/index.ts",
   "module": "./src/index.ts",
+  "main": "./src/index.ts",
   "types": "./src/index.ts",
   "dependencies": {
     "@fontsource/noto-emoji": "^5.0.20",


### PR DESCRIPTION
This is needed since vitest always is looking for the "main" key sadly.
