### PR TITLE
Fix duplicate text on paste

### DIFF
--- a/.changeset/gentle-swans-wash.md
+++ b/.changeset/gentle-swans-wash.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+Text no longer gets duplicated when pasting from the clipboard

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
@@ -16,6 +16,7 @@
 
 import { styled } from '@mui/material';
 import {
+  ClipboardEvent,
   Dispatch,
   DispatchWithoutAction,
   MouseEvent,
@@ -188,6 +189,16 @@ export function TextEditor({
     }
   }, [textRef, content, onChange]);
 
+  const handlePaste = useCallback(
+    (event: ClipboardEvent) => {
+      if (isEditMode === false) {
+        // Prevent paste text into the field if not in edit mode
+        event.preventDefault();
+      }
+    },
+    [isEditMode],
+  );
+
   useLayoutEffect(() => {
     if (textRef.current && textRef.current.innerText !== content) {
       textRef.current.innerText = content;
@@ -238,6 +249,7 @@ export function TextEditor({
       onMouseDown={handleMouseEvents}
       onMouseMove={handleMouseEvents}
       onMouseUp={handleMouseEvents}
+      onPaste={handlePaste}
       ref={textRef}
       suppressContentEditableWarning
     />

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextElement.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextElement.tsx
@@ -90,6 +90,13 @@ export const TextElement = ({
   // If text editing is exited before the blur is received force a submit
   useUnmount(handleBlur);
 
+  // Edit mode on mount only for empty text fields
+  const editModeOnMount =
+    activeElement?.type === 'shape' &&
+    activeElement?.kind === 'rectangle' &&
+    activeElement.fillColor === 'transparent' &&
+    activeElement.text.trim() === '';
+
   return (
     <ForeignObjectNoInteraction x={x} y={y} height={height} width={width}>
       <TextEditor
@@ -98,11 +105,7 @@ export const TextElement = ({
         contentAlignment={textAlignment}
         contentBold={textBold}
         contentItalic={textItalic}
-        editModeOnMount={
-          activeElement?.type === 'shape' &&
-          activeElement?.kind === 'rectangle' &&
-          activeElement.fillColor === 'transparent'
-        }
+        editModeOnMount={editModeOnMount}
         editable={active}
         onBlur={handleBlur}
         onChange={handleTextChange}


### PR DESCRIPTION
Before this change, text fields always start in edit mode. This commit changes the behaviour to only go to edit mode if the text field is empty (usually the case if a new text field is placed). In addition to that the paste event for text fields is only handled, if the text field is in edit mode (there is a cursor).

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
