### PR TITLE
Align toolbar to bottom of canvas

### DIFF
--- a/packages/react-sdk/src/components/Layout/Layout.tsx
+++ b/packages/react-sdk/src/components/Layout/Layout.tsx
@@ -40,6 +40,7 @@ import { UndoRedoBar } from '../UndoRedoBar';
 import { WhiteboardHost } from '../Whiteboard';
 import { PageLoader } from '../common/PageLoader';
 import { SlidesProvider } from './SlidesProvider';
+import { ToolbarCanvasContainer } from './ToolbarCanvasContainer';
 import { ToolbarContainer } from './ToolbarContainer';
 import { useLayoutState } from './useLayoutState';
 
@@ -164,16 +165,18 @@ function ContentArea() {
       <WhiteboardHost />
 
       {(!isViewingPresentation || isViewingPresentationInEditMode) && (
-        <ToolbarContainer bottom={(theme) => theme.spacing(1)}>
-          <Box flex="1" />
+        <ToolbarCanvasContainer>
+          <ToolbarContainer bottom={(theme) => theme.spacing(1)}>
+            <Box flex="1" />
 
-          <ToolsBar />
-          <UndoRedoBar />
+            <ToolsBar />
+            <UndoRedoBar />
 
-          <Box display="flex" justifyContent="flex-end" flex="1">
-            <HelpCenterBar />
-          </Box>
-        </ToolbarContainer>
+            <Box display="flex" justifyContent="flex-end" flex="1">
+              <HelpCenterBar />
+            </Box>
+          </ToolbarContainer>
+        </ToolbarCanvasContainer>
       )}
     </>
   );

--- a/packages/react-sdk/src/components/Layout/ToolbarCanvasContainer.tsx
+++ b/packages/react-sdk/src/components/Layout/ToolbarCanvasContainer.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Box } from '@mui/material';
+import React, { PropsWithChildren } from 'react';
+import { whiteboardHeight, whiteboardWidth } from '../Whiteboard';
+
+/**
+ * Absolute positioned container, with the same size as the canvas.
+ */
+export const ToolbarCanvasContainer: React.FC<PropsWithChildren<{}>> =
+  function ({ children }) {
+    return (
+      <Box
+        sx={{
+          aspectRatio: whiteboardWidth / whiteboardHeight,
+          left: 0,
+          maxHeight: '100%',
+          pointerEvents: 'none',
+          position: 'absolute',
+          top: 0,
+          width: '100%',
+        }}
+      >
+        {children}
+      </Box>
+    );
+  };


### PR DESCRIPTION
Wrap the toolbar with ToolbarCanvasContainer that has a similar size as the canvas. By this the toolbar is always aligned bottom of the canvas instead of flowing outside of it.

| Widget | Standalone |
| --- | --- |
| ![toolbar-widget](https://github.com/user-attachments/assets/7458560e-ab2b-4b58-a7d4-c6b75bbebbbd) | ![toolbar-standalone](https://github.com/user-attachments/assets/3c3aaef7-0c07-4896-872d-bcb27c99f73a) |

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
