### PR TITLE
Ensure our minimal svg size is 400px on the shortest side

### DIFF
--- a/packages/react-sdk/src/lib/determineImageSize.ts
+++ b/packages/react-sdk/src/lib/determineImageSize.ts
@@ -34,7 +34,7 @@ export async function determineImageSize(
 
       let width = image.width;
       let height = image.height;
-      // Ensure the if this is an SVG image the minimum shortest side is 400px
+      // Ensure that if this is an SVG image without size the shortest side is 400px
       if (type === 'image/svg+xml' && width === 0 && height === 0) {
         // The ratio cant be calculated if both dimensions are 0
         // See also https://github.com/whatwg/html/issues/3510 on why it is important to actually render it on the DOM to move on

--- a/packages/react-sdk/src/lib/determineImageSize.ts
+++ b/packages/react-sdk/src/lib/determineImageSize.ts
@@ -37,7 +37,7 @@ export async function determineImageSize(
       // Ensure the if this is an SVG image the minimum shortest side is 400px
       if (type === 'image/svg+xml' && width === 0 && height === 0) {
         // The ratio cant be calculated if both dimensions are 0
-        // See alsl https://github.com/whatwg/html/issues/3510 on why it is important to actually render it on the DOM to move on
+        // See also https://github.com/whatwg/html/issues/3510 on why it is important to actually render it on the DOM to move on
         // If the image is not rendered on the DOM the image will not be loaded and the dimensions will be 0.
 
         // Needed to calculate the aspect ratio


### PR DESCRIPTION
Fixes that svg images without size information broke. It makes the shortest side 400px while keeping the aspect ratio.

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
