### PR TITLE
Fix the endless loop when displaying images

### DIFF
--- a/packages/react-sdk/src/components/elements/image/ImageDisplay.tsx
+++ b/packages/react-sdk/src/components/elements/image/ImageDisplay.tsx
@@ -120,7 +120,7 @@ function ImageDisplay({
         abortController.abort();
       }
     };
-  }, []);
+  }, [setLoadError, setImageUri, baseUrl, mxc, mimeType]);
 
   const renderedSkeleton = loading ? (
     <Skeleton


### PR DESCRIPTION
This mainly fixes the constant loading of the image. This was caused by the `imageURL` being the dependency of the function, which also sets it while having no guard.

However, the deconstructor that we had can also safely be done when the img tag sends it's onload callback (See https://developer.mozilla.org/en-US/docs/Web/API/File_API/Using_files_from_web_applications#example_using_object_urls_to_display_images ).

This removed all dependencies (the others don't change anyway, so they do not have to be a dependency anyway) of the useEffect Hook and eliminated the problem in full.

The abort controller is a recommendation for this pattern, since you can end up with 2 requests on some rerenders when you do not have it. It doesn't break things if missing, but is more of a resource cleanup. (You also could have had a dangling request on unmount)

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
