### PR TITLE
Allow setting a container for the fullscreen mode

### DIFF
--- a/packages/react-sdk/src/App.tsx
+++ b/packages/react-sdk/src/App.tsx
@@ -54,5 +54,9 @@ export const App = ({ layoutProps }: AppProps) => {
     );
   }
 
-  return <Layout {...layoutProps} />;
+  return (
+    <div id="widget-root">
+      <Layout {...layoutProps} />
+    </div>
+  );
 };

--- a/packages/react-sdk/src/App.tsx
+++ b/packages/react-sdk/src/App.tsx
@@ -54,9 +54,5 @@ export const App = ({ layoutProps }: AppProps) => {
     );
   }
 
-  return (
-    <div id="widget-root">
-      <Layout {...layoutProps} />
-    </div>
-  );
+  return <Layout {...layoutProps} />;
 };

--- a/packages/react-sdk/src/components/Layout/Layout.tsx
+++ b/packages/react-sdk/src/components/Layout/Layout.tsx
@@ -42,6 +42,7 @@ import { PageLoader } from '../common/PageLoader';
 import { SlidesProvider } from './SlidesProvider';
 import { ToolbarCanvasContainer } from './ToolbarCanvasContainer';
 import { ToolbarContainer } from './ToolbarContainer';
+import { useFullscreenMode } from './useFullscreenMode';
 import { useLayoutState } from './useLayoutState';
 
 const TabPanelStyled = styled(TabPanel)(() => ({
@@ -65,6 +66,7 @@ export function Layout({ height = '100vh' }: LayoutProps) {
   const slideIds = useActiveWhiteboardInstanceSlideIds();
   const { state: presentationState } = usePresentationMode();
   const isViewingPresentation = presentationState.type === 'presentation';
+  const { isFullscreenMode } = useFullscreenMode();
 
   const { handleUploadDragEnter, uploadDragOverlay } =
     useSlideImageDropUpload();
@@ -77,7 +79,11 @@ export function Layout({ height = '100vh' }: LayoutProps) {
     <SlidesProvider>
       <GuidedTour disabled={isViewingPresentation} />
 
-      <Stack height={height} direction="row" bgcolor="background.paper">
+      <Stack
+        height={!isFullscreenMode ? height : '100vh'}
+        direction="row"
+        bgcolor="background.paper"
+      >
         <AnimatedSidebar
           visible={isSlideOverviewVisible && !isViewingPresentation}
           direction="right"

--- a/packages/react-sdk/src/components/Layout/SlidesProvider.tsx
+++ b/packages/react-sdk/src/components/Layout/SlidesProvider.tsx
@@ -33,6 +33,7 @@ export function SlidesProvider({ children }: PropsWithChildren<{}>) {
 
   return (
     <Tabs
+      id="widget-root"
       orientation="vertical"
       value={activeSlideId}
       onChange={handleSelectSlide}

--- a/packages/react-sdk/src/components/Layout/useFullscreenMode.ts
+++ b/packages/react-sdk/src/components/Layout/useFullscreenMode.ts
@@ -39,8 +39,10 @@ export function useFullscreenMode(): UseFullScreenModeResult {
   );
 
   const setFullscreenMode = useCallback((value: boolean) => {
+    const container =
+      document.getElementById('widget-root') ?? document.documentElement;
     if (value && !document.fullscreenElement) {
-      return document.documentElement.requestFullscreen();
+      return container.requestFullscreen();
     }
 
     if (!value && document.fullscreenElement) {

--- a/packages/react-sdk/src/components/Layout/useFullscreenMode.ts
+++ b/packages/react-sdk/src/components/Layout/useFullscreenMode.ts
@@ -39,9 +39,9 @@ export function useFullscreenMode(): UseFullScreenModeResult {
   );
 
   const setFullscreenMode = useCallback((value: boolean) => {
-    const container =
-      document.getElementById('widget-root') ?? document.documentElement;
     if (value && !document.fullscreenElement) {
+      const container =
+        document.getElementById('widget-root') ?? document.documentElement;
       return container.requestFullscreen();
     }
 


### PR DESCRIPTION
Allows setting the container of the neoboard. This is especially needed when we do not use an iframe for embedding it.

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
