### PR TITLE
Include matrix-neoboard-widget to build path

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Visit the widget url follow the further instructions: `http(s)://localhost:3000/
 ### Running with a local version of the matrix-widget-toolkit
 
 If changes inside matrix-widget-toolkit are required or for debugging purposes,
-you can clone the repos next to each other and yarn link the packages:
+you can clone the repos next to each other and link the packages with `yarn link`:
 
 ```
 ls

--- a/README.md
+++ b/README.md
@@ -70,6 +70,29 @@ For a list of available options, see [Configuration](./docs/configuration.md).
 Follow the [instructions to run the widget locally](https://github.com/nordeck/matrix-widget-toolkit/tree/main/example-widget-mui#running-the-widget-locally).
 Visit the widget url follow the further instructions: `http(s)://localhost:3000/`
 
+### Running with a local version of the matrix-widget-toolkit
+
+If changes inside matrix-widget-toolkit are required or for debugging purposes,
+you can clone the repos next to each other and yarn link the packages:
+
+```
+ls
+matrix-neoboard
+matrix-widget-toolkit
+```
+
+Then yarn link the required matrix-widget-toolkit packages, for example:
+
+```
+cd matrix-widget-toolkit
+yarn install
+cd packages/api
+yarn link
+cd ../../../matrix-neoboard
+yarn link @matrix-widget-toolkit/api
+yarn install
+```
+
 ### Available Scripts
 
 In the project directory, you can run:

--- a/matrix-neoboard-widget/craco.config.js
+++ b/matrix-neoboard-widget/craco.config.js
@@ -33,12 +33,16 @@ module.exports = function ({ env }) {
 };
 
 /**
- * Craco plugin for using local packages from the same mono repository.
+ * Craco plugin for using local packages from the same mono repository and matrix-widget-toolkit.
  */
 function importLocalPackages() {
   const path = require('path');
   const { getLoader, loaderByName } = require('@craco/craco');
   const absolutePath = path.join(__dirname, '../packages');
+  const matrixWidgetToolkitPath = path.join(
+    __dirname,
+    '../../matrix-widget-toolkit',
+  );
 
   function overrideWebpackConfig({ webpackConfig, context }) {
     const { isFound, match } = getLoader(
@@ -50,7 +54,10 @@ function importLocalPackages() {
         ? match.loader.include
         : [match.loader.include];
 
-      match.loader.include = include.concat(absolutePath);
+      match.loader.include = include.concat(
+        absolutePath,
+        matrixWidgetToolkitPath,
+      );
     }
     return webpackConfig;
   }


### PR DESCRIPTION
Sometimes it can be handy to debug or change matrix-widget-toolkit packages directly when developing NeoBoard.
This change adds the toolkit files to the webpack source paths.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
