### PR TITLE
Use Widget API for image downloads

### DIFF
--- a/.changeset/fifty-crabs-attend.md
+++ b/.changeset/fifty-crabs-attend.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-widget': patch
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+Use the Widget API for image downloads when available

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,7 +32,6 @@ const __dirname = path.dirname(__filename);
 export default ts.config(
   {
     ignores: [
-      '**/lib/**',
       '**/build/**',
       '**/coverage/**',
       '**/craco.config.js',

--- a/matrix-neoboard-widget/package.json
+++ b/matrix-neoboard-widget/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@matrix-widget-toolkit/api": "^3.4.0",
-    "@matrix-widget-toolkit/mui": "^2.0.3"
+    "@matrix-widget-toolkit/mui": "^2.0.3",
     "@nordeck/matrix-neoboard-react-sdk": "0.1.1",
     "i18next": "^23.14.0",
     "i18next-browser-languagedetector": "^8.0.0",

--- a/matrix-neoboard-widget/package.json
+++ b/matrix-neoboard-widget/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@matrix-widget-toolkit/api": "^3.4.0",
-    "@matrix-widget-toolkit/mui": "^2.0.3",
+    "@matrix-widget-toolkit/mui": "^2.0.3"
     "@nordeck/matrix-neoboard-react-sdk": "0.1.1",
     "i18next": "^23.14.0",
     "i18next-browser-languagedetector": "^8.0.0",

--- a/matrix-neoboard-widget/src/widgetCapabilities.ts
+++ b/matrix-neoboard-widget/src/widgetCapabilities.ts
@@ -113,4 +113,5 @@ export const widgetCapabilities = [
 
   MatrixCapabilities.MSC3846TurnServers,
   WidgetApiFromWidgetAction.MSC4039UploadFileAction,
+  WidgetApiFromWidgetAction.MSC4039DownloadFileAction,
 ];

--- a/packages/react-sdk/src/components/BoardBar/BoardBar.test.tsx
+++ b/packages/react-sdk/src/components/BoardBar/BoardBar.test.tsx
@@ -242,7 +242,9 @@ describe('<BoardBar/>', () => {
     );
 
     expect(
-      await whiteboardManager.getActiveWhiteboardInstance()?.export(''),
+      await whiteboardManager
+        .getActiveWhiteboardInstance()
+        ?.export(mockWidgetApi()),
     ).toEqual(data);
 
     await waitFor(() => {

--- a/packages/react-sdk/src/components/BoardBar/BoardBar.test.tsx
+++ b/packages/react-sdk/src/components/BoardBar/BoardBar.test.tsx
@@ -242,9 +242,7 @@ describe('<BoardBar/>', () => {
     );
 
     expect(
-      await whiteboardManager
-        .getActiveWhiteboardInstance()
-        ?.export(mockWidgetApi()),
+      await whiteboardManager.getActiveWhiteboardInstance()?.export(widgetApi),
     ).toEqual(data);
 
     await waitFor(() => {

--- a/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialogDownloadFile/ExportWhiteboardDialogDownloadFile.tsx
+++ b/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialogDownloadFile/ExportWhiteboardDialogDownloadFile.tsx
@@ -55,9 +55,7 @@ function useWhiteboardDownload(onDownloadFinished: () => void) {
 
     setIsDownloading(true);
     const filename = `${roomName}.nwb`;
-    const whiteboardData = await whiteboard.export(
-      widgetApi.widgetParameters.baseUrl,
-    );
+    const whiteboardData = await whiteboard.export(widgetApi);
     downloadData(filename, whiteboardData);
     onDownloadFinished();
   }, [

--- a/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialogDownloadPdf.test.tsx
+++ b/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialogDownloadPdf.test.tsx
@@ -155,7 +155,7 @@ describe('<ExportWhiteboardDialogDownloadPdf />', () => {
       expect(createWhiteboardPdf).toHaveBeenCalledWith({
         authorName: '@user-id',
         roomName: 'NeoBoard',
-        baseUrl: 'https://example.com',
+        widgetApi: widgetApi,
         whiteboardInstance: whiteboardManager.getActiveWhiteboardInstance(),
       });
     });

--- a/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialogDownloadPdf.tsx
+++ b/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialogDownloadPdf.tsx
@@ -102,13 +102,12 @@ function useGeneratePdf(
     const authorName = widgetApi.widgetParameters.userId
       ? getUserDisplayName(widgetApi.widgetParameters.userId)
       : '';
-    const baseUrl = widgetApi.widgetParameters.baseUrl ?? '';
 
     const subscription = createWhiteboardPdf({
       whiteboardInstance,
       roomName,
       authorName,
-      baseUrl,
+      widgetApi,
     }).subscribe({
       next: (blob) => {
         url = URL.createObjectURL(blob);

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdf.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdf.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { WidgetApi } from '@matrix-widget-toolkit/api';
 import { from, fromEvent, map, Observable, switchMap, take, tap } from 'rxjs';
 import { WhiteboardInstance } from '../../../state';
 import { createWhiteboardPdfDefinition } from './createWhiteboardPdfDefinition';
@@ -22,7 +23,7 @@ export function createWhiteboardPdf(params: {
   whiteboardInstance: WhiteboardInstance;
   roomName: string;
   authorName: string;
-  baseUrl: string;
+  widgetApi: WidgetApi;
 }): Observable<Blob> {
   const contentObservable = from(createWhiteboardPdfDefinition(params));
 

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfDefinition.test.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfDefinition.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { mockWidgetApi } from '@matrix-widget-toolkit/testing';
 import {
   mockEllipseElement,
   mockLineElement,
@@ -91,7 +92,7 @@ describe('createWhiteboardPdfDefinition', () => {
         whiteboardInstance,
         roomName: 'My Room',
         authorName: 'Alice',
-        baseUrl: 'https://example.com',
+        widgetApi: mockWidgetApi(),
       }),
     ).toMatchSnapshot();
   });
@@ -106,7 +107,7 @@ describe('createWhiteboardPdfDefinition', () => {
       whiteboardInstance,
       roomName: 'My Room',
       authorName: 'Alice',
-      baseUrl: 'https://example.com',
+      widgetApi: mockWidgetApi(),
     });
 
     expect(spy).toHaveBeenCalledWith('Noto Emoji');

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfDefinition.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfDefinition.ts
@@ -15,6 +15,7 @@
  */
 
 import '@fontsource/noto-emoji/400.css';
+import { WidgetApi } from '@matrix-widget-toolkit/api';
 import { Content, TDocumentDefinitions } from 'pdfmake/interfaces';
 import { isDefined } from '../../../lib';
 import { WhiteboardInstance } from '../../../state';
@@ -26,16 +27,16 @@ export async function createWhiteboardPdfDefinition({
   whiteboardInstance,
   roomName,
   authorName,
-  baseUrl,
+  widgetApi,
 }: {
   whiteboardInstance: WhiteboardInstance;
   roomName: string;
   authorName: string;
-  baseUrl: string;
+  widgetApi: WidgetApi;
 }): Promise<TDocumentDefinitions> {
   // make sure the font is loaded so the text size calculations are correct
   await forceLoadFontFamily('Noto Emoji');
-  const whiteboardExport = await whiteboardInstance.export(baseUrl);
+  const whiteboardExport = await whiteboardInstance.export(widgetApi);
 
   return {
     pageMargins: 0,

--- a/packages/react-sdk/src/components/ImportWhiteboardDialog/ImportWhiteboardDialog.test.tsx
+++ b/packages/react-sdk/src/components/ImportWhiteboardDialog/ImportWhiteboardDialog.test.tsx
@@ -250,7 +250,9 @@ describe('<ImportWhiteboardDialog/>', () => {
     );
 
     expect(
-      await whiteboardManager.getActiveWhiteboardInstance()?.export(''),
+      await whiteboardManager
+        .getActiveWhiteboardInstance()
+        ?.export(mockWidgetApi()),
     ).toEqual(data);
 
     expect(onClose).toHaveBeenCalled();

--- a/packages/react-sdk/src/components/Whiteboard/Element/ConnectedElement.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/Element/ConnectedElement.test.tsx
@@ -36,6 +36,8 @@ describe('<ConnectedElement />', () => {
     widgetApi = mockWidgetApi();
     jest.spyOn(console, 'error');
 
+    jest.mocked(URL.createObjectURL).mockReturnValue('http://...');
+
     const { whiteboardManager } = mockWhiteboardManager({
       slides: [['slide-0', [['element-0', mockImageElement()]]]],
     });
@@ -61,9 +63,10 @@ describe('<ConnectedElement />', () => {
 
   afterEach(() => {
     widgetApi.stop();
+    jest.mocked(URL.createObjectURL).mockReset();
   });
 
-  it('should render an image element', () => {
+  it('should render an image element', async () => {
     // @ts-ignore ignore readonly prop for tests
     widgetApi.widgetParameters.baseUrl = 'https://example.com';
 
@@ -76,7 +79,8 @@ describe('<ConnectedElement />', () => {
       { wrapper: Wrapper },
     );
 
-    expect(screen.getByTestId('element-element-0-image')).toBeInTheDocument();
+    const imageElement = await screen.findByTestId('element-element-0-image');
+    expect(imageElement).toBeInTheDocument();
   });
 
   it('should log and not render an image when there is no base URL', () => {

--- a/packages/react-sdk/src/components/elements/image/ImageDisplay.tsx
+++ b/packages/react-sdk/src/components/elements/image/ImageDisplay.tsx
@@ -94,6 +94,9 @@ function ImageDisplay({
 
         const blob = result.file.slice(0, result.file.size, mimeType);
         const downloadedFileDataUrl = URL.createObjectURL(blob);
+        if (downloadedFileDataUrl === '') {
+          throw new Error('Failed to create object URL');
+        }
         setImageUri(downloadedFileDataUrl);
       } catch (error) {
         console.log('Error downloading file:', error);
@@ -151,15 +154,16 @@ function ImageDisplay({
     downloadFile();
   }, [mxc, widgetApi]);
 
-  const renderedSkeleton = loading ? (
-    <Skeleton
-      data-testid={`element-${elementId}-skeleton`}
-      x={position.x}
-      y={position.y}
-      width={width}
-      height={height}
-    />
-  ) : null;
+  const renderedSkeleton =
+    loading && !loadError ? (
+      <Skeleton
+        data-testid={`element-${elementId}-skeleton`}
+        x={position.x}
+        y={position.y}
+        width={width}
+        height={height}
+      />
+    ) : null;
 
   const renderedPlaceholder = loadError ? (
     <ImagePlaceholder

--- a/packages/react-sdk/src/lib/index.ts
+++ b/packages/react-sdk/src/lib/index.ts
@@ -19,7 +19,7 @@ export { determineImageSize } from './determineImageSize';
 export { findForegroundColor } from './findForegroundColor';
 export { isDefined } from './isDefined';
 export { setLocale } from './locale';
-export * from './matrix';
+export { WidgetApiActionError, convertMxcToHttpUrl } from './matrix';
 export { findColor, useColorPalette } from './useColorPalette';
 export type { Color } from './useColorPalette';
 export { FontsLoadedContextProvider, useFontsLoaded } from './useFontsLoaded';

--- a/packages/react-sdk/src/lib/matrix/WidgetApiActionError.ts
+++ b/packages/react-sdk/src/lib/matrix/WidgetApiActionError.ts
@@ -14,5 +14,10 @@
  * limitations under the License.
  */
 
-export { convertMxcToHttpUrl } from './convertMxcToHttpUrl';
-export { WidgetApiActionError } from './WidgetApiActionError';
+export class WidgetApiActionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WidgetApiActionError';
+    Object.setPrototypeOf(this, WidgetApiActionError.prototype);
+  }
+}

--- a/packages/react-sdk/src/lib/testUtils/documentTestUtils.tsx
+++ b/packages/react-sdk/src/lib/testUtils/documentTestUtils.tsx
@@ -346,14 +346,12 @@ export function mockTextElement(shape: Partial<ShapeElement> = {}): Element {
  * Both mocked functions dispatch a "fullscreenchange" event on document and return a resolved Promise.
  */
 export function mockFullscreenApi(): void {
-  // Ignore TS and linter here for setting a mocked API
-  // @ts-ignore
+  // @ts-expect-error Ignore TS and linter here for setting a mocked API
   // eslint-disable-next-line
   document.fullscreenElement = null;
 
   document.exitFullscreen = jest.fn(function () {
-    // Ignore TS and linter here for setting a mocked API
-    // @ts-ignore
+    // @ts-expect-error Ignore TS and linter here for setting a mocked API
     // eslint-disable-next-line
     document.fullscreenElement = null;
     document.dispatchEvent(new Event('fullscreenchange'));
@@ -361,8 +359,7 @@ export function mockFullscreenApi(): void {
   });
 
   document.documentElement.requestFullscreen = jest.fn(function () {
-    // Ignore TS and linter here for setting a mocked API
-    // @ts-ignore
+    // @ts-expect-error Ignore TS and linter here for setting a mocked API
     // eslint-disable-next-line
     document.fullscreenElement = {};
     document.dispatchEvent(new Event('fullscreenchange'));

--- a/packages/react-sdk/src/lib/text-formatting/useToggleItalic.ts
+++ b/packages/react-sdk/src/lib/text-formatting/useToggleItalic.ts
@@ -22,17 +22,6 @@ import {
 } from '../../state';
 import { calculateTextItalicUpdates } from './calculateTextItalicUpdates';
 
-type UseToggleItalicResult = {
-  /**
-   * True, if at least one active element has italic text.
-   */
-  isItalic: boolean;
-  /**
-   * Toggle bold text of active elements.
-   */
-  toggleItalic: () => void;
-};
-
 export function useToggleItalic() {
   const slideInstance = useWhiteboardSlideInstance();
   const { activeElementIds } = useActiveElements();

--- a/packages/react-sdk/src/state/export/exportWhiteboard.test.ts
+++ b/packages/react-sdk/src/state/export/exportWhiteboard.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { mockWidgetApi } from '@matrix-widget-toolkit/testing';
 import fetchMock from 'fetch-mock-jest';
 import { convertBlobToBase64 } from '../../lib';
 import {
@@ -75,18 +76,18 @@ describe('convertWhiteboardToExportFormat', () => {
       addElementToSlide2(doc);
     });
 
-    expect(
-      await exportWhiteboard(document.getData(), 'https://example.com'),
-    ).toEqual({
-      version: 'net.nordeck.whiteboard@v1',
-      whiteboard: {
-        slides: [
-          { elements: [mockEllipseElement({ kind: 'ellipse' })] },
-          { elements: [mockEllipseElement({ kind: 'circle' })] },
-          { elements: [mockEllipseElement({ kind: 'triangle' })] },
-        ],
+    expect(await exportWhiteboard(document.getData(), mockWidgetApi())).toEqual(
+      {
+        version: 'net.nordeck.whiteboard@v1',
+        whiteboard: {
+          slides: [
+            { elements: [mockEllipseElement({ kind: 'ellipse' })] },
+            { elements: [mockEllipseElement({ kind: 'circle' })] },
+            { elements: [mockEllipseElement({ kind: 'triangle' })] },
+          ],
+        },
       },
-    });
+    );
   });
 
   it('should export images', async () => {
@@ -107,21 +108,21 @@ describe('convertWhiteboardToExportFormat', () => {
       return btoa('encoded test image data');
     });
 
-    expect(
-      await exportWhiteboard(document.getData(), 'https://example.com'),
-    ).toEqual({
-      version: 'net.nordeck.whiteboard@v1',
-      whiteboard: {
-        slides: [{ elements: [mockImageElement()] }],
-        files: [
-          // expect the file with base64 encoded content
-          {
-            data: btoa('encoded test image data'),
-            mxc: 'mxc://example.com/test1234',
-          },
-        ],
+    expect(await exportWhiteboard(document.getData(), mockWidgetApi())).toEqual(
+      {
+        version: 'net.nordeck.whiteboard@v1',
+        whiteboard: {
+          slides: [{ elements: [mockImageElement()] }],
+          files: [
+            // expect the file with base64 encoded content
+            {
+              data: btoa('encoded test image data'),
+              mxc: 'mxc://example.com/test1234',
+            },
+          ],
+        },
       },
-    });
+    );
   });
 
   it('should deduplicate exported images', async () => {
@@ -148,21 +149,21 @@ describe('convertWhiteboardToExportFormat', () => {
       return btoa('encoded test image data');
     });
 
-    expect(
-      await exportWhiteboard(document.getData(), 'https://example.com'),
-    ).toEqual({
-      version: 'net.nordeck.whiteboard@v1',
-      whiteboard: {
-        slides: [{ elements: [mockImageElement(), mockImageElement()] }],
-        files: [
-          // expect one file in the exported data
-          {
-            data: btoa('encoded test image data'),
-            mxc: 'mxc://example.com/test1234',
-          },
-        ],
+    expect(await exportWhiteboard(document.getData(), mockWidgetApi())).toEqual(
+      {
+        version: 'net.nordeck.whiteboard@v1',
+        whiteboard: {
+          slides: [{ elements: [mockImageElement(), mockImageElement()] }],
+          files: [
+            // expect one file in the exported data
+            {
+              data: btoa('encoded test image data'),
+              mxc: 'mxc://example.com/test1234',
+            },
+          ],
+        },
       },
-    });
+    );
   });
 
   it('should skip image downloads with errors', async () => {
@@ -195,21 +196,21 @@ describe('convertWhiteboardToExportFormat', () => {
     );
     jest.mocked(convertBlobToBase64).mockRejectedValue('test error');
 
-    expect(
-      await exportWhiteboard(document.getData(), 'https://example.com'),
-    ).toEqual({
-      version: 'net.nordeck.whiteboard@v1',
-      whiteboard: {
-        slides: [
-          {
-            elements: [
-              mockImageElement(),
-              mockImageElement({ mxc: 'mxc://example.com/test5678' }),
-            ],
-          },
-        ],
+    expect(await exportWhiteboard(document.getData(), mockWidgetApi())).toEqual(
+      {
+        version: 'net.nordeck.whiteboard@v1',
+        whiteboard: {
+          slides: [
+            {
+              elements: [
+                mockImageElement(),
+                mockImageElement({ mxc: 'mxc://example.com/test5678' }),
+              ],
+            },
+          ],
+        },
       },
-    });
+    );
   });
 
   it('should return elements in the correct order', async () => {
@@ -238,22 +239,22 @@ describe('convertWhiteboardToExportFormat', () => {
       moveElement1ToFront(doc);
     });
 
-    expect(
-      await exportWhiteboard(document.getData(), 'https://example.com'),
-    ).toEqual({
-      version: 'net.nordeck.whiteboard@v1',
-      whiteboard: {
-        slides: [
-          {
-            elements: [
-              mockEllipseElement({ kind: 'circle' }),
-              mockEllipseElement({ kind: 'triangle' }),
-              mockEllipseElement({ kind: 'ellipse' }),
-            ],
-          },
-        ],
+    expect(await exportWhiteboard(document.getData(), mockWidgetApi())).toEqual(
+      {
+        version: 'net.nordeck.whiteboard@v1',
+        whiteboard: {
+          slides: [
+            {
+              elements: [
+                mockEllipseElement({ kind: 'circle' }),
+                mockEllipseElement({ kind: 'triangle' }),
+                mockEllipseElement({ kind: 'ellipse' }),
+              ],
+            },
+          ],
+        },
       },
-    });
+    );
   });
 
   it('should include the lock status of a slide', async () => {
@@ -267,13 +268,13 @@ describe('convertWhiteboardToExportFormat', () => {
       lockSlide1(doc);
     });
 
-    expect(
-      await exportWhiteboard(document.getData(), 'https://example.com'),
-    ).toEqual({
-      version: 'net.nordeck.whiteboard@v1',
-      whiteboard: {
-        slides: [{ elements: [] }, { elements: [], lock: {} }],
+    expect(await exportWhiteboard(document.getData(), mockWidgetApi())).toEqual(
+      {
+        version: 'net.nordeck.whiteboard@v1',
+        whiteboard: {
+          slides: [{ elements: [] }, { elements: [], lock: {} }],
+        },
       },
-    });
+    );
   });
 });

--- a/packages/react-sdk/src/state/types.ts
+++ b/packages/react-sdk/src/state/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { StateEvent } from '@matrix-widget-toolkit/api';
+import { StateEvent, WidgetApi } from '@matrix-widget-toolkit/api';
 import { Observable } from 'rxjs';
 import { Whiteboard } from '../model';
 import { CommunicationChannelStatistics } from './communication';
@@ -111,7 +111,7 @@ export type WhiteboardInstance = {
    * @param baseUrl - Homeserver base URL used to download images
    * @returns exported document
    */
-  export(baseUrl: string): Promise<WhiteboardDocumentExport>;
+  export(widgetApi: WidgetApi): Promise<WhiteboardDocumentExport>;
   /**
    * Replace the whiteboard contents with the contents of the export file.
    *

--- a/packages/react-sdk/src/state/whiteboardInstanceImpl.ts
+++ b/packages/react-sdk/src/state/whiteboardInstanceImpl.ts
@@ -399,10 +399,10 @@ export class WhiteboardInstanceImpl implements WhiteboardInstance {
     return this.loadingSubject;
   }
 
-  async export(baseUrl: string): Promise<WhiteboardDocumentExport> {
+  async export(widgetApi: WidgetApi): Promise<WhiteboardDocumentExport> {
     return exportWhiteboard(
       this.synchronizedDocument.getDocument().getData(),
-      baseUrl,
+      widgetApi,
     );
   }
 


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

Uses the recent [downloadFile](https://github.com/matrix-org/matrix-widget-api/blob/a294bb6aae8244cb7e6fcffd88e30e214830a01b/src/driver/WidgetDriver.ts#L356) Widget API with support for authenticated media.

Has been tested with:
 - the latest `develop` Element Web + React SDK, which already implements it in the Widget Driver, with authenticated media **enabled**
- the latest `develop` Element Web + React SDK, **without** authenticated media enabled on the homeserver
- previous releases of Element Web + React SDK, in which the widget falls back to using the unauthenticated Media API due to lack of support for `downloadFile` in the Widget driver

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [X] Tests for new functionality and regression tests for bug fixes.
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
