### PR TITLE
Update changeset config and CI workflow

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,9 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "privatePackages": {
+    "version": true,
+    "tag": true
+  }
 }

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,7 +5,7 @@ name: Release Package
 on:
   push:
     tags:
-      - '*'
+      - '@nordeck/matrix-neoboard-widget@*'
 
 jobs:
   build:
@@ -37,7 +37,7 @@ jobs:
             org.opencontainers.image.description=A whiteboard widget for the Element messenger
             org.opencontainers.image.vendor=Nordeck IT + Consulting GmbH
           tags: |
-            type=semver,pattern={{version}}
+            type=match,pattern=@nordeck/matrix-neoboard-widget@(.+),group=1
 
       - name: Generate Dockerfile
         env:


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

This PR fixes the current ignoring of tagging private packages by `@changeset/cli`, introduced in [v2.27.4](https://github.com/changesets/changesets/pull/1361/files#diff-7d6586978c91a1af1052bec7136f7fea6d5c792eb5bc20896bc69d7110fc1785R24), by updating the changeset config and also adjusts the `publish-release.yml` to only trigger on widget releases and do the proper version tags, required due to the NPM-style tags created after migrating to a workspace project.

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
