### PR TITLE
Make Safari happy with toolbar wrapper min-width instead of width

### DIFF
--- a/.changeset/seven-rings-give.md
+++ b/.changeset/seven-rings-give.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+Fix toolbar horizontal centering in Safari

--- a/packages/react-sdk/src/components/Layout/ToolbarCanvasContainer.tsx
+++ b/packages/react-sdk/src/components/Layout/ToolbarCanvasContainer.tsx
@@ -32,7 +32,7 @@ export const ToolbarCanvasContainer: React.FC<PropsWithChildren<{}>> =
           pointerEvents: 'none',
           position: 'absolute',
           top: 0,
-          width: '100%',
+          minWidth: '100%',
         }}
       >
         {children}


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

Toolbar wrapper would shift the toolbar to the right side when vertical height of the browser decreased. This fixes it by using `min-width: 100%` instead of the previous `width: 100%`.

**Before**
<img width="988" alt="Screenshot 2024-09-17 at 10 57 18" src="https://github.com/user-attachments/assets/fa56d63c-2f3e-49d8-83cd-56e6e01cc595">

**After**
<img width="2041" alt="Screenshot 2024-09-24 at 16 49 28" src="https://github.com/user-attachments/assets/eb30dc32-d064-4a23-81ab-54ec6edccd01">

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [X] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
