### PR TITLE
Fix  color bar becomes invisible in light mode (similar in dark mode)

### DIFF
--- a/.changeset/seven-oranges-wonder.md
+++ b/.changeset/seven-oranges-wonder.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+Add Border to the color picker icon

--- a/packages/react-sdk/src/components/ElementBar/ColorPickerButton/TextColorPickerIcon.tsx
+++ b/packages/react-sdk/src/components/ElementBar/ColorPickerButton/TextColorPickerIcon.tsx
@@ -31,7 +31,12 @@ export function TextColorPickerIcon({ color }: TextColorPickerIconProps) {
         d="M 3.5,14 8.75,0 h 2.5 L 16.5,14 H 14.1 L 12.85,10.4 H 7.2 L 5.9,14 Z M 7.9,8.4 h 4.2 L 10.05,2.6 h -0.1 z"
         fill="currentColor"
       />
-      <path d="m 0,21 v -4 h 20 v 4 z" fill={color} />
+      <path
+        d="m 0,21 v -4 h 20 v 4 z"
+        fill={color}
+        stroke={'currentColor'}
+        strokeWidth={1}
+      />
     </svg>
   );
 }

--- a/packages/react-sdk/src/components/ElementBar/ColorPickerButton/TextColorPickerIcon.tsx
+++ b/packages/react-sdk/src/components/ElementBar/ColorPickerButton/TextColorPickerIcon.tsx
@@ -20,23 +20,28 @@ type TextColorPickerIconProps = {
 
 export function TextColorPickerIcon({ color }: TextColorPickerIconProps) {
   return (
-    <svg
-      width="20"
-      height="21"
-      viewBox="0 0 20 21"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M 3.5,14 8.75,0 h 2.5 L 16.5,14 H 14.1 L 12.85,10.4 H 7.2 L 5.9,14 Z M 7.9,8.4 h 4.2 L 10.05,2.6 h -0.1 z"
-        fill="currentColor"
-      />
-      <path
-        d="m 0,21 v -4 h 20 v 4 z"
-        fill={color}
-        stroke={'currentColor'}
-        strokeWidth={1}
-      />
-    </svg>
+    <div>
+      <svg
+        width="20"
+        height="21"
+        viewBox="0 -6 20 21"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M 3.5,14 8.75,0 h 2.5 L 16.5,14 H 14.1 L 12.85,10.4 H 7.2 L 5.9,14 Z M 7.9,8.4 h 4.2 L 10.05,2.6 h -0.1 z"
+          fill="currentColor"
+        />
+      </svg>
+      <div
+        style={{
+          width: '100%',
+          height: '5px',
+          backgroundColor: color,
+          border: '1px solid',
+          borderColor: 'currentcolor',
+        }}
+      ></div>
+    </div>
   );
 }


### PR DESCRIPTION
Add border on the color picker icon to make it visible in dark and light mode.

![Screenshot_20241010_145834](https://github.com/user-attachments/assets/a85591ab-6573-4f44-82e3-44016ca84446)

![Screenshot_20241010_145858](https://github.com/user-attachments/assets/dab6d495-4fcf-42c7-ad55-07dfff0a9df1)

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
