### PR TITLE
Send an initial snapshot after creating a document

### DIFF
--- a/.changeset/healthy-dolls-wonder.md
+++ b/.changeset/healthy-dolls-wonder.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+A snapshot is sent when a new document is created


### PR DESCRIPTION
On our way to improve „blank board on join“ issues.

Can be tested by these steps

Given I am in a room in Element Web
And I have „show hidden timeline events“ enabled in the Element Web dev tools
When I add the NeoBoard Widget
And I open it for the first time (and make no changes: leave it blank)
Then it should send a document event
And it should send a snapshot related to the document event

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
