### PR TITLE
NEO-875 Support selecting, dragging and resizing elements with touch inputs

### DIFF
--- a/packages/react-sdk/src/components/CollaborationBar/Collaborators/Collaborators.tsx
+++ b/packages/react-sdk/src/components/CollaborationBar/Collaborators/Collaborators.tsx
@@ -23,7 +23,7 @@ import {
   MenuItemProps,
 } from '@mui/material';
 import { unstable_useId as useId } from '@mui/utils';
-import { MouseEvent, useCallback, useMemo, useState } from 'react';
+import { PointerEvent, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ActiveWhiteboardMember,
@@ -68,7 +68,7 @@ export function Collaborators() {
   const open = Boolean(anchorEl);
 
   const handleMoreButtonClick = useCallback(
-    (event: MouseEvent<HTMLButtonElement>) => {
+    (event: PointerEvent<HTMLButtonElement>) => {
       setAnchorEl(event.currentTarget);
     },
     [],

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.test.tsx
@@ -128,7 +128,7 @@ describe('<DragSelect/>', () => {
     expect(screen.queryByTestId('drag-selection')).not.toBeInTheDocument();
   });
 
-  it('should render a selection if there is a ponter move and start coordinates', () => {
+  it('should render a selection if there is a pointer move and start coordinates', () => {
     render(<DragSelect />, { wrapper: Wrapper });
 
     // draw a selection from top left to 50,50

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.test.tsx
@@ -105,22 +105,22 @@ describe('<DragSelect/>', () => {
     widgetApi.stop();
   });
 
-  it('should clear the drag select start coordinates on mouse up', () => {
+  it('should clear the drag select start coordinates on pointer up', () => {
     render(<DragSelect />, { wrapper: Wrapper });
     act(() => {
       setDragSelectStartCoords({ x: 0, y: 0 });
     });
 
-    fireEvent.mouseUp(screen.getByTestId('drag-select-layer'));
+    fireEvent.pointerUp(screen.getByTestId('drag-select-layer'));
 
     expect(dragSelectStartCoords).toBeUndefined();
   });
 
-  it('should not render a selection if there is a mouse move but not start coordinates', () => {
+  it('should not render a selection if there is a pointer move but not start coordinates', () => {
     render(<DragSelect />, { wrapper: Wrapper });
 
     vi.mocked(svgUtils.calculateSvgCoords).mockReturnValue({ x: 50, y: 50 });
-    fireEvent.mouseMove(screen.getByTestId('drag-select-layer'), {
+    fireEvent.pointerMove(screen.getByTestId('drag-select-layer'), {
       clientX: 50,
       clientY: 50,
     });
@@ -128,7 +128,7 @@ describe('<DragSelect/>', () => {
     expect(screen.queryByTestId('drag-selection')).not.toBeInTheDocument();
   });
 
-  it('should render a selection if there is a mouse move and start coordinates', () => {
+  it('should render a selection if there is a ponter move and start coordinates', () => {
     render(<DragSelect />, { wrapper: Wrapper });
 
     // draw a selection from top left to 50,50
@@ -136,7 +136,7 @@ describe('<DragSelect/>', () => {
       setDragSelectStartCoords({ x: 0, y: 0 });
     });
     vi.mocked(svgUtils.calculateSvgCoords).mockReturnValue({ x: 50, y: 50 });
-    fireEvent.mouseMove(screen.getByTestId('drag-select-layer'), {
+    fireEvent.pointerMove(screen.getByTestId('drag-select-layer'), {
       clientX: 50,
       clientY: 50,
     });
@@ -152,7 +152,7 @@ describe('<DragSelect/>', () => {
       setDragSelectStartCoords({ x: 60, y: 60 });
     });
     vi.mocked(svgUtils.calculateSvgCoords).mockReturnValue({ x: 70, y: 70 });
-    fireEvent.mouseMove(screen.getByTestId('drag-select-layer'), {
+    fireEvent.pointerMove(screen.getByTestId('drag-select-layer'), {
       clientX: 70,
       clientY: 70,
     });
@@ -161,7 +161,7 @@ describe('<DragSelect/>', () => {
 
     // Now extend the selection to the corner where element-0 is located
     vi.mocked(svgUtils.calculateSvgCoords).mockReturnValue({ x: 0, y: 0 });
-    fireEvent.mouseMove(screen.getByTestId('drag-select-layer'), {
+    fireEvent.pointerMove(screen.getByTestId('drag-select-layer'), {
       clientX: 0,
       clientY: 0,
     });

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.tsx
@@ -15,7 +15,7 @@
  */
 
 import { styled, useTheme } from '@mui/material';
-import { MouseEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { PointerEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Point,
   ShapeElement,
@@ -101,12 +101,12 @@ export function DragSelect() {
     }
   }, [shape, slideInstance]);
 
-  const handleMouseUp = useCallback(() => {
+  const handlePointerUp = useCallback(() => {
     setDragSelectStartCoords();
   }, [setDragSelectStartCoords]);
 
-  const handleMouseMove = useCallback(
-    (event: MouseEvent<SVGRectElement>) => {
+  const handlePointerMove = useCallback(
+    (event: PointerEvent<SVGRectElement>) => {
       const point = calculateSvgCoords({ x: event.clientX, y: event.clientY });
       setEndCoords(point);
     },
@@ -129,8 +129,8 @@ export function DragSelect() {
       <rect
         fill="transparent"
         height="100%"
-        onMouseMove={handleMouseMove}
-        onMouseUp={handleMouseUp}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
         width="100%"
         data-testid="drag-select-layer"
       />


### PR DESCRIPTION
Allows to select, move, resize and change the text of elements using touch.

Other than #574, this PR does not break the mouse input.

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
