### PR TITLE
SvgCanvas: Don't forward `sx` to `<svg>`

### DIFF
--- a/packages/react-sdk/src/components/Whiteboard/SvgCanvas/SvgCanvas.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/SvgCanvas/SvgCanvas.tsx
@@ -29,7 +29,7 @@ import { useMeasure } from './useMeasure';
 import { calculateScale, calculateSvgCoords } from './utils';
 
 const Canvas = styled('svg', {
-  shouldForwardProp: (p) => p !== 'rounded',
+  shouldForwardProp: (p) => p !== 'rounded' && p !== 'sx',
 })<{ rounded?: boolean }>(({ theme, rounded }) => ({
   background: theme.palette.common.white,
   margin: 'auto',


### PR DESCRIPTION
`<svg>` is not a MUI component. It does not support `sx`.

The CSS style stays unchanged by this PR. It was and is valid.

## Before
Removes the `sx="[object Object]"` property from `<svg>`.
![2024-10-24_20-08](https://github.com/user-attachments/assets/a40bd324-d734-4674-ad0b-5c032de9ee32)

## After
Removes the property while keeping the style intact.
![2024-10-24_20-26](https://github.com/user-attachments/assets/ba1c5122-2a50-4ec7-b17c-016fbb9df549)
