### PR TITLE
Only start a selection with the primary mouse button

### DIFF
--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/UnSelectElementHandler.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/UnSelectElementHandler.tsx
@@ -38,15 +38,17 @@ export function UnSelectElementHandler() {
 
   const handleMouseDown = useCallback(
     (event: MouseEvent<SVGRectElement>) => {
-      const point = calculateSvgCoords({
-        x: event.clientX,
-        y: event.clientY,
-      });
-      setDragSelectStartCoords(point);
+      if (event.button === 0) {
+        const point = calculateSvgCoords({
+          x: event.clientX,
+          y: event.clientY,
+        });
+        setDragSelectStartCoords(point);
 
-      if (activeElementId) {
-        slideInstance.setActiveElementId(undefined);
-        window.getSelection()?.empty();
+        if (activeElementId) {
+          slideInstance.setActiveElementId(undefined);
+          window.getSelection()?.empty();
+        }
       }
     },
     [


### PR DESCRIPTION
Stops the selection from starting on anything but a primary mouse click (e.g. middle mouse click or "right" clicks for the context menu).

This is a nice bug fix, but also will allow us to use the secondary mouse button for dragging the infinite canvas (aka. "endless stage").

![2024-10-24_23-56](https://github.com/user-attachments/assets/6f4caa2b-d21a-41ac-bc6e-e4108026e193)


## Before
* Primary clicks start a selection.
* Secondary clicks start a selection too.

[Peek 2024-10-24 23-55.webm](https://github.com/user-attachments/assets/7ec20391-871a-4b44-9f2a-80fe0da371b6)

## After
* Primary clicks start a selection.
* Secondary clicks do not start a selection.

[Peek 2024-10-24 23-52.webm](https://github.com/user-attachments/assets/68fd33c8-168d-4ba2-964b-6e93c14ce309)
