### PR TITLE
Implement connection monitoring

### DIFF
--- a/.changeset/thin-trees-rule.md
+++ b/.changeset/thin-trees-rule.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-widget': minor
+'@nordeck/matrix-neoboard-react-sdk': minor
+---
+
+NeoBoard now monitors the browser's online state and displays a notification if offline

--- a/matrix-neoboard-widget/src/AppContainer.tsx
+++ b/matrix-neoboard-widget/src/AppContainer.tsx
@@ -21,6 +21,8 @@ import {
 } from '@matrix-widget-toolkit/mui';
 import {
   App,
+  ConnectionStateDialog,
+  ConnectionStateProvider,
   DraggableStyles,
   FontsLoadedContextProvider,
   GuidedTourProvider,
@@ -68,7 +70,10 @@ export const AppContainer = ({
                     <GuidedTourProvider>
                       <SnackbarProvider>
                         <Snackbar />
-                        <App />
+                        <ConnectionStateProvider>
+                          <ConnectionStateDialog />
+                          <App />
+                        </ConnectionStateProvider>
                       </SnackbarProvider>
                     </GuidedTourProvider>
                   </WhiteboardHotkeysProvider>

--- a/matrix-neoboard-widget/src/logger.ts
+++ b/matrix-neoboard-widget/src/logger.ts
@@ -28,6 +28,8 @@ prefix.apply(log, {
   },
 });
 
+log.setLevel('debug')
+
 // Add global error handlers to redirect log messages into the prefixed format.
 // This makes it easier to notice errors, even if you filter the console for the
 // prefix only.

--- a/matrix-neoboard-widget/src/logger.ts
+++ b/matrix-neoboard-widget/src/logger.ts
@@ -28,8 +28,6 @@ prefix.apply(log, {
   },
 });
 
-log.setLevel('debug')
-
 // Add global error handlers to redirect log messages into the prefixed format.
 // This makes it easier to notice errors, even if you filter the console for the
 // prefix only.

--- a/packages/react-sdk/src/components/Snackbar/SnackbarProvider.tsx
+++ b/packages/react-sdk/src/components/Snackbar/SnackbarProvider.tsx
@@ -101,6 +101,10 @@ export function SnackbarProvider({ children }: PropsWithChildren<{}>) {
           flexWrap: 'nowrap',
         },
       },
+      ClickAwayListenerProps: {
+        // Deactivate dismiss the snack bar by clicking anywhere
+        onClickAway: () => {},
+      },
     };
   }, [
     extraSnackbarProps,

--- a/packages/react-sdk/src/components/Snackbar/SnackbarProvider.tsx
+++ b/packages/react-sdk/src/components/Snackbar/SnackbarProvider.tsx
@@ -25,7 +25,14 @@ import {
 
 export type SnackbarProps = MuiSnackbarProps &
   Required<Pick<MuiSnackbarProps, 'key'>> &
-  Required<Pick<MuiSnackbarProps, 'message'>>;
+  Required<Pick<MuiSnackbarProps, 'message'>> & {
+    /**
+     * Whether this is a priority snackbar.
+     * Can only be replaced by another priority snackbar.
+     * Other non-priority snackbars won't replace it unless clearSnackbar was called.
+     */
+    priority?: boolean;
+  };
 
 export type SnackbarState = {
   /**
@@ -64,9 +71,17 @@ export function SnackbarProvider({ children }: PropsWithChildren<{}>) {
 
   const showSnackbar = useCallback(
     (snackbarProps: SnackbarProps) => {
+      if (
+        extraSnackbarProps?.priority === true &&
+        snackbarProps.priority === false
+      ) {
+        // Do not replace a priority snackbar with non-priority one.
+        return;
+      }
+
       setExtraSnackbarProps(snackbarProps);
     },
-    [setExtraSnackbarProps],
+    [extraSnackbarProps?.priority, setExtraSnackbarProps],
   );
 
   const snackbarProps: MuiSnackbarProps | undefined = useMemo(() => {

--- a/packages/react-sdk/src/components/connection-state/ConnectionStateDialog.tsx
+++ b/packages/react-sdk/src/components/connection-state/ConnectionStateDialog.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material';
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useConnectionState } from './useConnectionState';
+
+export const ConnectionStateDialog: React.FC = () => {
+  const { t } = useTranslation();
+  const {
+    connectionState,
+    connectionStateDialogOpen,
+    handleCloseConnectionStateDialog,
+  } = useConnectionState();
+
+  const text = useMemo(() => {
+    if (connectionState === 'no_internet_connection') {
+      return t(
+        'connectionState.dialog.text.no_internet_connection',
+        'NeoBoard cannot save your data at the moment. Check your internet connection. This message will disappear as soon as the data has been saved again. To be on the safe side, you can download a copy of the board using the export function.',
+      );
+    }
+
+    return t(
+      'connectionState.dialog.text.common',
+      'NeoBoard cannot save your data at the moment due to a connection problem. This message will disappear as soon as it has been saved again. To be on the safe side, you can download a copy of the board using the export function.',
+    );
+  }, [connectionState, t]);
+
+  if (!connectionStateDialogOpen) {
+    return null;
+  }
+
+  return (
+    <Dialog onClose={handleCloseConnectionStateDialog} open={true}>
+      <DialogTitle>
+        {t('connectionState.dialog.title', 'Your changes are not saved')}
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText>{text}</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCloseConnectionStateDialog} variant="outlined">
+          {t('connectionState.dialog.confirm', 'OK')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/packages/react-sdk/src/components/connection-state/ConnectionStateProvider.test.tsx
+++ b/packages/react-sdk/src/components/connection-state/ConnectionStateProvider.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { ComponentType, PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SnackbarProvider } from '../Snackbar';
+import { ConnectionStateProvider } from './ConnectionStateProvider';
+import { useConnectionState } from './useConnectionState';
+
+describe('<ConnectionStateProvider />', () => {
+  let Wrapper: ComponentType<PropsWithChildren<{}>>;
+
+  beforeEach(() => {
+    Wrapper = ({ children }: PropsWithChildren<{}>) => (
+      <SnackbarProvider>
+        <ConnectionStateProvider>{children}</ConnectionStateProvider>
+      </SnackbarProvider>
+    );
+  });
+
+  it('should have connectionState "online", if navigator is onLine', () => {
+    const { result } = renderHook(useConnectionState, { wrapper: Wrapper });
+    expect(result.current.connectionState).toBe('online');
+  });
+
+  it('should have connectionState "no_internet_connection" when navigator goes offline', async () => {
+    const { result } = renderHook(useConnectionState, {
+      wrapper: Wrapper,
+    });
+
+    // @ts-ignore forcefully set in test
+    window.navigator.onLine = false;
+
+    act(() => {
+      window.dispatchEvent(new Event('offline'));
+    });
+
+    expect(result.current.connectionState).toBe('no_internet_connection');
+  });
+
+  it('should have connectionState "online" when navigator goes online', async () => {
+    // @ts-ignore forcefully set in test
+    window.navigator.onLine = false;
+
+    const { result } = renderHook(useConnectionState, {
+      wrapper: Wrapper,
+    });
+
+    // @ts-ignore forcefully set in test
+    window.navigator.onLine = true;
+
+    act(() => {
+      window.dispatchEvent(new Event('online'));
+    });
+
+    expect(result.current.connectionState).toBe('online');
+  });
+});

--- a/packages/react-sdk/src/components/connection-state/ConnectionStateProvider.test.tsx
+++ b/packages/react-sdk/src/components/connection-state/ConnectionStateProvider.test.tsx
@@ -30,7 +30,6 @@ import {
 import { mockWhiteboardManager } from '../../lib/testUtils';
 import {
   WhiteboardDocument,
-  WhiteboardInstance,
   WhiteboardManager,
   WhiteboardManagerProvider,
 } from '../../state';
@@ -44,7 +43,6 @@ describe('<ConnectionStateProvider />', () => {
   let widgetApi: MockedWidgetApi;
   let Wrapper: ComponentType<PropsWithChildren<{}>>;
   let whiteboardManager: Mocked<WhiteboardManager>;
-  let activeWhiteboardInstance: WhiteboardInstance;
   let synchronizedDocument: SynchronizedDocument<WhiteboardDocument>;
   let store: StoreType;
 
@@ -52,7 +50,6 @@ describe('<ConnectionStateProvider />', () => {
     store = createStore({ widgetApi });
     widgetApi = mockWidgetApi();
     ({ synchronizedDocument, whiteboardManager } = mockWhiteboardManager());
-    activeWhiteboardInstance = whiteboardManager.getActiveWhiteboardInstance()!;
     Wrapper = ({ children }: PropsWithChildren<{}>) => (
       <Provider store={store}>
         <WhiteboardManagerProvider whiteboardManager={whiteboardManager}>

--- a/packages/react-sdk/src/components/connection-state/ConnectionStateProvider.tsx
+++ b/packages/react-sdk/src/components/connection-state/ConnectionStateProvider.tsx
@@ -45,6 +45,10 @@ export const ConnectionStateProvider: React.FC<PropsWithChildren> = function ({
   const theme = useTheme();
   const { t } = useTranslation();
   const { clearSnackbar, showSnackbar, snackbarProps } = useSnackbar();
+  /**
+   * Basic connection monitoring. Works if there is any network connection and is highly browser dependant.
+   * Read more about it {@link https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine|here}.
+   */
   const networkState = useNetworkState();
   const [connectionStateDialogOpen, setConnectionStateDialogOpen] =
     useState(false);

--- a/packages/react-sdk/src/components/connection-state/ConnectionStateProvider.tsx
+++ b/packages/react-sdk/src/components/connection-state/ConnectionStateProvider.tsx
@@ -66,7 +66,7 @@ export const ConnectionStateProvider: React.FC<PropsWithChildren> = function ({
   const { t } = useTranslation();
   const { clearSnackbar, showSnackbar, snackbarProps } = useSnackbar();
   /**
-   * Basic connection monitoring. Works if there is any network connection and is highly browser dependant.
+   * Basic connection monitoring. Works if there is any network connection and is highly browser-dependent.
    * Read more about it {@link https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine|here}.
    */
   const networkState = useNetworkState();

--- a/packages/react-sdk/src/components/connection-state/ConnectionStateProvider.tsx
+++ b/packages/react-sdk/src/components/connection-state/ConnectionStateProvider.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import { Box, Button, useTheme } from '@mui/material';
+import React, {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNetworkState } from 'react-use';
+import { useSnackbar } from '../../components/Snackbar';
+
+type ConnectionState = 'online' | 'no_internet_connection';
+
+export type ConnectionStateState = {
+  connectionState: ConnectionState;
+  connectionStateDialogOpen: boolean;
+  handleCloseConnectionStateDialog: () => void;
+};
+
+export const ConnectionStateContext = createContext<
+  ConnectionStateState | undefined
+>(undefined);
+
+export const ConnectionStateProvider: React.FC<PropsWithChildren> = function ({
+  children,
+}) {
+  const theme = useTheme();
+  const { t } = useTranslation();
+  const { clearSnackbar, showSnackbar, snackbarProps } = useSnackbar();
+  const networkState = useNetworkState();
+  const [connectionStateDialogOpen, setConnectionStateDialogOpen] =
+    useState(false);
+  const connectionState: ConnectionState = networkState.online
+    ? 'online'
+    : 'no_internet_connection';
+
+  const handleLearnMoreClick = useCallback(() => {
+    setConnectionStateDialogOpen(true);
+  }, [setConnectionStateDialogOpen]);
+
+  /**
+   * Monitor the connection state.
+   * Display a snackbar on connection errors.
+   */
+  useEffect(() => {
+    if (connectionState === 'online') {
+      // Online - no connection state snackbar and no dialog
+      clearSnackbar();
+      setConnectionStateDialogOpen(false);
+      return;
+    }
+
+    if (connectionStateDialogOpen) {
+      // Give priority to the connection state dialog
+      clearSnackbar();
+      return;
+    }
+
+    if (connectionState === 'no_internet_connection') {
+      const changesNotSavedMessage = t(
+        'connectionState.snackbar.message',
+        'Changes not saved',
+      );
+
+      if (snackbarProps?.key === changesNotSavedMessage) {
+        // Do not replace the message with itself
+        return;
+      }
+
+      showSnackbar({
+        key: changesNotSavedMessage,
+        priority: true,
+        message: (
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              gap: theme.spacing(2),
+            }}
+          >
+            <WarningAmberIcon color="warning" />
+            {changesNotSavedMessage}
+          </Box>
+        ),
+        action: (
+          <Button size="small" onClick={handleLearnMoreClick}>
+            {t('connectionState.snackbar.action', 'learn more')}
+          </Button>
+        ),
+      });
+      return;
+    }
+  }, [
+    clearSnackbar,
+    connectionState,
+    connectionStateDialogOpen,
+    handleLearnMoreClick,
+    setConnectionStateDialogOpen,
+    showSnackbar,
+    snackbarProps,
+    t,
+    theme,
+  ]);
+
+  const handleCloseConnectionStateDialog = useCallback(() => {
+    setConnectionStateDialogOpen(false);
+  }, [setConnectionStateDialogOpen]);
+
+  return (
+    <ConnectionStateContext.Provider
+      value={{
+        handleCloseConnectionStateDialog,
+        connectionState,
+        connectionStateDialogOpen,
+      }}
+    >
+      {children}
+    </ConnectionStateContext.Provider>
+  );
+};

--- a/packages/react-sdk/src/components/connection-state/index.ts
+++ b/packages/react-sdk/src/components/connection-state/index.ts
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-export * from './App';
-export * from './components/common/PageLoader';
-export * from './components/connection-state';
-export * from './components/GuidedTour';
-export * from './components/Layout';
-export * from './components/Snackbar';
-export { DraggableStyles } from './components/Whiteboard/ElementBehaviors/Moveable';
-export * from './components/WhiteboardHotkeysProvider';
-export * from './i18n';
-export * from './lib';
-export * from './model';
-export * from './state';
-export * from './store';
+export { ConnectionStateDialog } from './ConnectionStateDialog';
+export { ConnectionStateProvider } from './ConnectionStateProvider';
+export { useConnectionState } from './useConnectionState';

--- a/packages/react-sdk/src/components/connection-state/useConnectionState.ts
+++ b/packages/react-sdk/src/components/connection-state/useConnectionState.ts
@@ -14,16 +14,20 @@
  * limitations under the License.
  */
 
-export * from './App';
-export * from './components/common/PageLoader';
-export * from './components/connection-state';
-export * from './components/GuidedTour';
-export * from './components/Layout';
-export * from './components/Snackbar';
-export { DraggableStyles } from './components/Whiteboard/ElementBehaviors/Moveable';
-export * from './components/WhiteboardHotkeysProvider';
-export * from './i18n';
-export * from './lib';
-export * from './model';
-export * from './state';
-export * from './store';
+import { useContext } from 'react';
+import {
+  ConnectionStateContext,
+  ConnectionStateState,
+} from './ConnectionStateProvider';
+
+export function useConnectionState(): ConnectionStateState {
+  const value = useContext(ConnectionStateContext);
+
+  if (!value) {
+    throw new Error(
+      'useConnectionState can only be used inside of <ConnectionStateProvider>',
+    );
+  }
+
+  return value;
+}

--- a/packages/react-sdk/src/locales/de/neoboard.json
+++ b/packages/react-sdk/src/locales/de/neoboard.json
@@ -91,6 +91,20 @@
     "shade_lightest": "am hellsten",
     "title": "Wähle eine Farbe"
   },
+  "connectionState": {
+    "dialog": {
+      "confirm": "OK",
+      "text": {
+        "common": "NeoBoard kann deine Daten wegen eines Verbindungsproblems im Moment nicht speichern. Diese Meldung wird ausgeblendet, sobald wieder gespeichert wurde. Um sicherzugehen, kannst du eine Kopie des Boards über die Exportfunktion herunterladen.",
+        "no_internet_connection": "NeoBoard kann deine Daten im Moment nicht speichern. Überprüfe deine Internetverbindung. Diese Meldung wird ausgeblendet, sobald wieder gespeichert wurde. Um sicherzugehen, kannst du eine Kopie des Boards über die Exportfunktion herunterladen."
+      },
+      "title": "Deine Änderungen sind nicht gespeichert"
+    },
+    "snackbar": {
+      "action": "mehr Info",
+      "message": "Änderungen nicht gespeichert"
+    }
+  },
   "copyableTextButton": {
     "copy-to-clipboard": "In die Zwischenablage kopieren"
   },

--- a/packages/react-sdk/src/locales/en/neoboard.json
+++ b/packages/react-sdk/src/locales/en/neoboard.json
@@ -91,6 +91,20 @@
     "shade_lightest": "lightest",
     "title": "Pick a color"
   },
+  "connectionState": {
+    "dialog": {
+      "confirm": "OK",
+      "text": {
+        "common": "NeoBoard cannot save your data at the moment due to a connection problem. This message will disappear as soon as it has been saved again. To be on the safe side, you can download a copy of the board using the export function.",
+        "no_internet_connection": "NeoBoard cannot save your data at the moment. Check your internet connection. This message will disappear as soon as the data has been saved again. To be on the safe side, you can download a copy of the board using the export function."
+      },
+      "title": "Your changes are not saved"
+    },
+    "snackbar": {
+      "action": "learn more",
+      "message": "Changes not saved"
+    }
+  },
   "copyableTextButton": {
     "copy-to-clipboard": "Copy to clipboard"
   },

--- a/packages/react-sdk/src/setupTests.ts
+++ b/packages/react-sdk/src/setupTests.ts
@@ -142,6 +142,9 @@ File.prototype.arrayBuffer = vi.fn();
 const fetchMocker = createFetchMock(vi);
 fetchMocker.enableMocks();
 
+// Mock the onLine prop
+Object.defineProperty(navigator, 'onLine', { value: true, writable: true });
+
 afterEach(() => {
   cleanup();
 });

--- a/packages/react-sdk/src/state/types.ts
+++ b/packages/react-sdk/src/state/types.ts
@@ -37,7 +37,9 @@ export type WhiteboardManager = {
   /** Get the active whiteboard instance */
   getActiveWhiteboardInstance(): WhiteboardInstance | undefined;
   /** Get an observable subject for the active whiteboard */
-  getActiveWhiteboardSubject(): ObservableBehaviorSubject<WhiteboardInstance  |undefined>;
+  getActiveWhiteboardSubject(): ObservableBehaviorSubject<
+    WhiteboardInstance | undefined
+  >;
   /** Clean up the current whiteboard. */
   clear(): void;
 };

--- a/packages/react-sdk/src/state/types.ts
+++ b/packages/react-sdk/src/state/types.ts
@@ -15,7 +15,7 @@
  */
 
 import { StateEvent, WidgetApi } from '@matrix-widget-toolkit/api';
-import { Observable } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { Whiteboard } from '../model';
 import { CommunicationChannelStatistics } from './communication';
 import {
@@ -36,6 +36,8 @@ export type WhiteboardManager = {
   ): void;
   /** Get the active whiteboard instance */
   getActiveWhiteboardInstance(): WhiteboardInstance | undefined;
+  /** Get an observable subject for the active whiteboard */
+  getActiveWhiteboardSubject(): ObservableBehaviorSubject<WhiteboardInstance  |undefined>;
   /** Clean up the current whiteboard. */
   clear(): void;
 };
@@ -302,3 +304,11 @@ export function isWhiteboardUndoManagerContext(
 
   return false;
 }
+
+/**
+ * BehaviorSubject type that only exposes functions for subscribers.
+ */
+export type ObservableBehaviorSubject<T> = Pick<
+  BehaviorSubject<T>,
+  'subscribe' | 'getValue' | 'pipe'
+>;

--- a/packages/react-sdk/src/state/useDistinctObserveBehaviorSubject.ts
+++ b/packages/react-sdk/src/state/useDistinctObserveBehaviorSubject.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+import { distinctUntilChanged } from 'rxjs';
+import { ObservableBehaviorSubject } from './types';
+
+/**
+ * Use the latest distinct (strict equal) value of a BehaviorSubject.
+ *
+ * @param subject - BehaviorSubject to observe
+ * @return The latest value of the BehaviorSubject
+ */
+export function useDistinctObserveBehaviorSubject<T>(
+  subject: ObservableBehaviorSubject<T>,
+): T {
+  const [value, setValue] = useState(subject.getValue());
+
+  useEffect(() => {
+    const subscription = subject
+      .pipe(distinctUntilChanged())
+      .subscribe(setValue);
+
+    return () => subscription.unsubscribe();
+  }, [subject]);
+
+  return value;
+}

--- a/packages/react-sdk/src/state/useWhiteboardManager.test.tsx
+++ b/packages/react-sdk/src/state/useWhiteboardManager.test.tsx
@@ -31,6 +31,7 @@ describe('useWhiteboardManager', () => {
     whiteboardManager = {
       getActiveWhiteboardInstance: vi.fn(),
       selectActiveWhiteboardInstance: vi.fn(),
+      getActiveWhiteboardSubject: vi.fn(),
       clear: vi.fn(),
     };
 

--- a/packages/react-sdk/src/store/connectionInfoSlice.ts
+++ b/packages/react-sdk/src/store/connectionInfoSlice.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSlice } from '@reduxjs/toolkit';
+import { RootState } from './store';
+
+export type ConnectionInfoState = {
+  snapshotFailed: boolean;
+};
+
+const initialState: ConnectionInfoState = {
+  snapshotFailed: false,
+};
+
+export const connectionInfoSlice = createSlice({
+  name: 'connectionInfo',
+  initialState,
+  reducers: {
+    setSnapshotFailed: (state) => {
+      return {
+        ...state,
+        snapshotFailed: true,
+      };
+    },
+    setSnapshotSuccessful: (state) => {
+      return {
+        ...state,
+        snapshotFailed: false,
+      };
+    },
+  },
+});
+
+export const { setSnapshotFailed, setSnapshotSuccessful } =
+  connectionInfoSlice.actions;
+
+export const selectConnectionInfo = (state: RootState) =>
+  state.connectionInfoReducer;
+
+export const connectionInfoReducer = connectionInfoSlice.reducer;

--- a/packages/react-sdk/src/store/index.ts
+++ b/packages/react-sdk/src/store/index.ts
@@ -15,6 +15,11 @@
  */
 
 export * from './api';
+export {
+  connectionInfoReducer,
+  setSnapshotFailed,
+  setSnapshotSuccessful,
+} from './connectionInfoSlice';
 export { useAppDispatch } from './reduxToolkitHooks';
 export { shapeSizesReducer } from './shapeSizesSlide';
 export { createStore } from './store';

--- a/packages/react-sdk/src/store/store.ts
+++ b/packages/react-sdk/src/store/store.ts
@@ -17,9 +17,9 @@
 import { WidgetApi } from '@matrix-widget-toolkit/api';
 import { autoBatchEnhancer, configureStore } from '@reduxjs/toolkit';
 import { baseApi } from './api/baseApi';
+import { connectionInfoReducer } from './connectionInfoSlice';
 import { loggerMiddleware } from './loggerMiddleware';
 import { shapeSizesReducer } from './shapeSizesSlide';
-import { connectionInfoReducer } from './connectionInfoSlice';
 
 export function createStore({
   widgetApi,

--- a/packages/react-sdk/src/store/store.ts
+++ b/packages/react-sdk/src/store/store.ts
@@ -19,6 +19,7 @@ import { autoBatchEnhancer, configureStore } from '@reduxjs/toolkit';
 import { baseApi } from './api/baseApi';
 import { loggerMiddleware } from './loggerMiddleware';
 import { shapeSizesReducer } from './shapeSizesSlide';
+import { connectionInfoReducer } from './connectionInfoSlice';
 
 export function createStore({
   widgetApi,
@@ -28,6 +29,7 @@ export function createStore({
   const store = configureStore({
     reducer: {
       [baseApi.reducerPath]: baseApi.reducer,
+      connectionInfoReducer,
       shapeSizesReducer,
     },
     middleware: (getDefaultMiddleware) => {


### PR DESCRIPTION
User perspective:
- Monitors the network state
- Displays a snackbar on send snapshot errors
- If the user clicks „learn more“ it shows a dialog with a message depending on the network state
- Tries to resend snapshots until success

![error-handling](https://github.com/user-attachments/assets/1710bd4d-0acd-41cf-93b2-ef1d6c62a255)

What changed:
- Snackbar can now display a „priority“ snackbar, overriding every other
- Snackbar is no longer dismissable by clicking anywhere
- New store slice with a connection info, currently providing if a snapshot failed
- Synchronised document now updates the last snapshot state in the store
- `ConnectionStateProvider` handling the connection logic
- A separate `ConnectionStateDialog` to display the „learn more“ info
- New `ObservableBehaviorSubject` as a helper
- `WhiteboardManager` now offers a subject to get changed whiteboard updates

Limitations:
- This PR does not handle the problem, that the hosting client queues the events → follow up task
- Since there is no specific error for rate limiting, the dialog only shows one of the „no internet connection“ or „common“ messages



<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
