### PR TITLE
crdt-documents.md: Fix type of mxc

### DIFF
--- a/docs/model/crdt-documents.md
+++ b/docs/model/crdt-documents.md
@@ -190,7 +190,7 @@ An image element
 | Field      | Type                                                            | Description                                                                                               |
 | ---------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | `type`     | `'image'`                                                       | Identifies the element as an image.                                                                       |
-| `mxc`      | `'string'`                                                      | [MXC URI](https://spec.matrix.org/v1.9/client-server-api/#matrix-content-mxc-uris) pointing to the image. |
+| `mxc`      | `string`                                                        | [MXC URI](https://spec.matrix.org/v1.9/client-server-api/#matrix-content-mxc-uris) pointing to the image. |
 | `fileName` | `string`                                                        | Image file name.                                                                                          |
 | `mimeType` | `'image/gif' \| 'image/jpeg' \| 'image/png' \| 'image/svg+xml'` | Supported image mime type.                                                                                |
 | `position` | `Point`                                                         | The position of the image on the whiteboard canvas.                                                       |


### PR DESCRIPTION
mxc has the type string and is not the string "string"
