### PR TITLE
Backport Document Previews from MC Version

### DIFF
--- a/.changeset/rude-deers-dress.md
+++ b/.changeset/rude-deers-dress.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': minor
+---
+
+Adds optional whiteboard previews saved in room state

--- a/.env.local.default
+++ b/.env.local.default
@@ -1,2 +1,3 @@
 # For more options, see docs/configuration.md
 REACT_APP_HOME_SERVER_URL=https://matrix-client.matrix.org
+REACT_APP_PREVIEWS=false

--- a/charts/matrix-neoboard-widget/values.dev.yaml
+++ b/charts/matrix-neoboard-widget/values.dev.yaml
@@ -5,3 +5,5 @@ env:
     value: "https://github.com/nordeck/matrix-neoboard"
   - name: REACT_APP_HOME_SERVER_URL
     value: "https://synapse.dev.nordeck.io"
+  - name: REACT_APP_PREVIEWS
+    value: "true"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,9 @@ REACT_APP_HOME_SERVER_URL=https://matrix-client.matrix.org
 # External link to the documentation that will be shown in the help menu if defined.
 REACT_APP_HELP_CENTER_URL="https://github.com/nordeck/matrix-neoboard"
 
+# optional - enables board previews state event usage (default: false)
+REACT_APP_PREVIEWS=true
+
 # optional - enable connection to React standalone devtools
 # Does only work in development mode.
 REACT_APP_DEVTOOLS=true

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -51,6 +51,10 @@ Snapshot
 Snapshots are used to restore the whiteboard on load and could be used to restore a later version.
 Snapshots are stored as room events in Matrix rooms.
 
+Preview
+: A preview of the whiteboard's first slide.
+Previews can be used by other Matrix clients to show a preview of the whiteboard content before opening or loading it. Previews are stored as room state events.
+
 [WebRTC](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API)
 : A framework for real-time peep-to-peer communication in browsers.
 

--- a/docs/model/matrix-events.md
+++ b/docs/model/matrix-events.md
@@ -7,6 +7,12 @@ The Matrix protocol is used as the base communication and storage layer for the 
 The whiteboard state is stored using the following events in a Matrix room:
 
 ```
+┌────────────────────────────────┐
+│                                │
+│ net.nordeck.whiteboard.preview │
+│                                │
+└────────────────────────────────┘
+
 ┌────────────────────────────────┐                  ┌─────────────────────────────────┐
 │                                │                  │                                 │
 │ net.nordeck.whiteboard         │◄─────────────────┤ net.nordeck.whiteboard.sessions │
@@ -99,6 +105,36 @@ The `state_key` of the event is also referred to as _whiteboard id_.
   "state_key": "<whiteboard-id>",
   "content": {
     "documentId": "$H1-nssrxUGbrMdKSDJcACCpmc4PrClb2WDSOrGUv6bs"
+  },
+  "event_id": "$event-id",
+  "room_id": "!room-id",
+  "origin_server_ts": 1665134498391
+}
+```
+
+### `net.nordeck.whiteboard.preview` (State Event)
+
+Holds a gzipped, base64 encoded preview of the whiteboard's first slide in SVG format.
+This is useful for Matrix clients that wish to show a preview of the whiteboard's contents but
+because state events are not encrypted, preview data can be made available to users that are not members
+of the room. If the gzipped, base64 encoded SVG exceeds the size that an event can hold,
+then the preview content is removed and not updated again until if fits within the size limit.
+
+#### Content
+
+| Field     | Type     | Description                                                                                               |
+| --------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `preview` | `string` | A gzipped, base64 encoded string that can be used by matrix clients to show a preview of the first slide. |
+
+#### Example
+
+```json
+{
+  "type": "net.nordeck.whiteboard.preview",
+  "sender": "@user-id",
+  "state_key": "",
+  "content": {
+    "preview": "4sIAAAAAAAAA91WTW/bMA..."
   },
   "event_id": "$event-id",
   "room_id": "!room-id",

--- a/matrix-neoboard-widget/src/widgetCapabilities.ts
+++ b/matrix-neoboard-widget/src/widgetCapabilities.ts
@@ -23,6 +23,7 @@ import {
   ROOM_EVENT_DOCUMENT_CHUNK,
   ROOM_EVENT_DOCUMENT_CREATE,
   ROOM_EVENT_DOCUMENT_SNAPSHOT,
+  STATE_EVENT_DOCUMENT_PREVIEW,
   STATE_EVENT_ROOM_NAME,
   STATE_EVENT_WHITEBOARD,
   STATE_EVENT_WHITEBOARD_SESSIONS,
@@ -38,6 +39,7 @@ import {
 const { userId } = extractWidgetParameters();
 
 export const widgetCapabilities = [
+  // Room Events
   WidgetEventCapability.forRoomEvent(
     EventDirection.Send,
     ROOM_EVENT_DOCUMENT_CREATE,
@@ -62,7 +64,17 @@ export const widgetCapabilities = [
     EventDirection.Receive,
     ROOM_EVENT_DOCUMENT_CHUNK,
   ),
-
+  // State Events
+  WidgetEventCapability.forStateEvent(
+    EventDirection.Send,
+    STATE_EVENT_DOCUMENT_PREVIEW,
+    '',
+  ),
+  WidgetEventCapability.forStateEvent(
+    EventDirection.Receive,
+    STATE_EVENT_DOCUMENT_PREVIEW,
+    '',
+  ),
   WidgetEventCapability.forStateEvent(
     EventDirection.Send,
     STATE_EVENT_POWER_LEVELS,
@@ -73,7 +85,6 @@ export const widgetCapabilities = [
     STATE_EVENT_POWER_LEVELS,
     '',
   ),
-
   WidgetEventCapability.forStateEvent(
     EventDirection.Receive,
     STATE_EVENT_ROOM_MEMBER,
@@ -101,7 +112,7 @@ export const widgetCapabilities = [
     EventDirection.Receive,
     STATE_EVENT_ROOM_NAME,
   ),
-
+  // To Device Events
   WidgetEventCapability.forToDeviceEvent(
     EventDirection.Send,
     TO_DEVICE_MESSAGE_CONNECTION_SIGNALING,
@@ -110,7 +121,7 @@ export const widgetCapabilities = [
     EventDirection.Receive,
     TO_DEVICE_MESSAGE_CONNECTION_SIGNALING,
   ),
-
+  // Others
   MatrixCapabilities.MSC3846TurnServers,
   WidgetApiFromWidgetAction.MSC4039UploadFileAction,
   WidgetApiFromWidgetAction.MSC4039DownloadFileAction,

--- a/packages/react-sdk/src/components/Layout/Layout.tsx
+++ b/packages/react-sdk/src/components/Layout/Layout.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { getEnvironment } from '@matrix-widget-toolkit/mui';
 import { TabPanel } from '@mui/base';
 import { Box, Collapse, Slide, Stack, styled } from '@mui/material';
 import { ReactElement } from 'react';
@@ -40,6 +41,7 @@ import { SlideOverviewBar } from '../SlideOverviewBar';
 import { ToolsBar } from '../ToolsBar';
 import { UndoRedoBar } from '../UndoRedoBar';
 import { WhiteboardHost } from '../Whiteboard';
+import { DocumentPreview } from '../Whiteboard/DocumentPreview';
 import { PageLoader } from '../common/PageLoader';
 import { SlidesProvider } from './SlidesProvider';
 import { ToolbarCanvasContainer } from './ToolbarCanvasContainer';
@@ -62,6 +64,8 @@ export type LayoutProps = {
 };
 
 export function Layout({ height = '100vh' }: LayoutProps) {
+  const previewsEnabled =
+    getEnvironment('REACT_APP_PREVIEWS', 'false') === 'true';
   const { loading } = useIsWhiteboardLoading();
   const { isDeveloperToolsVisible, isFullscreenMode, isSlideOverviewVisible } =
     useLayoutState();
@@ -81,6 +85,12 @@ export function Layout({ height = '100vh' }: LayoutProps) {
       <ImageUploadProvider>
         <ImportWhiteboardDialogProvider>
           <GuidedTour disabled={isViewingPresentation} />
+
+          {previewsEnabled && (
+            <SlideProvider slideId={slideIds.at(0)!}>
+              <DocumentPreview />
+            </SlideProvider>
+          )}
 
           <Stack
             height={!isFullscreenMode ? height : '100vh'}

--- a/packages/react-sdk/src/components/Whiteboard/DocumentPreview.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/DocumentPreview.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Box } from '@mui/material';
+import { useWhiteboardFirstSlideInstance } from '../../state/useWhiteboardSlideInstance';
+import { ConnectedElement } from './Element';
+import { SvgCanvas } from './SvgCanvas';
+import { whiteboardHeight, whiteboardWidth } from './constants';
+
+export function DocumentPreview() {
+  const slideInstance = useWhiteboardFirstSlideInstance();
+  const elementIds = slideInstance.getElementIds();
+
+  return (
+    <Box id="document-preview" width="0%" visibility="hidden">
+      <SvgCanvas
+        viewportHeight={whiteboardHeight}
+        viewportWidth={whiteboardWidth}
+      >
+        {elementIds.map((e) => {
+          return <ConnectedElement id={e} key={e} readOnly />;
+        })}
+      </SvgCanvas>
+    </Box>
+  );
+}

--- a/packages/react-sdk/src/components/Whiteboard/SvgCanvas/SvgCanvas.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/SvgCanvas/SvgCanvas.tsx
@@ -137,6 +137,7 @@ export function SvgCanvas({
             viewBox={`0 0 ${viewportWidth} ${viewportHeight}`}
             onMouseDown={onMouseDown}
             onMouseMove={handleMouseMove}
+            xmlns="http://www.w3.org/2000/svg"
           >
             {children}
           </Canvas>

--- a/packages/react-sdk/src/components/Whiteboard/SvgCanvas/utils.ts
+++ b/packages/react-sdk/src/components/Whiteboard/SvgCanvas/utils.ts
@@ -37,3 +37,18 @@ export function calculateScale(
   const heightRatio = height / viewportHeight;
   return Math.max(widthRatio, heightRatio);
 }
+
+export async function svg2preview(html: HTMLElement): Promise<string> {
+  const encoder = new TextEncoder();
+  const uint8Array = encoder.encode(html.outerHTML);
+
+  const compressedStream = new Response(
+    new Blob([uint8Array]).stream().pipeThrough(new CompressionStream('gzip')),
+  ).arrayBuffer();
+
+  const compressedUint8Array = new Uint8Array(await compressedStream);
+  const binaryString = String.fromCharCode(...compressedUint8Array);
+  const base64String = btoa(binaryString);
+
+  return base64String;
+}

--- a/packages/react-sdk/src/model/documentPreview.test.ts
+++ b/packages/react-sdk/src/model/documentPreview.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  STATE_EVENT_DOCUMENT_PREVIEW,
+  isValidDocumentPreviewEvent,
+} from './documentPreview';
+
+describe('isValidDocumentPreviewEvent', () => {
+  it('should accept event', () => {
+    expect(
+      isValidDocumentPreviewEvent({
+        content: {
+          preview: 'data:image/png;base64,...',
+        },
+        event_id: '$event-id',
+        origin_server_ts: 0,
+        room_id: '!room-id',
+        state_key: '',
+        sender: '@user-id',
+        type: STATE_EVENT_DOCUMENT_PREVIEW,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/react-sdk/src/model/documentPreview.ts
+++ b/packages/react-sdk/src/model/documentPreview.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { StateEvent } from '@matrix-widget-toolkit/api';
+import Joi from 'joi';
+import { isValidEvent } from './validation';
+
+export const STATE_EVENT_DOCUMENT_PREVIEW = 'net.nordeck.whiteboard.preview';
+
+export type DocumentPreviewEvent = {
+  preview: string;
+};
+
+const documentPreviewEventSchema = Joi.object<DocumentPreviewEvent, true>({
+  preview: Joi.string().required(),
+}).unknown();
+
+export function isValidDocumentPreviewEvent(
+  event: StateEvent<unknown>,
+): event is StateEvent<DocumentPreviewEvent> {
+  return isValidEvent(
+    event,
+    STATE_EVENT_DOCUMENT_PREVIEW,
+    documentPreviewEventSchema,
+  );
+}

--- a/packages/react-sdk/src/model/index.ts
+++ b/packages/react-sdk/src/model/index.ts
@@ -31,6 +31,11 @@ export type { DocumentChunk } from './documentChunk';
 export { ROOM_EVENT_DOCUMENT_CREATE } from './documentCreate';
 export type { DocumentCreate } from './documentCreate';
 export {
+  STATE_EVENT_DOCUMENT_PREVIEW,
+  isValidDocumentPreviewEvent,
+} from './documentPreview';
+export type { DocumentPreviewEvent } from './documentPreview';
+export {
   ROOM_EVENT_DOCUMENT_SNAPSHOT,
   isValidDocumentSnapshotRoomEvent,
 } from './documentSnapshot';

--- a/packages/react-sdk/src/state/useOwnedWhiteboard.tsx
+++ b/packages/react-sdk/src/state/useOwnedWhiteboard.tsx
@@ -15,11 +15,16 @@
  */
 
 import { StateEvent } from '@matrix-widget-toolkit/api';
+import { getEnvironment } from '@matrix-widget-toolkit/mui';
 import { useWidgetApi } from '@matrix-widget-toolkit/react';
 import { first } from 'lodash';
 import loglevel from 'loglevel';
 import { useAsync } from 'react-use';
-import { STATE_EVENT_WHITEBOARD_SESSIONS, Whiteboard } from '../model';
+import {
+  STATE_EVENT_DOCUMENT_PREVIEW,
+  STATE_EVENT_WHITEBOARD_SESSIONS,
+  Whiteboard,
+} from '../model';
 import { useAppDispatch } from '../store';
 import {
   documentSnapshotApi,
@@ -54,6 +59,8 @@ export function useOwnedWhiteboard(): UseOwnedWhiteboardResponse {
   const [updateWhiteboard] = useUpdateWhiteboardMutation();
   const [patchPowerLevels] = usePatchPowerLevelsMutation();
   const { canInitializeWhiteboard } = usePowerLevels();
+  const previewsEnabled =
+    getEnvironment('REACT_APP_PREVIEWS', 'false') === 'true';
 
   const {
     data: whiteboardsState,
@@ -82,6 +89,9 @@ export function useOwnedWhiteboard(): UseOwnedWhiteboardResponse {
           changes: {
             events: {
               [STATE_EVENT_WHITEBOARD_SESSIONS]: 0,
+              ...(previewsEnabled && {
+                [STATE_EVENT_DOCUMENT_PREVIEW]: 0,
+              }),
             },
           },
         }).unwrap();

--- a/packages/react-sdk/src/state/useWhiteboardSlideInstance.tsx
+++ b/packages/react-sdk/src/state/useWhiteboardSlideInstance.tsx
@@ -45,6 +45,12 @@ export function useWhiteboardSlideInstance(): WhiteboardSlideInstance {
   return whiteboardInstance.getSlide(slideId);
 }
 
+export function useWhiteboardFirstSlideInstance(): WhiteboardSlideInstance {
+  const whiteboardInstance = useActiveWhiteboardInstance();
+  const slideId = whiteboardInstance.getSlideIds()[0];
+  return whiteboardInstance.getSlide(slideId);
+}
+
 export function useSlideElementIds(): string[] {
   const slideInstance = useWhiteboardSlideInstance();
 

--- a/packages/react-sdk/src/store/api/documentPreviewApi.ts
+++ b/packages/react-sdk/src/store/api/documentPreviewApi.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { StateEvent } from '@matrix-widget-toolkit/api';
+import { first, isError } from 'lodash';
+import { filter } from 'rxjs';
+import {
+  DocumentPreviewEvent,
+  STATE_EVENT_DOCUMENT_PREVIEW,
+  isValidDocumentPreviewEvent,
+} from '../../model';
+import { ThunkExtraArgument } from '../store';
+import { baseApi } from './baseApi';
+
+/**
+ * Endpoints to read the document preview event.
+ *
+ * @remarks this api extends the {@link baseApi} so it should
+ *          not be registered at the store.
+ */
+export const documentPreviewApi = baseApi.injectEndpoints({
+  endpoints: (builder) => ({
+    /**
+     * Return the document preview event of a room.
+     */
+    getDocumentPreview: builder.query<
+      { event: StateEvent<DocumentPreviewEvent> | undefined },
+      void
+    >({
+      queryFn: async (_, { extra }) => {
+        const widgetApi = await (extra as ThunkExtraArgument).widgetApi;
+
+        try {
+          const events = await widgetApi.receiveStateEvents(
+            STATE_EVENT_DOCUMENT_PREVIEW,
+          );
+
+          return {
+            data: { event: first(events.filter(isValidDocumentPreviewEvent)) },
+          };
+        } catch (e) {
+          return {
+            error: {
+              name: 'LoadFailed',
+              message: `Could not load document preview: ${
+                isError(e) ? e.message : e
+              }`,
+            },
+          };
+        }
+      },
+
+      async onCacheEntryAdded(
+        _,
+        { cacheDataLoaded, cacheEntryRemoved, extra, updateCachedData },
+      ) {
+        const widgetApi = await (extra as ThunkExtraArgument).widgetApi;
+
+        // wait until first data is cached
+        await cacheDataLoaded;
+
+        const subscription = widgetApi
+          .observeStateEvents(STATE_EVENT_DOCUMENT_PREVIEW)
+          .pipe(filter(isValidDocumentPreviewEvent))
+          .subscribe((event) => {
+            updateCachedData(() => ({ event }));
+          });
+
+        // wait until subscription is cancelled
+        await cacheEntryRemoved;
+
+        subscription.unsubscribe();
+      },
+    }),
+
+    /**
+     * Create a document snapshot in the current room.
+     */
+    createDocumentPreview: builder.mutation<
+      { event: StateEvent<DocumentPreviewEvent> },
+      { documentId: string; data: string }
+    >({
+      async queryFn({ data }, { extra }) {
+        const widgetApi = await (extra as ThunkExtraArgument).widgetApi;
+
+        try {
+          const maxSize = 60000;
+          // if preview data is too big, clear the preview content.
+          // IMO this is better than showing an outdated preview that
+          // doesn't correspond to actual contents
+          if (data.length > maxSize) {
+            data = '';
+          }
+
+          const previewEvent =
+            await widgetApi.sendStateEvent<DocumentPreviewEvent>(
+              STATE_EVENT_DOCUMENT_PREVIEW,
+              {
+                preview: data,
+              },
+            );
+          return { data: { event: previewEvent } };
+        } catch (e) {
+          return {
+            error: {
+              name: 'UpdateFailed',
+              message: `Could not create document preview: ${
+                isError(e) ? e.message : e
+              }`,
+            },
+          };
+        }
+      },
+    }),
+  }),
+});
+
+export const { useGetDocumentPreviewQuery } = documentPreviewApi;

--- a/packages/react-sdk/src/store/api/index.ts
+++ b/packages/react-sdk/src/store/api/index.ts
@@ -16,6 +16,10 @@
 
 export { baseApi } from './baseApi';
 export {
+  documentPreviewApi,
+  useGetDocumentPreviewQuery,
+} from './documentPreviewApi';
+export {
   documentSnapshotApi,
   useCreateDocumentMutation,
 } from './documentSnapshotApi';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1387,9 +1387,9 @@
     undici-types "~6.19.8"
 
 "@types/node@^12.7.1":
-  version "12.20.55"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
-  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+  version "12.20.52"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.52.tgz#2fd2dc6bfa185601b15457398d4ba1ef27f81251"
+  integrity sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw==
 
 "@types/parse-json@^4.0.0":
   version "4.0.2"


### PR DESCRIPTION
* Use room state event for whiteboard preview
* Store gziped, base64 encoded SVG data instead of image thumbnails
* Apply feedback from review
* Remove debug logs
* Fix end of file
* Add missing capability
* Fix yarn lock file
* Fix Matrix event docs
* Simplify preview component
* Patch power levels to enable any room member to send a preview state event
---------

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

Cherry picking from `release/mc-version`

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
