### PR TITLE
Give arrow head SVG end markers a unique Id per rending

### DIFF
--- a/.changeset/green-spies-pump.md
+++ b/.changeset/green-spies-pump.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+An error was fixed, that caused arrow heads sometimes not appear on the first slide

--- a/packages/react-sdk/src/components/elements/line/Display.tsx
+++ b/packages/react-sdk/src/components/elements/line/Display.tsx
@@ -41,10 +41,10 @@ const LineDisplay = ({
     points: { start, end },
   } = getRenderProperties(element);
 
-  const { endMarkerId, endMarker } = useEndMarker(elementId, element);
+  const { endMarkerId, endMarker } = useEndMarker(element);
 
   const renderedChild = (
-    <g>
+    <g data-testid={`element-${elementId}`}>
       {endMarker}
       <line
         fill="none"

--- a/packages/react-sdk/src/components/elements/line/useEndMarker.test.tsx
+++ b/packages/react-sdk/src/components/elements/line/useEndMarker.test.tsx
@@ -15,14 +15,30 @@
  */
 
 import { renderHook } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { useId } from 'react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockLineElement } from '../../../lib/testUtils/documentTestUtils';
 import { useEndMarker } from './useEndMarker';
 
+vi.mock('react', async (importActual) => ({
+  ...(await importActual()),
+  useId: vi.fn(),
+}));
+
 describe('useEndMarker', () => {
+  let reactUseId = 1;
+
+  beforeAll(() => {
+    vi.mocked(useId).mockImplementation(() => `id-${reactUseId++}`);
+  });
+
+  beforeEach(() => {
+    reactUseId = 1;
+  });
+
   it('should return an empty result if there is no end marker', () => {
     const element = mockLineElement();
-    const { result } = renderHook(() => useEndMarker('element-0', element));
+    const { result } = renderHook(() => useEndMarker(element));
     expect(result.current).toEqual({
       endMarkerId: undefined,
       endMarker: null,
@@ -31,8 +47,8 @@ describe('useEndMarker', () => {
 
   it('should return an end marker', () => {
     const element = mockLineElement({ endMarker: 'arrow-head-line' });
-    const { result } = renderHook(() => useEndMarker('element-0', element));
-    expect(result.current.endMarkerId).toEqual('element-0-end-marker');
-    expect(result.current.endMarker?.props.id).toBe('element-0-end-marker');
+    const { result } = renderHook(() => useEndMarker(element));
+    expect(result.current.endMarkerId).toEqual('end-marker-id-1');
+    expect(result.current.endMarker?.props.id).toBe('end-marker-id-1');
   });
 });

--- a/packages/react-sdk/src/components/elements/line/useEndMarker.tsx
+++ b/packages/react-sdk/src/components/elements/line/useEndMarker.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ReactElement } from 'react';
+import { ReactElement, useId } from 'react';
 import { PathElement } from '../../../state';
 import { ArrowHeadLineEndMarker } from './ArrowHeadLineEndMarker';
 
@@ -43,11 +43,9 @@ type UseEndMarkerResult =
  * @param elementId - ID of the element to which the marker belongs
  * @param element - The element to which the marker belongs
  */
-export function useEndMarker(
-  elementId: string,
-  element: PathElement,
-): UseEndMarkerResult {
-  const endMarkerId = `${elementId}-end-marker`;
+export function useEndMarker(element: PathElement): UseEndMarkerResult {
+  const uniqueId = useId();
+  const endMarkerId = `end-marker-${uniqueId}`;
 
   if (element.endMarker === 'arrow-head-line') {
     return {


### PR DESCRIPTION
Before it may happened, that the same ID was used multiple times, for example for slide previews. End markers now always get a unique ID per rendering.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
