### PR TITLE
NEO-1075: Shapes have a minimum size enforced on creation / loading

### DIFF
--- a/.changeset/thick-colts-help.md
+++ b/.changeset/thick-colts-help.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-widget': patch
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+Shapes now have a minimum size enforced when creating or loading

--- a/matrix-neoboard-widget/src/logger.ts
+++ b/matrix-neoboard-widget/src/logger.ts
@@ -38,7 +38,7 @@ window.addEventListener('unhandledrejection', (event) => {
 window.addEventListener('error', (event) => {
   if (event.message.startsWith('ResizeObserver loop limit exceeded')) {
     // This error can come up a lot, therefore we are ignoring it to avoid
-    // spamming the console. The error is "save to ignore":
+    // spamming the console. The error is "safe to ignore":
     // https://stackoverflow.com/a/50387233/218902
     return;
   }

--- a/packages/react-sdk/src/components/Whiteboard/Draft/DraftLineChild.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/Draft/DraftLineChild.tsx
@@ -49,11 +49,23 @@ export const DraftLineChild = ({
 
   const handleMouseUp = useCallback(() => {
     if (cursorPoints) {
-      if (cursorPoints.length > 1) {
+      // check for minimal distance between points to avoid creating zero-sized lines
+      const uniqueCursorPoints = cursorPoints.filter((point, index) => {
+        return (
+          cursorPoints.findIndex((p, i) => {
+            if (i >= index) return false;
+            const distance = Math.sqrt(
+              (p.x - point.x) ** 2 + (p.y - point.y) ** 2,
+            );
+            return distance < 1;
+          }) === -1
+        );
+      });
+      if (uniqueCursorPoints.length > 1) {
         slideInstance.addElement(
           createShapeFromPoints({
             kind,
-            cursorPoints,
+            cursorPoints: uniqueCursorPoints,
             strokeColor,
             gridCellSize: isShowGrid ? gridCellSize : undefined,
             onlyStartAndEndPoints,

--- a/packages/react-sdk/src/components/Whiteboard/Draft/DraftLineChild.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/Draft/DraftLineChild.tsx
@@ -49,23 +49,11 @@ export const DraftLineChild = ({
 
   const handleMouseUp = useCallback(() => {
     if (cursorPoints) {
-      // check for minimal distance between points to avoid creating zero-sized lines
-      const uniqueCursorPoints = cursorPoints.filter((point, index) => {
-        return (
-          cursorPoints.findIndex((p, i) => {
-            if (i >= index) return false;
-            const distance = Math.sqrt(
-              (p.x - point.x) ** 2 + (p.y - point.y) ** 2,
-            );
-            return distance < 1;
-          }) === -1
-        );
-      });
-      if (uniqueCursorPoints.length > 1) {
+      if (cursorPoints.length > 1) {
         slideInstance.addElement(
           createShapeFromPoints({
             kind,
-            cursorPoints: uniqueCursorPoints,
+            cursorPoints,
             strokeColor,
             gridCellSize: isShowGrid ? gridCellSize : undefined,
             onlyStartAndEndPoints,

--- a/packages/react-sdk/src/components/Whiteboard/Draft/createShape.test.ts
+++ b/packages/react-sdk/src/components/Whiteboard/Draft/createShape.test.ts
@@ -135,18 +135,18 @@ describe('createShape', () => {
     });
   });
 
-  it('should constrain to the grid', () => {
+  it('should constrain shape to the grid', () => {
     const result = createShape({
       kind: 'circle',
       startCoords: { x: 10, y: 20 },
       endCoords: { x: 30, y: 60 },
       fillColor: '#ffffff',
-      gridCellSize: 40,
+      gridCellSize: 20,
     });
     expect(result).toEqual({
-      width: 40,
+      width: 20,
       height: 40,
-      position: { x: 0, y: 40 },
+      position: { x: 20, y: 20 },
       type: 'shape',
       kind: 'circle',
       text: '',
@@ -160,12 +160,12 @@ describe('createShape', () => {
       startCoords: { x: 30, y: 60 },
       endCoords: { x: 10, y: 20 },
       fillColor: '#ffffff',
-      gridCellSize: 40,
+      gridCellSize: 20,
     });
     expect(result).toEqual({
-      width: 40,
+      width: 20,
       height: 40,
-      position: { x: 0, y: 40 },
+      position: { x: 20, y: 20 },
       type: 'shape',
       kind: 'circle',
       text: '',
@@ -249,7 +249,7 @@ describe('createShapeFromPoints', () => {
     });
   });
 
-  it('should constrain to the grid', () => {
+  it('should constrain line to the grid', () => {
     const cursorPoints = [
       { x: 10, y: 20 },
       { x: 50, y: 60 },
@@ -259,17 +259,35 @@ describe('createShapeFromPoints', () => {
       cursorPoints,
       strokeColor: '#000000',
       onlyStartAndEndPoints: true,
-      gridCellSize: 40,
+      gridCellSize: 20,
     });
     expect(result).toEqual({
       points: [
         { x: 0, y: 0 },
         { x: 40, y: 40 },
       ],
-      position: { x: 0, y: 40 },
+      position: { x: 20, y: 20 },
       strokeColor: '#000000',
       type: 'path',
       kind: 'line',
+    });
+  });
+
+  it('should create shape with minimum width and height', () => {
+    const result = createShape({
+      kind: 'circle',
+      startCoords: { x: 30, y: 60 },
+      endCoords: { x: 30.5, y: 60.5 },
+      fillColor: '#ffffff',
+    });
+    expect(result).toEqual({
+      width: 1,
+      height: 1,
+      position: { x: 30, y: 60 },
+      type: 'shape',
+      kind: 'circle',
+      text: '',
+      fillColor: '#ffffff',
     });
   });
 });

--- a/packages/react-sdk/src/components/Whiteboard/Draft/createShape.ts
+++ b/packages/react-sdk/src/components/Whiteboard/Draft/createShape.ts
@@ -96,9 +96,8 @@ export function createShape({
   }
 
   // `width` and `height` must not be 0.
-  // Picked 2px because it's also the minimum size when riszing a shape.
-  width = Math.max(width, 2);
-  height = Math.max(height, 2);
+  width = Math.max(width, 1);
+  height = Math.max(height, 1);
 
   return {
     fillColor,

--- a/packages/react-sdk/src/components/Whiteboard/Draft/createShape.ts
+++ b/packages/react-sdk/src/components/Whiteboard/Draft/createShape.ts
@@ -95,6 +95,11 @@ export function createShape({
     }
   }
 
+  // `width` and `height` must not be 0.
+  // Picked 2px because it's also the minimum size when riszing a shape.
+  width = Math.max(width, 2);
+  height = Math.max(height, 2);
+
   return {
     fillColor,
     height,

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/utils.test.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/utils.test.ts
@@ -48,7 +48,7 @@ describe('calculateDragDimension', () => {
   it('should ensure a minimum size', () => {
     expect(calculateDragDimension(0, 1)).toEqual({
       position: 0,
-      size: 2,
+      size: 1,
       inverted: false,
     });
   });
@@ -279,8 +279,8 @@ describe('calculateDimensions', () => {
     ).toEqual({
       x: 15,
       y: 30,
-      width: 2,
-      height: 2,
+      width: 1,
+      height: 1,
     });
   });
 
@@ -441,7 +441,7 @@ describe('computeResizing', () => {
 
   const viewportWidth = 360;
   const viewportHeight = 360;
-  const gridCellSize = 40;
+  const gridCellSize = 20;
 
   const line = mockLineElement({
     position: { x: 120, y: 160 },

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/utils.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/utils.ts
@@ -103,8 +103,8 @@ export function calculateDragDimension(
     ? dragOrigin - constrainedDragPosition
     : constrainedDragPosition - dragOrigin;
 
-  // Force shapes to have at least a dimension of two, to match our validation.
-  const size = Math.max(2, dimension);
+  // Force shapes to have at least a dimension of one
+  const size = Math.max(1, dimension);
   return {
     position,
     size,

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextElement.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextElement.tsx
@@ -99,6 +99,11 @@ export const TextElement = ({
     activeElement.fillColor === 'transparent' &&
     activeElement.text.trim() === '';
 
+  // foreign object can't have negative dimensions
+  if (height < 0 || width < 0) {
+    return null;
+  }
+
   return (
     <ForeignObjectNoInteraction x={x} y={y} height={height} width={width}>
       <TextEditor

--- a/packages/react-sdk/src/state/crdt/documents/elements.test.ts
+++ b/packages/react-sdk/src/state/crdt/documents/elements.test.ts
@@ -148,9 +148,11 @@ describe('isValidElement', () => {
     { width: undefined },
     { width: null },
     { width: '111' },
+    { width: 0 },
     { height: undefined },
     { height: null },
     { height: '111' },
+    { height: 0 },
     { fillColor: undefined },
     { fillColor: null },
     { fillColor: 111 },
@@ -225,9 +227,11 @@ describe('isValidElement', () => {
     { width: undefined },
     { width: null },
     { width: '111' },
+    { width: 0 },
     { height: undefined },
     { height: null },
     { height: '111' },
+    { height: 0 },
   ])('should reject an image event with patch %j', (patch: object) => {
     const data = {
       type: 'image',

--- a/packages/react-sdk/src/state/crdt/documents/elements.ts
+++ b/packages/react-sdk/src/state/crdt/documents/elements.ts
@@ -63,8 +63,8 @@ const shapeElementSchema = elementBaseSchema
     kind: Joi.string()
       .valid('rectangle', 'circle', 'ellipse', 'triangle')
       .required(),
-    width: Joi.number().strict().required(),
-    height: Joi.number().strict().required(),
+    width: Joi.number().strict().min(1).required(),
+    height: Joi.number().strict().min(1).required(),
     fillColor: Joi.string().required(),
     strokeColor: Joi.string().strict(),
     strokeWidth: Joi.number().strict(),
@@ -134,8 +134,8 @@ const imageElementSchema = elementBaseSchema
     mimeType: Joi.string()
       .valid(...Object.keys(defaultAcceptedImageTypes))
       .optional(),
-    width: Joi.number().strict().required(),
-    height: Joi.number().strict().required(),
+    width: Joi.number().strict().min(1).required(),
+    height: Joi.number().strict().min(1).required(),
   })
   .required();
 


### PR DESCRIPTION
We already enforce this minimum size when resizing. Now, it's also enforced while.

I couldn't find the code that enforces the minimum size when reszing. Would be great to use the same code / values / constant here.

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [X] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
