### PR TITLE
Fix waiting for the TURN server config from the Widget API

### DIFF
--- a/.changeset/breezy-flies-doubt.md
+++ b/.changeset/breezy-flies-doubt.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+NeoBoard now more reliably uses the TURN server provided by the Matrix server configuration.

--- a/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.ts
+++ b/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.ts
@@ -19,13 +19,20 @@ import { cloneDeep } from 'lodash';
 import { getLogger } from 'loglevel';
 import {
   BehaviorSubject,
+  NEVER,
   Observable,
   Subject,
   distinctUntilChanged,
+  filter,
+  firstValueFrom,
   from,
+  interval,
+  map,
   mergeMap,
+  race,
   switchMap,
   takeUntil,
+  timeout,
 } from 'rxjs';
 import {
   Message,
@@ -33,7 +40,7 @@ import {
   PeerConnectionStatistics,
   WebRtcPeerConnection,
 } from './connection';
-import { SessionManager } from './discovery';
+import { Session, SessionManager } from './discovery';
 import { SignalingChannel } from './signaling';
 import { CommunicationChannel, CommunicationChannelStatistics } from './types';
 import { observeVisibilityState } from './visibilityState';
@@ -76,39 +83,7 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
     this.sessionManager
       .observeSessionJoined()
       .pipe(takeUntil(this.destroySubject))
-      .subscribe((session) => {
-        const sessionId = this.sessionManager.getSessionId();
-
-        this.logger.log('joined', session.sessionId, session.userId);
-
-        if (!sessionId) {
-          throw new Error('Unknown session id');
-        }
-
-        const peerConnection = new WebRtcPeerConnection(
-          this.signalingChannel,
-          session,
-          sessionId,
-          { turnServer: this.turnServers },
-        );
-        this.peerConnections.push(peerConnection);
-
-        peerConnection
-          .observeMessages()
-          .subscribe((m) => this.messagesSubject.next(m));
-
-        peerConnection.observeStatistics().subscribe({
-          next: (peerConnectionStatistics) => {
-            this.addPeerConnectionStatistics(
-              peerConnection.getConnectionId(),
-              peerConnectionStatistics,
-            );
-          },
-          complete: () => {
-            this.addPeerConnectionStatistics(peerConnection.getConnectionId());
-          },
-        });
-      });
+      .subscribe(this.handleSessionJoined.bind(this));
 
     this.sessionManager
       .observeSessionLeft()
@@ -220,6 +195,67 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
 
     this.statistics.localSessionId = undefined;
     this.statisticsSubject.next(cloneDeep(this.statistics));
+  }
+
+  /**
+   * If there are already known TURN servers, this is a noop.
+   * Otherwise wait for TURN servers from the Widget API until a timeout.
+   */
+  private async initTurnServers(): Promise<void> {
+    if (this.turnServers !== undefined) {
+      // TURN servers already known
+      return;
+    }
+
+    const source = race(
+      interval(250).pipe(
+        map(() => {
+          return this.turnServers;
+        }),
+        filter((t) => t !== undefined),
+      ),
+      NEVER.pipe(timeout(2500)),
+    );
+
+    await firstValueFrom(source);
+  }
+
+  private async handleSessionJoined(session: Session): Promise<void> {
+    const sessionId = this.sessionManager.getSessionId();
+
+    this.logger.log('joined', session.sessionId, session.userId);
+
+    if (!sessionId) {
+      throw new Error('Unknown session id');
+    }
+
+    // Wait for the Widget API or TURN servers to be ready
+    await this.widgetApiPromise;
+    await this.initTurnServers();
+
+    const peerConnection = new WebRtcPeerConnection(
+      this.signalingChannel,
+      session,
+      sessionId,
+      { turnServer: this.turnServers },
+    );
+    this.peerConnections.push(peerConnection);
+
+    peerConnection
+      .observeMessages()
+      .subscribe((m) => this.messagesSubject.next(m));
+
+    peerConnection.observeStatistics().subscribe({
+      next: (peerConnectionStatistics) => {
+        this.addPeerConnectionStatistics(
+          peerConnection.getConnectionId(),
+          peerConnectionStatistics,
+        );
+      },
+      complete: () => {
+        this.addPeerConnectionStatistics(peerConnection.getConnectionId());
+      },
+    });
   }
 
   private addPeerConnectionStatistics(


### PR DESCRIPTION
The test changes look more crazy, than they actually are. There is now a test using the deferred TURN server config. It moved into it's own `describe` block for the setup.

The other notable change is the new `initTurnServers` function and calling it when setting up a connection.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
