### PR TITLE
Migrate to new toolkit version without state event result.

### DIFF
--- a/matrix-neoboard-widget/package.json
+++ b/matrix-neoboard-widget/package.json
@@ -7,8 +7,8 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@matrix-widget-toolkit/api": "^3.4.2",
-    "@matrix-widget-toolkit/mui": "^2.1.0",
+    "@matrix-widget-toolkit/api": "^4.0.0",
+    "@matrix-widget-toolkit/mui": "^2.1.1",
     "@nordeck/matrix-neoboard-react-sdk": "1.0.0",
     "i18next": "^23.15.2",
     "i18next-browser-languagedetector": "^8.0.0",

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -15,9 +15,9 @@
   "type": "module",
   "dependencies": {
     "@fontsource/noto-emoji": "^5.1.0",
-    "@matrix-widget-toolkit/api": "^3.4.2",
-    "@matrix-widget-toolkit/mui": "^2.1.0",
-    "@matrix-widget-toolkit/react": "^2.0.3",
+    "@matrix-widget-toolkit/api": "^4.0.0",
+    "@matrix-widget-toolkit/mui": "^2.1.1",
+    "@matrix-widget-toolkit/react": "^2.0.4",
     "@mui/base": "^5.0.0-beta.64",
     "@mui/icons-material": "^6.1.2",
     "@mui/lab": "^6.0.0-beta.18",
@@ -51,7 +51,7 @@
     "react-i18next": "^15.0.1"
   },
   "devDependencies": {
-    "@matrix-widget-toolkit/testing": "^3.0.1",
+    "@matrix-widget-toolkit/testing": "^3.0.3",
     "@testing-library/jest-dom": "^6.6.2",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",

--- a/packages/react-sdk/src/store/api/powerLevelsApi.test.ts
+++ b/packages/react-sdk/src/store/api/powerLevelsApi.test.ts
@@ -123,22 +123,11 @@ describe('patchPowerLevels', () => {
 
     const store = createStore({ widgetApi });
 
-    await expect(
-      store.dispatch(
-        powerLevelsApi.endpoints.patchPowerLevels.initiate({
-          changes: { users_default: 0, events_default: 0 },
-        }),
-      ),
-    ).resolves.toEqual({
-      data: expect.objectContaining({
-        content: {
-          users: { '@user-id': 100 },
-          users_default: 0,
-          events_default: 0,
-        },
-        room_id: '!room-id',
+    await store.dispatch(
+      powerLevelsApi.endpoints.patchPowerLevels.initiate({
+        changes: { users_default: 0, events_default: 0 },
       }),
-    });
+    );
 
     expect(widgetApi.sendStateEvent).toHaveBeenCalledWith(
       'm.room.power_levels',
@@ -162,21 +151,11 @@ describe('patchPowerLevels', () => {
 
     const store = createStore({ widgetApi });
 
-    await expect(
-      store.dispatch(
-        powerLevelsApi.endpoints.patchPowerLevels.initiate({
-          changes: { users_default: 100 },
-        }),
-      ),
-    ).resolves.toEqual({
-      data: expect.objectContaining({
-        content: {
-          users: { '@user-id': 100 },
-          users_default: 100,
-        },
-        room_id: '!room-id',
+    await store.dispatch(
+      powerLevelsApi.endpoints.patchPowerLevels.initiate({
+        changes: { users_default: 100 },
       }),
-    });
+    );
 
     expect(widgetApi.sendStateEvent).not.toHaveBeenCalled();
   });

--- a/packages/react-sdk/src/store/api/powerLevelsApi.ts
+++ b/packages/react-sdk/src/store/api/powerLevelsApi.ts
@@ -97,7 +97,7 @@ export const powerLevelsApi = baseApi.injectEndpoints({
     }),
 
     patchPowerLevels: builder.mutation<
-      StateEvent<PowerLevelsStateEvent>,
+      null,
       { changes: Partial<PowerLevelsStateEvent> }
     >({
       async queryFn({ changes }, { extra }) {
@@ -121,15 +121,12 @@ export const powerLevelsApi = baseApi.injectEndpoints({
             powerLevelEvent &&
             isEqual(powerLevelEvent.content, powerLevels)
           ) {
-            return { data: powerLevelEvent };
+            return { data: null };
           }
 
-          const data = await widgetApi.sendStateEvent(
-            STATE_EVENT_POWER_LEVELS,
-            powerLevels,
-          );
+          await widgetApi.sendStateEvent(STATE_EVENT_POWER_LEVELS, powerLevels);
 
-          return { data };
+          return { data: null };
         } catch (e) {
           return {
             error: {

--- a/packages/react-sdk/src/store/api/whiteboardApi.ts
+++ b/packages/react-sdk/src/store/api/whiteboardApi.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { compareOriginServerTS, StateEvent } from '@matrix-widget-toolkit/api';
+import {
+  compareOriginServerTS,
+  makeEventFromSendStateEventResult,
+  StateEvent,
+} from '@matrix-widget-toolkit/api';
 import { createEntityAdapter, EntityState } from '@reduxjs/toolkit';
 import { isEqual, isError, last } from 'lodash';
 import { bufferTime, filter } from 'rxjs';
@@ -142,13 +146,27 @@ export const whiteboardApi = baseApi.injectEndpoints({
             return { data: { event: whiteboardEvent } };
           }
 
-          const event = await widgetApi.sendStateEvent(
+          const result = await widgetApi.sendStateEvent(
             STATE_EVENT_WHITEBOARD,
             whiteboard,
             { stateKey: whiteboardId },
           );
 
-          return { data: { event } };
+          if (widgetApi.widgetParameters.userId === undefined) {
+            throw new Error('Own user ID is undefined');
+          }
+
+          return {
+            data: {
+              event: makeEventFromSendStateEventResult(
+                STATE_EVENT_WHITEBOARD,
+                whiteboardId,
+                whiteboard,
+                widgetApi.widgetParameters.userId,
+                result,
+              ),
+            },
+          };
         } catch (e) {
           return {
             error: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,16 +307,16 @@
     human-id "^1.0.2"
     prettier "^2.7.1"
 
-"@emotion/babel-plugin@^11.12.0":
-  version "11.12.0"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz#7b43debb250c313101b3f885eba634f1d723fcc2"
-  integrity sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==
+"@emotion/babel-plugin@^11.13.5":
+  version "11.13.5"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz#eab8d65dbded74e0ecfd28dc218e75607c4e7bc0"
+  integrity sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==
   dependencies:
     "@babel/helper-module-imports" "^7.16.7"
     "@babel/runtime" "^7.18.3"
     "@emotion/hash" "^0.9.2"
     "@emotion/memoize" "^0.9.0"
-    "@emotion/serialize" "^1.2.0"
+    "@emotion/serialize" "^1.3.3"
     babel-plugin-macros "^3.1.0"
     convert-source-map "^1.5.0"
     escape-string-regexp "^4.0.0"
@@ -324,18 +324,18 @@
     source-map "^0.5.7"
     stylis "4.2.0"
 
-"@emotion/cache@11.13.1":
-  version "11.13.1"
-  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.13.1.tgz#fecfc54d51810beebf05bf2a161271a1a91895d7"
-  integrity sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==
+"@emotion/cache@11.14.0", "@emotion/cache@^11.14.0":
+  version "11.14.0"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.14.0.tgz#ee44b26986eeb93c8be82bb92f1f7a9b21b2ed76"
+  integrity sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==
   dependencies:
     "@emotion/memoize" "^0.9.0"
     "@emotion/sheet" "^1.4.0"
-    "@emotion/utils" "^1.4.0"
+    "@emotion/utils" "^1.4.2"
     "@emotion/weak-memoize" "^0.4.0"
     stylis "4.2.0"
 
-"@emotion/cache@^11.13.0", "@emotion/cache@^11.13.5":
+"@emotion/cache@^11.13.5":
   version "11.13.5"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.13.5.tgz#e78dad0489e1ed7572507ba8ed9d2130529e4266"
   integrity sha512-Z3xbtJ+UcK76eWkagZ1onvn/wAVb1GOMuR15s30Fm2wrMgC7jzpnO2JZXr4eujTTqoQFUrZIw/rT0c6Zzjca1g==
@@ -363,30 +363,19 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.9.0.tgz#745969d649977776b43fc7648c556aaa462b4102"
   integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
 
-"@emotion/react@11.13.3":
-  version "11.13.3"
-  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.13.3.tgz#a69d0de2a23f5b48e0acf210416638010e4bd2e4"
-  integrity sha512-lIsdU6JNrmYfJ5EbUCf4xW1ovy5wKQ2CkPRM4xogziOxH1nXxBSjpC9YqbFAP7circxMfYp+6x676BqWcEiixg==
+"@emotion/react@11.14.0":
+  version "11.14.0"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.14.0.tgz#cfaae35ebc67dd9ef4ea2e9acc6cd29e157dd05d"
+  integrity sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==
   dependencies:
     "@babel/runtime" "^7.18.3"
-    "@emotion/babel-plugin" "^11.12.0"
-    "@emotion/cache" "^11.13.0"
-    "@emotion/serialize" "^1.3.1"
-    "@emotion/use-insertion-effect-with-fallbacks" "^1.1.0"
-    "@emotion/utils" "^1.4.0"
+    "@emotion/babel-plugin" "^11.13.5"
+    "@emotion/cache" "^11.14.0"
+    "@emotion/serialize" "^1.3.3"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.2.0"
+    "@emotion/utils" "^1.4.2"
     "@emotion/weak-memoize" "^0.4.0"
     hoist-non-react-statics "^3.3.1"
-
-"@emotion/serialize@^1.2.0", "@emotion/serialize@^1.3.0", "@emotion/serialize@^1.3.1":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.3.2.tgz#e1c1a2e90708d5d85d81ccaee2dfeb3cc0cccf7a"
-  integrity sha512-grVnMvVPK9yUVE6rkKfAJlYZgo0cu3l9iMC77V7DW6E1DUIrU68pSEXRmFZFOFB1QFo57TncmOcvcbMDWsL4yA==
-  dependencies:
-    "@emotion/hash" "^0.9.2"
-    "@emotion/memoize" "^0.9.0"
-    "@emotion/unitless" "^0.10.0"
-    "@emotion/utils" "^1.4.1"
-    csstype "^3.0.2"
 
 "@emotion/serialize@^1.3.3":
   version "1.3.3"
@@ -404,32 +393,27 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.4.0.tgz#c9299c34d248bc26e82563735f78953d2efca83c"
   integrity sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==
 
-"@emotion/styled@11.13.0":
-  version "11.13.0"
-  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.13.0.tgz#633fd700db701472c7a5dbef54d6f9834e9fb190"
-  integrity sha512-tkzkY7nQhW/zC4hztlwucpT8QEZ6eUzpXDRhww/Eej4tFfO0FxQYWRyg/c5CCXa4d/f174kqeXYjuQRnhzf6dA==
+"@emotion/styled@11.14.0":
+  version "11.14.0"
+  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.14.0.tgz#f47ca7219b1a295186d7661583376fcea95f0ff3"
+  integrity sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==
   dependencies:
     "@babel/runtime" "^7.18.3"
-    "@emotion/babel-plugin" "^11.12.0"
+    "@emotion/babel-plugin" "^11.13.5"
     "@emotion/is-prop-valid" "^1.3.0"
-    "@emotion/serialize" "^1.3.0"
-    "@emotion/use-insertion-effect-with-fallbacks" "^1.1.0"
-    "@emotion/utils" "^1.4.0"
+    "@emotion/serialize" "^1.3.3"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.2.0"
+    "@emotion/utils" "^1.4.2"
 
 "@emotion/unitless@^0.10.0":
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.10.0.tgz#2af2f7c7e5150f497bdabd848ce7b218a27cf745"
   integrity sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==
 
-"@emotion/use-insertion-effect-with-fallbacks@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.1.0.tgz#1a818a0b2c481efba0cf34e5ab1e0cb2dcb9dfaf"
-  integrity sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==
-
-"@emotion/utils@^1.4.0", "@emotion/utils@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.4.1.tgz#b3adbb43de12ee2149541c4f1337d2eb7774f0ad"
-  integrity sha512-BymCXzCG3r72VKJxaYVwOXATqXIZ85cuvg0YOUDxMGNrKc1DJRZk8MgV5wyXRyEayIMd4FuXJIUgTBXvDNW5cA==
+"@emotion/use-insertion-effect-with-fallbacks@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz#8a8cb77b590e09affb960f4ff1e9a89e532738bf"
+  integrity sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==
 
 "@emotion/utils@^1.4.2":
   version "1.4.2"
@@ -926,57 +910,54 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
-"@matrix-widget-toolkit/api@^3.4.2":
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/@matrix-widget-toolkit/api/-/api-3.4.2.tgz#ce42a841c8cb51d8c6a61016e9fdff3703a734b9"
-  integrity sha512-zATxVBtlxsEN1VeIp4NGNpy/SdHPdKXaN+NbVMYG1CU3PryVENngCWjr5038fMpem2ZpLtyjxyUSvPlRKT8kbw==
+"@matrix-widget-toolkit/api@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@matrix-widget-toolkit/api/-/api-4.0.0.tgz#12586b353f52eccc13be9708351c76bcf8bb444c"
+  integrity sha512-A6VaQw5shEWMoM1qKr+400lTpM13qWnwujS/htftEBV93caKHf3zHfgYcLq55miYgVFrPafaTTnNPxSpHGGPIQ==
   dependencies:
-    matrix-widget-api "^1.9.0"
-    qs "^6.13.0"
-    rxjs "^7.8.1"
+    matrix-widget-api "1.10.0"
+    qs "6.13.1"
+    rxjs "7.8.1"
 
-"@matrix-widget-toolkit/mui@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@matrix-widget-toolkit/mui/-/mui-2.1.0.tgz#772bf63b8ae5be1a28c10b9d7c392a47b7118897"
-  integrity sha512-aRtbZbvtOQX6v5u7tSf65NzKmIQWPmwPdeLH8OVKUYx5GkBehrjKyPqRqeFuHsO8Cb11ZkExpEC02/r44+rF1g==
+"@matrix-widget-toolkit/mui@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@matrix-widget-toolkit/mui/-/mui-2.1.1.tgz#12485160d5059ecbd83a3c5ce931ea8784446220"
+  integrity sha512-nk9BQvWc9h/NxDY6b19Vgo12JH9VphgTDupLi8e+Z7ufx5/trkPliYUeLjIyyhNiY30/GxiBpR11ZFW56z1K3A==
   dependencies:
-    "@emotion/cache" "11.13.1"
-    "@emotion/react" "11.13.3"
-    "@emotion/styled" "11.13.0"
+    "@emotion/cache" "11.14.0"
+    "@emotion/react" "11.14.0"
+    "@emotion/styled" "11.14.0"
     "@fontsource/inter" "5.1.0"
-    "@matrix-widget-toolkit/api" "^3.4.2"
-    "@matrix-widget-toolkit/react" "^2.0.3"
-    "@mui/icons-material" "6.1.7"
-    "@mui/material" "6.1.7"
-    "@mui/utils" "6.1.7"
-    i18next "23.16.5"
-    i18next-browser-languagedetector "8.0.0"
+    "@matrix-widget-toolkit/api" "^4.0.0"
+    "@matrix-widget-toolkit/react" "^2.0.4"
+    "@mui/icons-material" "6.1.10"
+    "@mui/material" "6.1.10"
+    "@mui/utils" "6.1.10"
+    i18next "24.0.5"
+    i18next-browser-languagedetector "8.0.2"
     i18next-resources-to-backend "1.2.1"
     matrix-widget-api "1.10.0"
-    react-i18next "15.1.1"
+    react-i18next "15.1.3"
     react-use "17.5.1"
 
-"@matrix-widget-toolkit/react@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@matrix-widget-toolkit/react/-/react-2.0.3.tgz#148cf31c4571e7f5dc0eabf176d7432fde54b577"
-  integrity sha512-YoWurD8To9HyX19EEi026+O3O/nOqyu95qUoKxvPLNv8IINrStdGrp6yBHqiQ4jKh7oKgdAXO4AsqZwauAaLaw==
+"@matrix-widget-toolkit/react@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@matrix-widget-toolkit/react/-/react-2.0.4.tgz#98d4c71e20242c61ab1f677b6d1df5d40e315e20"
+  integrity sha512-CFwY/nF5l3uAYTdLFtpbbCCqO/eGexKAxVUG8ERJ3w0xOZ301eJflrwYpOrBLJXWR3EzxE3u5IH9PNqHPDNqSA==
   dependencies:
-    "@matrix-widget-toolkit/api" "^3.4.2"
-    matrix-widget-api "^1.9.0"
-    react "^18.2.0"
-    react-error-boundary "^3.1.4"
-    react-use "^17.5.1"
+    "@matrix-widget-toolkit/api" "^4.0.0"
+    matrix-widget-api "1.10.0"
+    react-error-boundary "4.1.2"
+    react-use "17.5.1"
 
-"@matrix-widget-toolkit/testing@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@matrix-widget-toolkit/testing/-/testing-3.0.1.tgz#b0eaad61470b304a79f4ed6a44eebf517eb33ea9"
-  integrity sha512-DTTouK2mZd6lWO4vJNNdkP2WYhVTXuAvTYF+0WayzffFrHHQHdm2mIoFUrBXY+0786X5ERbtYTOdb5Hy3x54lw==
+"@matrix-widget-toolkit/testing@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@matrix-widget-toolkit/testing/-/testing-3.0.3.tgz#a84a0b55ba3e495b2db2f36ed55331ecabe389ed"
+  integrity sha512-jc3uFw3qCL/zwICctCeOwbH9R5NhN6oCTvLq6wXK87pz1Gq+cL1b7qeHuzkihGBuLpSWvqX7iA0HcNVPlUs7qw==
   dependencies:
-    "@matrix-widget-toolkit/api" "^3.4.2"
-    lodash-es "^4.17.21"
-    matrix-widget-api "^1.9.0"
-    rxjs "^7.8.1"
-    vitest "^2.1.3"
+    "@matrix-widget-toolkit/api" "^4.0.0"
+    matrix-widget-api "1.10.0"
+    rxjs "7.8.1"
 
 "@mui/base@5.0.0-beta.64", "@mui/base@^5.0.0-beta.64":
   version "5.0.0-beta.64"
@@ -991,12 +972,24 @@
     clsx "^2.1.1"
     prop-types "^15.8.1"
 
+"@mui/core-downloads-tracker@^6.1.10":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-6.2.0.tgz#52953b858eaf3204ac505bf0329528fd3130c775"
+  integrity sha512-Nn5PSkUqbDrvezpiiiYZiAbX4SFEiy3CbikUL6pWOXEUsq+L1j50OOyyUIHpaX2Hr+5V5UxTh+fPeC4nsGNhdw==
+
 "@mui/core-downloads-tracker@^6.1.7":
   version "6.1.10"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-6.1.10.tgz#871b5a4876cfd0beac6672fe50d57e0c0a53db36"
   integrity sha512-LY5wdiLCBDY7u+Od8UmFINZFGN/5ZU90fhAslf/ZtfP+5RhuY45f679pqYIxe0y54l6Gkv9PFOc8Cs10LDTBYg==
 
-"@mui/icons-material@6.1.7", "@mui/icons-material@^6.1.2":
+"@mui/icons-material@6.1.10":
+  version "6.1.10"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-6.1.10.tgz#9ed27fc750ab4811da94c1a1252253d9d1e86cc2"
+  integrity sha512-G6P1BCSt6EQDcKca47KwvKjlqgOXFbp2I3oWiOlFgKYTANBH89yk7ttMQ5ysqNxSYAB+4TdM37MlPYp4+FkVrQ==
+  dependencies:
+    "@babel/runtime" "^7.26.0"
+
+"@mui/icons-material@^6.1.2":
   version "6.1.7"
   resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-6.1.7.tgz#79c0fa7087acbcba2fe81f89d9dda15cb65c6742"
   integrity sha512-RGzkeHNArIVy5ZQ12bq/8VYNeICEyngngsFskTJ/2hYKhIeIII3iRGtaZaSvLpXh7h3Fg3VKTulT+QU0w5K4XQ==
@@ -1016,7 +1009,25 @@
     clsx "^2.1.1"
     prop-types "^15.8.1"
 
-"@mui/material@6.1.7", "@mui/material@^6.1.2":
+"@mui/material@6.1.10":
+  version "6.1.10"
+  resolved "https://registry.yarnpkg.com/@mui/material/-/material-6.1.10.tgz#eab2a9df24c68548d0df2b5b25c0410311313ff9"
+  integrity sha512-txnwYObY4N9ugv5T2n5h1KcbISegZ6l65w1/7tpSU5OB6MQCU94YkP8n/3slDw2KcEfRk4+4D8EUGfhSPMODEQ==
+  dependencies:
+    "@babel/runtime" "^7.26.0"
+    "@mui/core-downloads-tracker" "^6.1.10"
+    "@mui/system" "^6.1.10"
+    "@mui/types" "^7.2.19"
+    "@mui/utils" "^6.1.10"
+    "@popperjs/core" "^2.11.8"
+    "@types/react-transition-group" "^4.4.11"
+    clsx "^2.1.1"
+    csstype "^3.1.3"
+    prop-types "^15.8.1"
+    react-is "^18.3.1"
+    react-transition-group "^4.4.5"
+
+"@mui/material@^6.1.2":
   version "6.1.7"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-6.1.7.tgz#a30dcfdae6e3cbb184669813d6b3a8addd4540ee"
   integrity sha512-KsjujQL/A2hLd1PV3QboF+W6SSL5QqH6ZlSuQoeYz9r69+TnyBFIevbYLxdjJcJmGBjigL5pfpn7hTGop+vhSg==
@@ -1074,19 +1085,7 @@
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.19.tgz#c941954dd24393fdce5f07830d44440cf4ab6c80"
   integrity sha512-6XpZEM/Q3epK9RN8ENoXuygnqUQxE+siN/6rGRi2iwJPgBUR25mphYQ9ZI87plGh58YoZ5pp40bFvKYOCDJ3tA==
 
-"@mui/utils@6.1.7":
-  version "6.1.7"
-  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-6.1.7.tgz#0959d9772ae13c6ceac984a493e06aebb9087e71"
-  integrity sha512-Gr7cRZxBoZ0BIa3Xqf/2YaUrBLyNPJvXPQH3OsD9WMZukI/TutibbQBVqLYpgqJn8pKSjbD50Yq2auG0wI1xOw==
-  dependencies:
-    "@babel/runtime" "^7.26.0"
-    "@mui/types" "^7.2.19"
-    "@types/prop-types" "^15.7.13"
-    clsx "^2.1.1"
-    prop-types "^15.8.1"
-    react-is "^18.3.1"
-
-"@mui/utils@^6.0.2", "@mui/utils@^6.1.10", "@mui/utils@^6.1.7":
+"@mui/utils@6.1.10", "@mui/utils@^6.0.2", "@mui/utils@^6.1.10", "@mui/utils@^6.1.7":
   version "6.1.10"
   resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-6.1.10.tgz#edf8c5c9cf930a8290b5347550ece15f5800b1c3"
   integrity sha512-1ETuwswGjUiAf2dP9TkBy8p49qrw2wXa+RuAjNTRE5+91vtXJ1HKrs7H9s8CZd1zDlQVzUcUAPm9lpQwF5ogTw==
@@ -3906,7 +3905,14 @@ hyphenate-style-name@^1.0.3:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz#1797bf50369588b47b72ca6d5e65374607cf4436"
   integrity sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==
 
-i18next-browser-languagedetector@8.0.0, i18next-browser-languagedetector@^8.0.0:
+i18next-browser-languagedetector@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.0.2.tgz#037ca25c26877cad778f060a9e177054d9f8eaa3"
+  integrity sha512-shBvPmnIyZeD2VU5jVGIOWP7u9qNG3Lj7mpaiPFpbJ3LVfHZJvVzKR4v1Cb91wAOFpNw442N+LGPzHOHsten2g==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
+
+i18next-browser-languagedetector@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.0.0.tgz#b6fdd9b43af67c47f2c26c9ba27710a1eaf31e2f"
   integrity sha512-zhXdJXTTCoG39QsrOCiOabnWj2jecouOqbchu3EfhtSHxIB5Uugnm9JaizenOy39h7ne3+fLikIjeW88+rgszw==
@@ -3957,7 +3963,14 @@ i18next-resources-to-backend@1.2.1, i18next-resources-to-backend@^1.2.1:
   dependencies:
     "@babel/runtime" "^7.23.2"
 
-i18next@23.16.5, i18next@^23.15.2, i18next@^23.5.1:
+i18next@24.0.5:
+  version "24.0.5"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-24.0.5.tgz#2678986eca46411cae0329542a84dd4cd7e5f2f0"
+  integrity sha512-1jSdEzgFPGLZRsQwydoMFCBBaV+PmrVEO5WhANllZPX4y2JSGTxUjJ+xVklHIsiS95uR8gYc/y0hYZWevucNjg==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
+
+i18next@^23.15.2, i18next@^23.5.1:
   version "23.16.5"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-23.16.5.tgz#53d48ae9f985fd73fc1fcb96e6c7d90ababf0831"
   integrity sha512-KTlhE3EP9x6pPTAW7dy0WKIhoCpfOGhRQlO+jttQLgzVaoOjWwBWramu7Pp0i+8wDNduuzXfe3kkVbzrKyrbTA==
@@ -4593,11 +4606,6 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
-
-lodash-es@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -5354,10 +5362,10 @@ punycode@^2.1.0, punycode@^2.3.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-qs@^6.13.0:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.13.0.tgz#6ca3bd58439f7e245655798997787b0d88a51906"
-  integrity sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==
+qs@6.13.1:
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.13.1.tgz#3ce5fc72bd3a8171b85c99b93c65dd20b7d1b16e"
+  integrity sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==
   dependencies:
     side-channel "^1.0.6"
 
@@ -5423,10 +5431,10 @@ react-dropzone@^14.2.9:
     file-selector "^0.6.0"
     prop-types "^15.8.1"
 
-react-error-boundary@^3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
-  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+react-error-boundary@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.1.2.tgz#bc750ad962edb8b135d6ae922c046051eb58f289"
+  integrity sha512-GQDxZ5Jd+Aq/qUxbCm1UtzmL/s++V7zKgE8yMktJiCQXCCFZnMZh9ng+6/Ne6PjNSXH0L9CjeOEREfRnq6Duag==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
@@ -5446,10 +5454,18 @@ react-hotkeys-hook@^4.5.0:
   resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-4.5.1.tgz#990260ecc7e5a431414148a93b02a2f1a9707897"
   integrity sha512-scAEJOh3Irm0g95NIn6+tQVf/OICCjsQsC9NBHfQws/Vxw4sfq1tDQut5fhTEvPraXhu/sHxRd9lOtxzyYuNAg==
 
-react-i18next@*, react-i18next@15.1.1, react-i18next@^15.0.1:
+react-i18next@*, react-i18next@^15.0.1:
   version "15.1.1"
   resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-15.1.1.tgz#30bc76b39ded6ee37f1457677e46e6d6f11d9f64"
   integrity sha512-R/Vg9wIli2P3FfeI8o1eNJUJue5LWpFsQePCHdQDmX0Co3zkr6kdT8gAseb/yGeWbNz1Txc4bKDQuZYsC0kQfw==
+  dependencies:
+    "@babel/runtime" "^7.25.0"
+    html-parse-stringify "^3.0.1"
+
+react-i18next@15.1.3:
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-15.1.3.tgz#172c3905038ea4f90699a19949a0084b5641c94f"
+  integrity sha512-J11oA30FbM3NZegUZjn8ySK903z6PLBz/ZuBYyT1JMR0QPrW6PFXvl1WoUhortdGi9dM0m48/zJQlPskVZXgVw==
   dependencies:
     "@babel/runtime" "^7.25.0"
     html-parse-stringify "^3.0.1"
@@ -5546,7 +5562,7 @@ react-use@17.5.1, react-use@^17.5.1:
     ts-easing "^0.2.0"
     tslib "^2.1.0"
 
-react@^18.2.0, react@^18.3.1:
+react@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
@@ -5820,7 +5836,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^7.8.1:
+rxjs@7.8.1, rxjs@^7.8.1:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
   integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
@@ -6755,7 +6771,7 @@ vitest-fetch-mock@^0.4.1:
   resolved "https://registry.yarnpkg.com/vitest-fetch-mock/-/vitest-fetch-mock-0.4.1.tgz#2a865f0685e168c7c425616d0b2708d2b3050fc4"
   integrity sha512-Y6VEV2AgJps1t9NUdhID/vUwarAuhOkPHShfoEruIlQr5+O31hgJ4YmZpU8kVWD3KQjEyZqPeMibWehd7rMq+A==
 
-vitest@^2.1.3, vitest@^2.1.4:
+vitest@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/vitest/-/vitest-2.1.4.tgz#ba8f4589fb639cf5a9e6af54781667312b3e8230"
   integrity sha512-eDjxbVAJw1UJJCHr5xr/xM86Zx+YxIEXGAR+bmnEID7z9qWfoxpHw0zdobz+TQAFOLT+nEXz3+gx6nUJ7RgmlQ==


### PR DESCRIPTION
Before WidgetApi.sendStateEvent returned the entire event. This is no longer the case.

Needs to go together with https://github.com/nordeck/matrix-widget-toolkit/pull/870

Not sure if this needs a changeset. In theory it does not change anything.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
