### PR TITLE
Set Vite base path to ""

### DIFF
--- a/matrix-neoboard-widget/vite.config.ts
+++ b/matrix-neoboard-widget/vite.config.ts
@@ -28,6 +28,8 @@ if (process.env.VITE_DEV_SSL === 'true') {
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  // overriding the default '/' base allows for sub-path deployments
+  base: '',
   esbuild: {
     // needed to fix neoboard yjs errors, see: https://github.com/vitejs/vite/issues/11722
     target: 'es2020',


### PR DESCRIPTION
The default is "/". Because of that it didn't work in sub-paths.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
