### PR TITLE
Limit text height in PDF export

### DIFF
--- a/.changeset/khaki-drinks-itch.md
+++ b/.changeset/khaki-drinks-itch.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+On PDF export texts do no longer overflow shapes. Lines, that would be cut off are not printed at all.

--- a/packages/react-sdk/src/components/BoardBar/pdf/__snapshots__/createWhiteboardPdfDefinition.test.ts.snap
+++ b/packages/react-sdk/src/components/BoardBar/pdf/__snapshots__/createWhiteboardPdfDefinition.test.ts.snap
@@ -45,6 +45,7 @@ exports[`createWhiteboardPdfDefinition > should generate a pdf header and table 
                       "fontSize": 10,
                       "lineHeight": 1,
                       "margin": 0,
+                      "maxHeight": 100,
                       "text": [
                         "Rectangle",
                       ],
@@ -99,6 +100,7 @@ exports[`createWhiteboardPdfDefinition > should generate a pdf header and table 
                       "fontSize": 10,
                       "lineHeight": 1,
                       "margin": 0,
+                      "maxHeight": 100,
                       "text": [
                         "Rectangle Text",
                       ],
@@ -151,6 +153,7 @@ exports[`createWhiteboardPdfDefinition > should generate a pdf header and table 
                       "fontSize": 10,
                       "lineHeight": 1,
                       "margin": 0,
+                      "maxHeight": 100,
                       "text": [
                         "Circle ",
                         {
@@ -207,6 +210,7 @@ exports[`createWhiteboardPdfDefinition > should generate a pdf header and table 
                       "fontSize": 10,
                       "lineHeight": 1,
                       "margin": 0,
+                      "maxHeight": 100,
                       "text": [
                         "Ellipse",
                       ],
@@ -270,6 +274,7 @@ exports[`createWhiteboardPdfDefinition > should generate a pdf header and table 
                       "fontSize": 10,
                       "lineHeight": 1,
                       "margin": 0,
+                      "maxHeight": 100,
                       "text": [
                         "Triangle ",
                         {

--- a/packages/react-sdk/src/components/BoardBar/pdf/utils.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/utils.ts
@@ -160,6 +160,13 @@ export function textContent(
     lineHeight: 1,
     margin: 0,
     font: 'Inter',
+    // Set maxHeight to prevent text overflows.
+    // This is not optimal, because it does not clip the text.
+    // Instead it does not draw lines, that would not fit into the shape.
+    // Uses element.height and not textProperties.height + padding to avoid being too strict and
+    // cut things off, that should actually be there.
+    // @ts-expect-error This does exist but is not yet part of @types/pdfmake
+    maxHeight: element.height,
   };
 
   return {


### PR DESCRIPTION
This is not an optimal solution, but the best we can do with pdfmake. If we want to cut off text we need to change pdfmake. For that we need a new ticket with a higher estimation.

With the max height property lines that would not fit into a shape are not printed at all.

| This PR |
| --- |
| ![image](https://github.com/user-attachments/assets/c973f358-d3cd-4bcc-b8b2-91af5eeb8edc) |
| Before |
|  ![image](https://github.com/user-attachments/assets/f14f48fa-8cf8-447c-9bed-7b309b85a6b9) | 

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
