### PR TITLE
Run standalone build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,76 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
+  build-standalone:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: matrix-neoboard
+          # required for changesets
+          fetch-depth: '0'
+          # don't persist the credentials so the changesets action doesn't use the
+          # github actions token but the git token provided via environment variable
+          persist-credentials: false
+
+      - uses: actions/checkout@v4
+        with:
+          repository: nordeck/matrix-neoboard-standalone
+          path: matrix-neoboard-standalone
+          # required for changesets
+          fetch-depth: '0'
+          # don't persist the credentials so the changesets action doesn't use the
+          # github actions token but the git token provided via environment variable
+          persist-credentials: false
+          ssh-key: ${{ secrets.STANDALONE_DEPLOY_KEY }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'matrix-neoboard-standalone/package.json'
+          cache: 'yarn'
+          cache-dependency-path: |
+            matrix-neoboard-standalone/yarn.lock
+            matrix-neoboard/yarn.lock
+
+      - name: yarn install neoboard
+        working-directory: ./matrix-neoboard/
+        run: yarn install --frozen-lockfile
+
+      - name: yarn install neoboard standalone
+        working-directory: ./matrix-neoboard-standalone/
+        run: yarn install --frozen-lockfile
+
+      - name: depcheck
+        working-directory: ./matrix-neoboard-standalone/
+        run: yarn depcheck
+
+      - name: prettier:check
+        working-directory: ./matrix-neoboard-standalone/
+        run: yarn prettier:check
+
+      - name: Check Linting Rules
+        working-directory: ./matrix-neoboard-standalone/
+        run: yarn lint
+
+      - name: type checking and declarations
+        working-directory: ./matrix-neoboard-standalone/
+        run: yarn tsc
+
+      - name: Check Translations
+        working-directory: ./matrix-neoboard-standalone/
+        run: yarn translate --fail-on-update
+
+      - name: test
+        working-directory: ./matrix-neoboard-standalone/
+        run: yarn run test:all
+
+      - name: build
+        working-directory: ./matrix-neoboard-standalone/
+        run: yarn build && yarn version:info
+
   deploy-pages:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     name: Deploy to GitHub Pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         working-directory: ./matrix-neoboard-standalone/
         run: yarn tsc
 
-      - name: Check Translations
+      - name: Check translations
         working-directory: ./matrix-neoboard-standalone/
         run: yarn translate --fail-on-update
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           persist-credentials: false
           ssh-key: ${{ secrets.STANDALONE_DEPLOY_KEY }}
 
-      - name: Setup Node.js
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: 'matrix-neoboard-standalone/package.json'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
         working-directory: ./matrix-neoboard-standalone/
         run: yarn prettier:check
 
-      - name: Check Linting Rules
+      - name: Check linting rules
         working-directory: ./matrix-neoboard-standalone/
         run: yarn lint
 


### PR DESCRIPTION
We want to do this to detect if changes break NeoBoard standalone.

Copy & pasted parts of the NeoBoard Standalone CI. We cannot re-use the workflow because it is in a private repo. This is the low-tech solution, but it works.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
