### PR TITLE
Only show text formatting toolbar buttons when shapes have text

### DIFF
--- a/.changeset/rotten-cobras-whisper.md
+++ b/.changeset/rotten-cobras-whisper.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+Only show text tools when applicable

--- a/packages/react-sdk/src/components/ElementBar/ColorPickerButton/TextColorPicker.tsx
+++ b/packages/react-sdk/src/components/ElementBar/ColorPickerButton/TextColorPicker.tsx
@@ -51,6 +51,10 @@ export function TextColorPicker() {
   const defaultShade = hasTextShape ? activeShapeTextShade : activeTextShade;
 
   let color = extractFirstTextColor(activeElements);
+
+  // Gets a default color when there is no text, based on the fill color of the first
+  // selected element. This is required for when the text formatting tools are shown
+  // if you start typing new text into a shape
   if (color == undefined) {
     const element = activeElements[0];
     if (element && 'fillColor' in element) {

--- a/packages/react-sdk/src/components/ElementBar/ColorPickerButton/TextColorPicker.tsx
+++ b/packages/react-sdk/src/components/ElementBar/ColorPickerButton/TextColorPicker.tsx
@@ -17,9 +17,11 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { findColor, useColorPalette } from '../../../lib';
+import { isEmptyText } from '../../../lib/text-formatting';
 import {
   includesShapeWithText,
   includesTextShape,
+  ShapeElement,
   useActiveElements,
   useElements,
 } from '../../../state';
@@ -44,6 +46,7 @@ export function TextColorPicker() {
   const { activeElementIds } = useActiveElements();
   const activeElementsObject = useElements(activeElementIds);
   const activeElements = Object.values(activeElementsObject);
+  const elements = Object.values(activeElements);
 
   const hasText = includesTextShape(activeElements);
   const hasTextShape = includesShapeWithText(activeElements);
@@ -85,6 +88,12 @@ export function TextColorPicker() {
       setActiveShapeTextShade,
     ],
   );
+
+  if (
+    elements.every((element) => isEmptyText((element as ShapeElement).text))
+  ) {
+    return null;
+  }
 
   return (
     <ColorPicker

--- a/packages/react-sdk/src/components/ElementBar/ColorPickerButton/TextColorPicker.tsx
+++ b/packages/react-sdk/src/components/ElementBar/ColorPickerButton/TextColorPicker.tsx
@@ -16,12 +16,10 @@
 
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { findColor, useColorPalette } from '../../../lib';
-import { isEmptyText } from '../../../lib/text-formatting';
+import { findColor, findForegroundColor, useColorPalette } from '../../../lib';
 import {
   includesShapeWithText,
   includesTextShape,
-  ShapeElement,
   useActiveElements,
   useElements,
 } from '../../../state';
@@ -46,14 +44,20 @@ export function TextColorPicker() {
   const { activeElementIds } = useActiveElements();
   const activeElementsObject = useElements(activeElementIds);
   const activeElements = Object.values(activeElementsObject);
-  const elements = Object.values(activeElements);
 
   const hasText = includesTextShape(activeElements);
   const hasTextShape = includesShapeWithText(activeElements);
 
   const defaultShade = hasTextShape ? activeShapeTextShade : activeTextShade;
 
-  const color = extractFirstTextColor(activeElements);
+  let color = extractFirstTextColor(activeElements);
+  if (color == undefined) {
+    const element = activeElements[0];
+    if (element && 'fillColor' in element) {
+      color = findForegroundColor(element.fillColor);
+    }
+  }
+
   const paletteColor =
     color !== undefined ? findColor(color, colorPalette) : undefined;
   const shade =
@@ -88,12 +92,6 @@ export function TextColorPicker() {
       setActiveShapeTextShade,
     ],
   );
-
-  if (
-    elements.every((element) => isEmptyText((element as ShapeElement).text))
-  ) {
-    return null;
-  }
 
   return (
     <ColorPicker

--- a/packages/react-sdk/src/components/ElementBar/ColorPickerButton/extractFirstTextColor.ts
+++ b/packages/react-sdk/src/components/ElementBar/ColorPickerButton/extractFirstTextColor.ts
@@ -15,7 +15,6 @@
  */
 
 import { findForegroundColor } from '../../../lib';
-import { isEmptyText } from '../../../lib/text-formatting';
 import { Element } from '../../../state';
 
 /**
@@ -28,7 +27,7 @@ import { Element } from '../../../state';
  */
 export function extractFirstTextColor(elements: Element[]): string | undefined {
   for (const element of elements) {
-    if ('text' in element && !isEmptyText(element.text)) {
+    if ('text' in element && element.text.length > 0) {
       return (
         // The element has an explicit color set, return it
         element.textColor ??

--- a/packages/react-sdk/src/components/ElementBar/ColorPickerButton/extractFirstTextColor.ts
+++ b/packages/react-sdk/src/components/ElementBar/ColorPickerButton/extractFirstTextColor.ts
@@ -15,6 +15,7 @@
  */
 
 import { findForegroundColor } from '../../../lib';
+import { isEmptyText } from '../../../lib/text-formatting';
 import { Element } from '../../../state';
 
 /**
@@ -27,7 +28,7 @@ import { Element } from '../../../state';
  */
 export function extractFirstTextColor(elements: Element[]): string | undefined {
   for (const element of elements) {
-    if ('text' in element && element.text.length > 0) {
+    if ('text' in element && !isEmptyText(element.text)) {
       return (
         // The element has an explicit color set, return it
         element.textColor ??

--- a/packages/react-sdk/src/components/ElementBar/ElementBar.test.tsx
+++ b/packages/react-sdk/src/components/ElementBar/ElementBar.test.tsx
@@ -90,6 +90,18 @@ describe('<ElementBar/>', () => {
     ).toBeInTheDocument();
 
     expect(
+      within(toolbar).getByRole('checkbox', {
+        name: 'Bold',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      within(toolbar).getByRole('checkbox', {
+        name: 'Italic',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
       within(toolbar).getByRole('button', {
         name: 'Pick a text color',
       }),
@@ -106,6 +118,59 @@ describe('<ElementBar/>', () => {
         name: 'Text Alignment',
       }),
     ).toBeInTheDocument();
+
+    expect(
+      within(toolbar).getByRole('button', {
+        name: 'Duplicate the active element',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      within(toolbar).getByRole('button', { name: 'Delete element' }),
+    ).toBeInTheDocument();
+  });
+
+  it('should not render text tools when not required', () => {
+    activeSlide.setActiveElementIds(['element-2']);
+    render(<ElementBar showTextTools={false} />, { wrapper: Wrapper });
+
+    const toolbar = screen.getByRole('toolbar', { name: 'Element' });
+
+    expect(
+      within(toolbar).queryByRole('combobox', {
+        name: 'Select font size',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      within(toolbar).queryByRole('checkbox', {
+        name: 'Bold',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      within(toolbar).queryByRole('checkbox', {
+        name: 'Italic',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      within(toolbar).queryByRole('button', {
+        name: 'Pick a text color',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      within(toolbar).getByRole('button', {
+        name: 'Pick a color',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      within(toolbar).queryByRole('radiogroup', {
+        name: 'Text Alignment',
+      }),
+    ).not.toBeInTheDocument();
 
     expect(
       within(toolbar).getByRole('button', {

--- a/packages/react-sdk/src/components/ElementBar/ElementBar.tsx
+++ b/packages/react-sdk/src/components/ElementBar/ElementBar.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Toolbar } from '../common/Toolbar';
 import { ElementColorPicker } from './ColorPickerButton/ElementColorPicker';
@@ -25,18 +26,24 @@ import { TextAlignmentButtons } from './TextAlignmentButtons';
 import { TextBoldButton } from './TextBoldButton';
 import { TextItalicButton } from './TextItalicButton';
 
-export function ElementBar() {
+export function ElementBar({
+  showTextTools = true,
+}: PropsWithChildren<{ showTextTools?: boolean }>) {
   const { t } = useTranslation('neoboard');
   const toolbarTitle = t('elementBar.title', 'Element');
 
   return (
     <Toolbar aria-label={toolbarTitle}>
-      <FontSizeButton />
-      <TextBoldButton />
-      <TextItalicButton />
-      <TextColorPicker />
+      {showTextTools && (
+        <>
+          <FontSizeButton />
+          <TextBoldButton />
+          <TextItalicButton />
+          <TextColorPicker />
+          <TextAlignmentButtons />
+        </>
+      )}
       <ElementColorPicker />
-      <TextAlignmentButtons />
       <DuplicateActiveElementButton />
       <DeleteActiveElementButton />
     </Toolbar>

--- a/packages/react-sdk/src/components/ElementBar/ElementBar.tsx
+++ b/packages/react-sdk/src/components/ElementBar/ElementBar.tsx
@@ -39,8 +39,8 @@ export function ElementBar({
           <FontSizeButton />
           <TextBoldButton />
           <TextItalicButton />
-          <TextColorPicker />
           <TextAlignmentButtons />
+          <TextColorPicker />
         </>
       )}
       <ElementColorPicker />

--- a/packages/react-sdk/src/components/ElementBar/FontSizeButton/FontSizeButton.tsx
+++ b/packages/react-sdk/src/components/ElementBar/FontSizeButton/FontSizeButton.tsx
@@ -16,8 +16,8 @@
 
 import { MenuItem, Select } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { useFontSize } from '../../../lib/text-formatting';
-import { useActiveElements, useElements } from '../../../state';
+import { isEmptyText, useFontSize } from '../../../lib/text-formatting';
+import { ShapeElement, useActiveElements, useElements } from '../../../state';
 
 const FONT_SIZES = [8, 16, 24, 32, 48, 64, 96, 128, 160, 192];
 
@@ -30,6 +30,12 @@ export function FontSizeButton() {
   const elements = Object.values(activeElements);
 
   if (elements.every((element) => element.type !== 'shape')) {
+    return null;
+  }
+
+  if (
+    elements.every((element) => isEmptyText((element as ShapeElement).text))
+  ) {
     return null;
   }
 

--- a/packages/react-sdk/src/components/ElementBar/FontSizeButton/FontSizeButton.tsx
+++ b/packages/react-sdk/src/components/ElementBar/FontSizeButton/FontSizeButton.tsx
@@ -16,8 +16,8 @@
 
 import { MenuItem, Select } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { isEmptyText, useFontSize } from '../../../lib/text-formatting';
-import { ShapeElement, useActiveElements, useElements } from '../../../state';
+import { useFontSize } from '../../../lib/text-formatting';
+import { useActiveElements, useElements } from '../../../state';
 
 const FONT_SIZES = [8, 16, 24, 32, 48, 64, 96, 128, 160, 192];
 
@@ -30,12 +30,6 @@ export function FontSizeButton() {
   const elements = Object.values(activeElements);
 
   if (elements.every((element) => element.type !== 'shape')) {
-    return null;
-  }
-
-  if (
-    elements.every((element) => isEmptyText((element as ShapeElement).text))
-  ) {
     return null;
   }
 

--- a/packages/react-sdk/src/components/ElementBar/TextAlignmentButtons/TextAlignmentButtons.test.tsx
+++ b/packages/react-sdk/src/components/ElementBar/TextAlignmentButtons/TextAlignmentButtons.test.tsx
@@ -24,6 +24,7 @@ import {
   WhiteboardTestingContextProvider,
   mockEllipseElement,
   mockLineElement,
+  mockRectangleElement,
   mockWhiteboardManager,
 } from '../../../lib/testUtils/documentTestUtils';
 import { WhiteboardSlideInstance } from '../../../state';
@@ -48,9 +49,15 @@ describe('<TextAlignmentButtons/>', () => {
         [
           'slide-0',
           [
-            ['element-0', mockEllipseElement({ textAlignment: 'left' })],
+            [
+              'element-0',
+              mockEllipseElement({ text: 'Hello', textAlignment: 'left' }),
+            ],
             ['element-1', mockLineElement()],
-            ['element-2', mockEllipseElement({ textAlignment: 'right' })],
+            [
+              'element-2',
+              mockRectangleElement({ text: 'Goodbye', textAlignment: 'right' }),
+            ],
           ],
         ],
       ],

--- a/packages/react-sdk/src/components/ElementBar/TextAlignmentButtons/TextAlignmentButtons.test.tsx
+++ b/packages/react-sdk/src/components/ElementBar/TextAlignmentButtons/TextAlignmentButtons.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { MockedWidgetApi, mockWidgetApi } from '@matrix-widget-toolkit/testing';
-import { act, render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axe from 'axe-core';
 import { ComponentType, PropsWithChildren } from 'react';
@@ -113,22 +113,6 @@ describe('<TextAlignmentButtons/>', () => {
     expect(screen.getByRole('radio', { name: 'Left' })).toBeChecked();
     expect(screen.getByRole('radio', { name: 'Center' })).not.toBeChecked();
     expect(screen.getByRole('radio', { name: 'Right' })).not.toBeChecked();
-  });
-
-  it('should hide for non-shape elements', async () => {
-    render(<TextAlignmentButtons />, { wrapper: Wrapper });
-
-    const radioGroup = screen.getByRole('radiogroup', {
-      name: 'Text Alignment',
-    });
-
-    act(() => {
-      slide.setActiveElementId('element-1');
-    });
-
-    await waitFor(() => {
-      expect(radioGroup).not.toBeInTheDocument();
-    });
   });
 
   it('should switch the text alignment for one element', async () => {

--- a/packages/react-sdk/src/components/ElementBar/TextAlignmentButtons/TextAlignmentButtons.tsx
+++ b/packages/react-sdk/src/components/ElementBar/TextAlignmentButtons/TextAlignmentButtons.tsx
@@ -19,7 +19,6 @@ import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
 import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { isEmptyText } from '../../../lib/text-formatting';
 import {
   TextAlignment,
   useActiveElements,
@@ -47,24 +46,6 @@ export function TextAlignmentButtons() {
   );
 
   const elementsArray = Object.values(elements);
-
-  const onlyNonShapes = elementsArray.every(function (element) {
-    return element.type !== 'shape';
-  });
-
-  if (
-    elementsArray.every(
-      (element) => element.type === 'shape' && isEmptyText(element.text),
-    )
-  ) {
-    return null;
-  }
-
-  if (onlyNonShapes) {
-    // There is no text alignment tool for only non-shapes
-    return null;
-  }
-
   let textAlignment: TextAlignment = 'center';
 
   for (const element of elementsArray) {

--- a/packages/react-sdk/src/components/ElementBar/TextAlignmentButtons/TextAlignmentButtons.tsx
+++ b/packages/react-sdk/src/components/ElementBar/TextAlignmentButtons/TextAlignmentButtons.tsx
@@ -19,6 +19,7 @@ import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
 import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { isEmptyText } from '../../../lib/text-formatting';
 import {
   TextAlignment,
   useActiveElements,
@@ -50,6 +51,14 @@ export function TextAlignmentButtons() {
   const onlyNonShapes = elementsArray.every(function (element) {
     return element.type !== 'shape';
   });
+
+  if (
+    elementsArray.every(
+      (element) => element.type === 'shape' && isEmptyText(element.text),
+    )
+  ) {
+    return null;
+  }
 
   if (onlyNonShapes) {
     // There is no text alignment tool for only non-shapes

--- a/packages/react-sdk/src/components/ElementBar/TextBoldButton/TextBoldButton.test.tsx
+++ b/packages/react-sdk/src/components/ElementBar/TextBoldButton/TextBoldButton.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { MockedWidgetApi, mockWidgetApi } from '@matrix-widget-toolkit/testing';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axe from 'axe-core';
 import { ComponentType, PropsWithChildren } from 'react';
@@ -91,20 +91,6 @@ describe('<TextBoldButton />', () => {
   it('should reflect the bold text state of the first element', () => {
     render(<TextBoldButton />, { wrapper: Wrapper });
     expect(screen.getByRole('checkbox', { name: 'Bold' })).not.toBeChecked();
-  });
-
-  it('should hide for non-shape elements', async () => {
-    render(<TextBoldButton />, { wrapper: Wrapper });
-
-    const checkbox = screen.getByRole('checkbox', { name: 'Bold' });
-
-    act(() => {
-      slide.setActiveElementId('line');
-    });
-
-    await waitFor(() => {
-      expect(checkbox).not.toBeInTheDocument();
-    });
   });
 
   // Only test one toggle case here.

--- a/packages/react-sdk/src/components/ElementBar/TextBoldButton/TextBoldButton.test.tsx
+++ b/packages/react-sdk/src/components/ElementBar/TextBoldButton/TextBoldButton.test.tsx
@@ -50,9 +50,15 @@ describe('<TextBoldButton />', () => {
         [
           'slide',
           [
-            ['rectangle', mockRectangleElement({ textBold: false })],
-            ['circle', mockCircleElement({ textBold: true })],
-            ['triangle', mockTriangleElement({ textBold: false })],
+            [
+              'rectangle',
+              mockRectangleElement({ text: 'Hello', textBold: false }),
+            ],
+            ['circle', mockCircleElement({ text: 'Hello', textBold: true })],
+            [
+              'triangle',
+              mockTriangleElement({ text: 'Hello', textBold: false }),
+            ],
             ['line', mockLineElement()],
           ],
         ],

--- a/packages/react-sdk/src/components/ElementBar/TextBoldButton/TextBoldButton.tsx
+++ b/packages/react-sdk/src/components/ElementBar/TextBoldButton/TextBoldButton.tsx
@@ -16,27 +16,12 @@
 
 import FormatBoldIcon from '@mui/icons-material/FormatBold';
 import { useTranslation } from 'react-i18next';
-import { isEmptyText, useToggleBold } from '../../../lib/text-formatting';
-import { ShapeElement, useActiveElements, useElements } from '../../../state';
+import { useToggleBold } from '../../../lib/text-formatting';
 import { ToolbarToggle } from '../../common/Toolbar';
 
 export function TextBoldButton() {
   const { t } = useTranslation('neoboard');
   const { isBold, toggleBold } = useToggleBold();
-
-  const { activeElementIds } = useActiveElements();
-  const activeElements = useElements(activeElementIds);
-  const elements = Object.values(activeElements);
-
-  if (elements.every((element) => element.type !== 'shape')) {
-    return null;
-  }
-
-  if (
-    elements.every((element) => isEmptyText((element as ShapeElement).text))
-  ) {
-    return null;
-  }
 
   return (
     <ToolbarToggle

--- a/packages/react-sdk/src/components/ElementBar/TextBoldButton/TextBoldButton.tsx
+++ b/packages/react-sdk/src/components/ElementBar/TextBoldButton/TextBoldButton.tsx
@@ -16,8 +16,8 @@
 
 import FormatBoldIcon from '@mui/icons-material/FormatBold';
 import { useTranslation } from 'react-i18next';
-import { useToggleBold } from '../../../lib/text-formatting';
-import { useActiveElements, useElements } from '../../../state';
+import { isEmptyText, useToggleBold } from '../../../lib/text-formatting';
+import { ShapeElement, useActiveElements, useElements } from '../../../state';
 import { ToolbarToggle } from '../../common/Toolbar';
 
 export function TextBoldButton() {
@@ -29,6 +29,12 @@ export function TextBoldButton() {
   const elements = Object.values(activeElements);
 
   if (elements.every((element) => element.type !== 'shape')) {
+    return null;
+  }
+
+  if (
+    elements.every((element) => isEmptyText((element as ShapeElement).text))
+  ) {
     return null;
   }
 

--- a/packages/react-sdk/src/components/ElementBar/TextItalicButton/TextItalicButton.test.tsx
+++ b/packages/react-sdk/src/components/ElementBar/TextItalicButton/TextItalicButton.test.tsx
@@ -50,9 +50,15 @@ describe('<TextItalicButton />', () => {
         [
           'slide',
           [
-            ['rectangle', mockRectangleElement({ textItalic: false })],
-            ['circle', mockCircleElement({ textItalic: true })],
-            ['triangle', mockTriangleElement({ textItalic: false })],
+            [
+              'rectangle',
+              mockRectangleElement({ text: 'Hello', textItalic: false }),
+            ],
+            ['circle', mockCircleElement({ text: 'Hello', textItalic: true })],
+            [
+              'triangle',
+              mockTriangleElement({ text: 'Hello', textItalic: false }),
+            ],
             ['line', mockLineElement()],
           ],
         ],

--- a/packages/react-sdk/src/components/ElementBar/TextItalicButton/TextItalicButton.test.tsx
+++ b/packages/react-sdk/src/components/ElementBar/TextItalicButton/TextItalicButton.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { MockedWidgetApi, mockWidgetApi } from '@matrix-widget-toolkit/testing';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axe from 'axe-core';
 import { ComponentType, PropsWithChildren } from 'react';
@@ -93,20 +93,6 @@ describe('<TextItalicButton />', () => {
   it('should reflect the italic text state of the first element', () => {
     render(<TextItalicButton />, { wrapper: Wrapper });
     expect(screen.getByRole('checkbox', { name: 'Italic' })).not.toBeChecked();
-  });
-
-  it('should hide for non-shape elements', async () => {
-    render(<TextItalicButton />, { wrapper: Wrapper });
-
-    const checkbox = screen.getByRole('checkbox', { name: 'Italic' });
-
-    act(() => {
-      slide.setActiveElementId('line');
-    });
-
-    await waitFor(() => {
-      expect(checkbox).not.toBeInTheDocument();
-    });
   });
 
   // Only test one toggle case here.

--- a/packages/react-sdk/src/components/ElementBar/TextItalicButton/TextItalicButton.tsx
+++ b/packages/react-sdk/src/components/ElementBar/TextItalicButton/TextItalicButton.tsx
@@ -16,27 +16,13 @@
 
 import FormatItalicIcon from '@mui/icons-material/FormatItalic';
 import { useTranslation } from 'react-i18next';
-import { isEmptyText, useToggleItalic } from '../../../lib/text-formatting';
-import { ShapeElement, useActiveElements, useElements } from '../../../state';
+import { useToggleItalic } from '../../../lib/text-formatting';
 import { ToolbarToggle } from '../../common/Toolbar';
 
 export function TextItalicButton() {
-  const { activeElementIds } = useActiveElements();
-  const activeElements = useElements(activeElementIds);
-  const elements = Object.values(activeElements);
   const { t } = useTranslation('neoboard');
 
   const { isItalic, toggleItalic } = useToggleItalic();
-
-  if (elements.every((element) => element.type !== 'shape')) {
-    return null;
-  }
-
-  if (
-    elements.every((element) => isEmptyText((element as ShapeElement).text))
-  ) {
-    return null;
-  }
 
   return (
     <ToolbarToggle

--- a/packages/react-sdk/src/components/ElementBar/TextItalicButton/TextItalicButton.tsx
+++ b/packages/react-sdk/src/components/ElementBar/TextItalicButton/TextItalicButton.tsx
@@ -16,8 +16,8 @@
 
 import FormatItalicIcon from '@mui/icons-material/FormatItalic';
 import { useTranslation } from 'react-i18next';
-import { useToggleItalic } from '../../../lib/text-formatting';
-import { useActiveElements, useElements } from '../../../state';
+import { isEmptyText, useToggleItalic } from '../../../lib/text-formatting';
+import { ShapeElement, useActiveElements, useElements } from '../../../state';
 import { ToolbarToggle } from '../../common/Toolbar';
 
 export function TextItalicButton() {
@@ -29,6 +29,12 @@ export function TextItalicButton() {
   const { isItalic, toggleItalic } = useToggleItalic();
 
   if (elements.every((element) => element.type !== 'shape')) {
+    return null;
+  }
+
+  if (
+    elements.every((element) => isEmptyText((element as ShapeElement).text))
+  ) {
     return null;
   }
 

--- a/packages/react-sdk/src/components/Whiteboard/Element/ConnectedElement.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/Element/ConnectedElement.tsx
@@ -29,13 +29,13 @@ export const ConnectedElement = ({
   readOnly = false,
   activeElementIds = [],
   overrides = {},
-  showTextTools = () => {},
+  enableTextTools = () => {},
 }: {
   id: string;
   readOnly?: boolean;
   activeElementIds?: string[];
   overrides?: Elements;
-  showTextTools?: (isVisible: boolean) => void;
+  enableTextTools?: (isVisible: boolean) => void;
 }) => {
   const widgetApi = useWidgetApi();
   const element = useElementOverride(id);
@@ -65,7 +65,7 @@ export const ConnectedElement = ({
           <EllipseDisplay
             {...element}
             {...otherProps}
-            enableTextTools={showTextTools}
+            enableTextTools={enableTextTools}
           />
         );
       } else if (element.kind === 'rectangle') {
@@ -73,7 +73,7 @@ export const ConnectedElement = ({
           <RectangleDisplay
             {...element}
             {...otherProps}
-            enableTextTools={showTextTools}
+            enableTextTools={enableTextTools}
           />
         );
       } else if (element.kind === 'triangle') {
@@ -81,7 +81,7 @@ export const ConnectedElement = ({
           <TriangleDisplay
             {...element}
             {...otherProps}
-            enableTextTools={showTextTools}
+            enableTextTools={enableTextTools}
           />
         );
       }

--- a/packages/react-sdk/src/components/Whiteboard/Element/ConnectedElement.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/Element/ConnectedElement.tsx
@@ -29,13 +29,13 @@ export const ConnectedElement = ({
   readOnly = false,
   activeElementIds = [],
   overrides = {},
-  enableTextTools = () => {},
+  setTextToolsEnabled = () => {},
 }: {
   id: string;
   readOnly?: boolean;
   activeElementIds?: string[];
   overrides?: Elements;
-  enableTextTools?: (isVisible: boolean) => void;
+  setTextToolsEnabled?: (enabled: boolean) => void;
 }) => {
   const widgetApi = useWidgetApi();
   const element = useElementOverride(id);
@@ -65,7 +65,7 @@ export const ConnectedElement = ({
           <EllipseDisplay
             {...element}
             {...otherProps}
-            enableTextTools={enableTextTools}
+            setTextToolsEnabled={setTextToolsEnabled}
           />
         );
       } else if (element.kind === 'rectangle') {
@@ -73,7 +73,7 @@ export const ConnectedElement = ({
           <RectangleDisplay
             {...element}
             {...otherProps}
-            enableTextTools={enableTextTools}
+            setTextToolsEnabled={setTextToolsEnabled}
           />
         );
       } else if (element.kind === 'triangle') {
@@ -81,7 +81,7 @@ export const ConnectedElement = ({
           <TriangleDisplay
             {...element}
             {...otherProps}
-            enableTextTools={enableTextTools}
+            setTextToolsEnabled={setTextToolsEnabled}
           />
         );
       }

--- a/packages/react-sdk/src/components/Whiteboard/Element/ConnectedElement.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/Element/ConnectedElement.tsx
@@ -29,11 +29,13 @@ export const ConnectedElement = ({
   readOnly = false,
   activeElementIds = [],
   overrides = {},
+  showTextTools = () => {},
 }: {
   id: string;
   readOnly?: boolean;
   activeElementIds?: string[];
   overrides?: Elements;
+  showTextTools?: (isVisible: boolean) => void;
 }) => {
   const widgetApi = useWidgetApi();
   const element = useElementOverride(id);
@@ -59,11 +61,29 @@ export const ConnectedElement = ({
       }
     } else if (element.type === 'shape') {
       if (element.kind === 'circle' || element.kind === 'ellipse') {
-        return <EllipseDisplay {...element} {...otherProps} />;
+        return (
+          <EllipseDisplay
+            {...element}
+            {...otherProps}
+            enableTextTools={showTextTools}
+          />
+        );
       } else if (element.kind === 'rectangle') {
-        return <RectangleDisplay {...element} {...otherProps} />;
+        return (
+          <RectangleDisplay
+            {...element}
+            {...otherProps}
+            enableTextTools={showTextTools}
+          />
+        );
       } else if (element.kind === 'triangle') {
-        return <TriangleDisplay {...element} {...otherProps} />;
+        return (
+          <TriangleDisplay
+            {...element}
+            {...otherProps}
+            enableTextTools={showTextTools}
+          />
+        );
       }
     } else if (element.type === 'image') {
       if (widgetApi.widgetParameters.baseUrl === undefined) {

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/types.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/types.ts
@@ -25,5 +25,5 @@ export type WithSelectionProps = {
 export type WithExtendedSelectionProps = WithSelectionProps & {
   activeElementIds?: string[];
   overrides?: Elements;
-  enableTextTools?: (isVisible: boolean) => void;
+  setTextToolsEnabled?: (enabled: boolean) => void;
 };

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/types.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/types.ts
@@ -25,4 +25,5 @@ export type WithSelectionProps = {
 export type WithExtendedSelectionProps = WithSelectionProps & {
   activeElementIds?: string[];
   overrides?: Elements;
+  enableTextTools?: (isVisible: boolean) => void;
 };

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
@@ -107,7 +107,7 @@ export type TextEditorProps = {
   height: number;
   fontSize?: number;
   editModeOnMount: boolean;
-  enableTextTools: ((isVisible: boolean) => void) | undefined;
+  setTextToolsEnabled: ((enabled: boolean) => void) | undefined;
 };
 
 // TODO: Consider an alternative to content-editable. Right now it allows to do unexpected things
@@ -126,7 +126,7 @@ export function TextEditor({
   height,
   fontSize,
   editModeOnMount = false,
-  enableTextTools = () => {},
+  setTextToolsEnabled = () => {},
 }: TextEditorProps) {
   const textRef = useRef<HTMLDivElement>(null);
   const [isEditMode, setEditMode] = useState(editModeOnMount);
@@ -137,9 +137,9 @@ export function TextEditor({
       onBlur();
 
       setEditMode(false);
-      enableTextTools(false);
+      setTextToolsEnabled(false);
     }
-  }, [editable, isEditMode, onBlur, enableTextTools]);
+  }, [editable, isEditMode, onBlur, setTextToolsEnabled]);
 
   const handleDoubleClick = useCallback(
     (event: MouseEvent) => {
@@ -149,12 +149,12 @@ export function TextEditor({
 
       if (editable) {
         setEditMode(true);
-        enableTextTools(true);
+        setTextToolsEnabled(true);
       } else {
         event.preventDefault();
       }
     },
-    [editable, isEditMode, enableTextTools],
+    [editable, isEditMode, setTextToolsEnabled],
   );
 
   const handleFocus = useCallback(() => {
@@ -181,11 +181,11 @@ export function TextEditor({
       if (textRef.current) {
         fitText(textRef.current, fontSize, contentBold, contentItalic);
         if (!isEmptyText(textRef.current.innerText)) {
-          enableTextTools(true);
+          setTextToolsEnabled(true);
         }
       }
     });
-  }, [fontSize, contentBold, contentItalic, enableTextTools]);
+  }, [fontSize, contentBold, contentItalic, setTextToolsEnabled]);
 
   const handleKeyUp = useCallback(() => {
     if (textRef.current) {

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
@@ -137,7 +137,6 @@ export function TextEditor({
       onBlur();
 
       setEditMode(false);
-      enableTextTools(false);
     }
   }, [editable, isEditMode, onBlur, enableTextTools]);
 

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
@@ -27,6 +27,7 @@ import {
   useState,
 } from 'react';
 import { useFontsLoaded } from '../../../../lib';
+import { isEmptyText } from '../../../../lib/text-formatting';
 import { TextAlignment } from '../../../../state';
 import {
   HOTKEY_SCOPE_WHITEBOARD,
@@ -106,6 +107,7 @@ export type TextEditorProps = {
   height: number;
   fontSize?: number;
   editModeOnMount: boolean;
+  enableTextTools: ((isVisible: boolean) => void) | undefined;
 };
 
 // TODO: Consider an alternative to content-editable. Right now it allows to do unexpected things
@@ -124,6 +126,7 @@ export function TextEditor({
   height,
   fontSize,
   editModeOnMount = false,
+  enableTextTools = () => {},
 }: TextEditorProps) {
   const textRef = useRef<HTMLDivElement>(null);
   const [isEditMode, setEditMode] = useState(editModeOnMount);
@@ -134,8 +137,9 @@ export function TextEditor({
       onBlur();
 
       setEditMode(false);
+      enableTextTools(false);
     }
-  }, [editable, isEditMode, onBlur]);
+  }, [editable, isEditMode, onBlur, enableTextTools]);
 
   const handleDoubleClick = useCallback(
     (event: MouseEvent) => {
@@ -175,9 +179,12 @@ export function TextEditor({
     window.requestAnimationFrame(() => {
       if (textRef.current) {
         fitText(textRef.current, fontSize, contentBold, contentItalic);
+        if (!isEmptyText(textRef.current.innerText)) {
+          enableTextTools(true);
+        }
       }
     });
-  }, [fontSize, contentBold, contentItalic, textRef]);
+  }, [fontSize, contentBold, contentItalic, enableTextTools]);
 
   const handleKeyUp = useCallback(() => {
     if (textRef.current) {

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
@@ -137,6 +137,7 @@ export function TextEditor({
       onBlur();
 
       setEditMode(false);
+      enableTextTools(false);
     }
   }, [editable, isEditMode, onBlur, enableTextTools]);
 
@@ -148,11 +149,12 @@ export function TextEditor({
 
       if (editable) {
         setEditMode(true);
+        enableTextTools(true);
       } else {
         event.preventDefault();
       }
     },
-    [editable, isEditMode],
+    [editable, isEditMode, enableTextTools],
   );
 
   const handleFocus = useCallback(() => {

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextElement.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextElement.tsx
@@ -50,6 +50,8 @@ export type TextElementProps = {
   elementId: string;
   textColor?: string;
   fontSize?: number;
+
+  enableTextTools: ((isVisible: boolean) => void) | undefined;
 };
 
 export const TextElement = ({
@@ -66,6 +68,7 @@ export const TextElement = ({
   elementId,
   textColor,
   fontSize,
+  enableTextTools,
 }: TextElementProps) => {
   const slideInstance = useWhiteboardSlideInstance();
   const [unsubmittedText, setUnsubmittedText] = useState(text);
@@ -119,6 +122,7 @@ export const TextElement = ({
         height={height}
         width={width}
         fontSize={fontSize}
+        enableTextTools={enableTextTools}
       />
     </ForeignObjectNoInteraction>
   );

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextElement.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextElement.tsx
@@ -51,7 +51,7 @@ export type TextElementProps = {
   textColor?: string;
   fontSize?: number;
 
-  enableTextTools: ((isVisible: boolean) => void) | undefined;
+  setTextToolsEnabled: ((enabled: boolean) => void) | undefined;
 };
 
 export const TextElement = ({
@@ -68,7 +68,7 @@ export const TextElement = ({
   elementId,
   textColor,
   fontSize,
-  enableTextTools,
+  setTextToolsEnabled,
 }: TextElementProps) => {
   const slideInstance = useWhiteboardSlideInstance();
   const [unsubmittedText, setUnsubmittedText] = useState(text);
@@ -122,7 +122,7 @@ export const TextElement = ({
         height={height}
         width={width}
         fontSize={fontSize}
-        enableTextTools={enableTextTools}
+        setTextToolsEnabled={setTextToolsEnabled}
       />
     </ForeignObjectNoInteraction>
   );

--- a/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
@@ -65,7 +65,6 @@ const WhiteboardHost = ({
   const { activeElementIds } = useActiveElements();
   const overrides = useElementOverrides(activeElementIds);
   const [areTextToolsVisible, setTextToolsVisible] = useState(false);
-  const [canShowToolbar, setCanShowToolbar] = useState(false);
 
   // iterate over all activeElements and check if any of them has text content
   const hasTextElement = useMemo(() => {
@@ -79,11 +78,8 @@ const WhiteboardHost = ({
   }, [activeElementIds, slideInstance]);
 
   useEffect(() => {
-    if (activeElementIds.length > 0 && slideInstance) {
-      setTextToolsVisible(hasTextElement);
-      setCanShowToolbar(true);
-    }
-  }, [activeElementIds, hasTextElement, slideInstance]);
+    setTextToolsVisible(hasTextElement);
+  }, [activeElementIds, hasTextElement]);
 
   return (
     <Box
@@ -102,8 +98,7 @@ const WhiteboardHost = ({
         additionalChildren={
           dragSelectStartCoords === undefined &&
           !readOnly &&
-          activeElementIds.length > 0 &&
-          canShowToolbar && (
+          activeElementIds.length > 0 && (
             <ElementBarWrapper elementIds={activeElementIds}>
               <ElementBar showTextTools={areTextToolsVisible} />
             </ElementBarWrapper>
@@ -128,7 +123,7 @@ const WhiteboardHost = ({
             readOnly={readOnly}
             activeElementIds={activeElementIds}
             overrides={overrides}
-            showTextTools={setTextToolsVisible}
+            enableTextTools={setTextToolsVisible}
           />
         ))}
 

--- a/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
@@ -15,9 +15,10 @@
  */
 
 import { Box } from '@mui/material';
-import { useCallback, useMemo, useState } from 'react';
-import { isEmptyText } from '../../lib/text-formatting';
+import { useCallback, useState } from 'react';
 import {
+  includesShapeWithText,
+  includesTextShape,
   type Point,
   useActiveElements,
   useIsWhiteboardLoading,
@@ -64,20 +65,13 @@ const WhiteboardHost = ({
     useLayoutState();
   const { activeElementIds } = useActiveElements();
   const overrides = useElementOverrides(activeElementIds);
-  const [enableTextTools, setEnableTextTools] = useState(false);
+  const [textToolsEnabled, setTextToolsEnabled] = useState(false);
 
-  // iterate over all activeElements and check if any of them has text content
-  const hasTextShape = useMemo(() => {
-    return activeElementIds.some((id) => {
-      const element = slideInstance.getElement(id);
-      if (element?.type === 'shape') {
-        return !isEmptyText(element.text);
-      }
-      return false;
-    });
-  }, [activeElementIds, slideInstance]);
+  const hasElementWithText =
+    includesTextShape(Object.values(overrides)) ||
+    includesShapeWithText(Object.values(overrides));
 
-  const showTextTools = enableTextTools || hasTextShape;
+  const showTextTools = textToolsEnabled || hasElementWithText;
 
   return (
     <Box
@@ -121,7 +115,7 @@ const WhiteboardHost = ({
             readOnly={readOnly}
             activeElementIds={activeElementIds}
             overrides={overrides}
-            enableTextTools={setEnableTextTools}
+            setTextToolsEnabled={setTextToolsEnabled}
           />
         ))}
 

--- a/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Box } from '@mui/material';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { isEmptyText } from '../../lib/text-formatting';
 import {
   type Point,
@@ -64,10 +64,10 @@ const WhiteboardHost = ({
     useLayoutState();
   const { activeElementIds } = useActiveElements();
   const overrides = useElementOverrides(activeElementIds);
-  const [areTextToolsVisible, setTextToolsVisible] = useState(false);
+  const [enableTextTools, setEnableTextTools] = useState(false);
 
   // iterate over all activeElements and check if any of them has text content
-  const hasTextElement = useMemo(() => {
+  const hasTextShape = useMemo(() => {
     return activeElementIds.some((id) => {
       const element = slideInstance.getElement(id);
       if (element?.type === 'shape') {
@@ -77,9 +77,7 @@ const WhiteboardHost = ({
     });
   }, [activeElementIds, slideInstance]);
 
-  useEffect(() => {
-    setTextToolsVisible(hasTextElement);
-  }, [activeElementIds, hasTextElement]);
+  const showTextTools = enableTextTools || hasTextShape;
 
   return (
     <Box
@@ -100,7 +98,7 @@ const WhiteboardHost = ({
           !readOnly &&
           activeElementIds.length > 0 && (
             <ElementBarWrapper elementIds={activeElementIds}>
-              <ElementBar showTextTools={areTextToolsVisible} />
+              <ElementBar showTextTools={showTextTools} />
             </ElementBarWrapper>
           )
         }
@@ -123,7 +121,7 @@ const WhiteboardHost = ({
             readOnly={readOnly}
             activeElementIds={activeElementIds}
             overrides={overrides}
-            enableTextTools={setTextToolsVisible}
+            enableTextTools={setEnableTextTools}
           />
         ))}
 

--- a/packages/react-sdk/src/components/elements/ellipse/Display.tsx
+++ b/packages/react-sdk/src/components/elements/ellipse/Display.tsx
@@ -72,6 +72,7 @@ const EllipseDisplay = ({
           height={text.height}
           fillColor={shape.fillColor}
           fontSize={text.fontSize}
+          enableTextTools={shape.enableTextTools}
         />
       )}
     </g>

--- a/packages/react-sdk/src/components/elements/ellipse/Display.tsx
+++ b/packages/react-sdk/src/components/elements/ellipse/Display.tsx
@@ -72,7 +72,7 @@ const EllipseDisplay = ({
           height={text.height}
           fillColor={shape.fillColor}
           fontSize={text.fontSize}
-          enableTextTools={shape.enableTextTools}
+          setTextToolsEnabled={shape.setTextToolsEnabled}
         />
       )}
     </g>

--- a/packages/react-sdk/src/components/elements/rectangle/Display.tsx
+++ b/packages/react-sdk/src/components/elements/rectangle/Display.tsx
@@ -69,6 +69,7 @@ const RectangleDisplay = ({
           fillColor={shape.fillColor}
           textColor={shape.textColor}
           fontSize={text.fontSize}
+          enableTextTools={shape.enableTextTools}
         />
       )}
     </g>

--- a/packages/react-sdk/src/components/elements/rectangle/Display.tsx
+++ b/packages/react-sdk/src/components/elements/rectangle/Display.tsx
@@ -69,7 +69,7 @@ const RectangleDisplay = ({
           fillColor={shape.fillColor}
           textColor={shape.textColor}
           fontSize={text.fontSize}
-          enableTextTools={shape.enableTextTools}
+          setTextToolsEnabled={shape.setTextToolsEnabled}
         />
       )}
     </g>

--- a/packages/react-sdk/src/components/elements/triangle/Display.tsx
+++ b/packages/react-sdk/src/components/elements/triangle/Display.tsx
@@ -66,6 +66,7 @@ const TriangleDisplay = ({
           height={text.height}
           fillColor={shape.fillColor}
           fontSize={text.fontSize}
+          enableTextTools={shape.enableTextTools}
         />
       )}
     </g>

--- a/packages/react-sdk/src/components/elements/triangle/Display.tsx
+++ b/packages/react-sdk/src/components/elements/triangle/Display.tsx
@@ -66,7 +66,7 @@ const TriangleDisplay = ({
           height={text.height}
           fillColor={shape.fillColor}
           fontSize={text.fontSize}
-          enableTextTools={shape.enableTextTools}
+          setTextToolsEnabled={shape.setTextToolsEnabled}
         />
       )}
     </g>

--- a/packages/react-sdk/src/lib/text-formatting/isEmptyText.test.ts
+++ b/packages/react-sdk/src/lib/text-formatting/isEmptyText.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isEmptyText } from './isEmptyText';
+
+describe('isEmptyText', () => {
+  it('should return true for an empty string', () => {
+    expect(isEmptyText('')).toBe(true);
+  });
+
+  it('should return true for a string with only spaces', () => {
+    expect(isEmptyText('   ')).toBe(true);
+  });
+
+  it('should return true for a string with only tabs', () => {
+    expect(isEmptyText('\t\t\t')).toBe(true);
+  });
+
+  it('should return true for a string with only newlines', () => {
+    expect(isEmptyText('\n\n\n')).toBe(true);
+  });
+
+  it('should return false for a non-empty string', () => {
+    expect(isEmptyText('Hello')).toBe(false);
+  });
+
+  it('should return false for a string with non-whitespace characters and spaces', () => {
+    expect(isEmptyText('  Hello  ')).toBe(false);
+  });
+
+  it('should return false for a string with mixed whitespace and non-whitespace characters', () => {
+    expect(isEmptyText(' \t\nHello\n\t ')).toBe(false);
+  });
+});

--- a/packages/react-sdk/src/lib/text-formatting/isEmptyText.ts
+++ b/packages/react-sdk/src/lib/text-formatting/isEmptyText.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-export function isEmptyText(text: string) {
+export function isEmptyText(text?: string | null) {
+  if (text === undefined || text === null) {
+    return true;
+  }
+
   if (text.trim() === '') {
     return true;
   }

--- a/packages/react-sdk/src/lib/text-formatting/isEmptyText.ts
+++ b/packages/react-sdk/src/lib/text-formatting/isEmptyText.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-export { isEmptyText } from './isEmptyText';
-export { useFontSize } from './useFontSize';
-export { useToggleBold } from './useToggleBold';
-export { useToggleItalic } from './useToggleItalic';
+export function isEmptyText(text: string) {
+  if (text.trim() === '') {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

Text formatting tools in the shape toolbar (including text color) will only be shown when applicable, which is when the shape actually has text in it or the user started typing.

**Before**
https://github.com/user-attachments/assets/45e66bb9-4471-422a-8a48-5bafd7f9dbdd

**After**
https://github.com/user-attachments/assets/efc19781-fa44-4c04-80f5-e8903b98cad5

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [X] Tests for new functionality and regression tests for bug fixes.
- [X] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
