### PR TITLE
Fix MUI dialog issue in fullscreen mode

### DIFF
--- a/.changeset/large-pillows-guess.md
+++ b/.changeset/large-pillows-guess.md
@@ -3,4 +3,4 @@
 '@nordeck/matrix-neoboard-widget': patch
 ---
 
-Apply fullscreen styles to the body element instead of the html element to resolve MUI dialog display issues.
+Fix the issue where the dialog is not displayed in fullscreen mode.

--- a/.changeset/large-pillows-guess.md
+++ b/.changeset/large-pillows-guess.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+Apply fullscreen styles to the body element instead of the html element to resolve MUI dialog display issues.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,7 +78,7 @@ export default ts.config(
             {
               name: '@mui/material',
               importNames: ['Dialog'],
-              message: 'Pleas use neoboard react SKD Dialog instad',
+              message: 'Please use the Neoboard React SDK Dialog instead.',
             },
           ],
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -75,6 +75,11 @@ export default ts.config(
               importNames: ['act'],
               message: 'Please import "act" from "react" instead',
             },
+            {
+              name: '@mui/material',
+              importNames: ['Dialog'],
+              message: 'Pleas use neoboard react SKD Dialog instad',
+            },
           ],
         },
       ],

--- a/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialog.tsx
+++ b/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialog.tsx
@@ -18,7 +18,6 @@ import CloseIcon from '@mui/icons-material/Close';
 import {
   Alert,
   Button,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
@@ -35,6 +34,7 @@ import {
 import { unstable_useId as useId, visuallyHidden } from '@mui/utils';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Dialog } from '../common/Dialog';
 import { ExportWhiteboardDialogDownloadFile } from './ExportWhiteboardDialogDownloadFile';
 import { ExportWhiteboardDialogDownloadPdf } from './ExportWhiteboardDialogDownloadPdf';
 
@@ -54,7 +54,6 @@ export function ExportWhiteboardDialog({
     <Dialog
       aria-labelledby={dialogTitleId}
       aria-describedby={dialogDescriptionId}
-      container={document.getElementById('widget-root')}
       open={open}
       onClose={onClose}
       maxWidth="sm"

--- a/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialog.tsx
+++ b/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialog.tsx
@@ -54,6 +54,7 @@ export function ExportWhiteboardDialog({
     <Dialog
       aria-labelledby={dialogTitleId}
       aria-describedby={dialogDescriptionId}
+      container={document.getElementById('widget-root')}
       open={open}
       onClose={onClose}
       maxWidth="sm"

--- a/packages/react-sdk/src/components/DeveloperTools/DeveloperToolsDialog.tsx
+++ b/packages/react-sdk/src/components/DeveloperTools/DeveloperToolsDialog.tsx
@@ -44,7 +44,7 @@ export function DeveloperToolsDialog({
 }) {
   const { t } = useTranslation('neoboard');
 
-  const { document, communicationChannel } =
+  const { document: communicationDocument, communicationChannel } =
     useActiveWhiteboardInstanceStatistics();
 
   const dialogTitleId = useId();
@@ -58,6 +58,7 @@ export function DeveloperToolsDialog({
       maxWidth="md"
       aria-labelledby={dialogTitleId}
       aria-describedby={dialogDescriptionId}
+      container={document.getElementById('widget-root')}
     >
       <DialogTitle
         id={dialogTitleId}
@@ -98,7 +99,7 @@ export function DeveloperToolsDialog({
               </Typography>
             </AccordionSummary>
             <AccordionDetails>
-              <DocumentSyncStatisticsView document={document} />
+              <DocumentSyncStatisticsView document={communicationDocument} />
             </AccordionDetails>
           </Accordion>
 

--- a/packages/react-sdk/src/components/DeveloperTools/DeveloperToolsDialog.tsx
+++ b/packages/react-sdk/src/components/DeveloperTools/DeveloperToolsDialog.tsx
@@ -21,7 +21,6 @@ import {
   AccordionDetails,
   AccordionSummary,
   Box,
-  Dialog,
   DialogContent,
   DialogTitle,
   IconButton,
@@ -31,6 +30,7 @@ import {
 import { unstable_useId as useId } from '@mui/utils';
 import { useTranslation } from 'react-i18next';
 import { useActiveWhiteboardInstanceStatistics } from '../../state';
+import { Dialog } from '../common/Dialog';
 import { CommunicationChannelStatisticsView } from './CommunicationChannelStatisticsView';
 import { DocumentSyncStatisticsView } from './DocumentSyncStatisticsView';
 import { WhiteboardSessionsTable } from './WhiteboardSessions';
@@ -44,7 +44,7 @@ export function DeveloperToolsDialog({
 }) {
   const { t } = useTranslation('neoboard');
 
-  const { document: communicationDocument, communicationChannel } =
+  const { document, communicationChannel } =
     useActiveWhiteboardInstanceStatistics();
 
   const dialogTitleId = useId();
@@ -58,7 +58,6 @@ export function DeveloperToolsDialog({
       maxWidth="md"
       aria-labelledby={dialogTitleId}
       aria-describedby={dialogDescriptionId}
-      container={document.getElementById('widget-root')}
     >
       <DialogTitle
         id={dialogTitleId}
@@ -99,7 +98,7 @@ export function DeveloperToolsDialog({
               </Typography>
             </AccordionSummary>
             <AccordionDetails>
-              <DocumentSyncStatisticsView document={communicationDocument} />
+              <DocumentSyncStatisticsView document={document} />
             </AccordionDetails>
           </Accordion>
 

--- a/packages/react-sdk/src/components/HelpCenterBar/InfoDialog.tsx
+++ b/packages/react-sdk/src/components/HelpCenterBar/InfoDialog.tsx
@@ -59,6 +59,7 @@ export function InfoDialog({ open, onClose }: InfoDialogProps) {
       onClose={onClose}
       fullWidth
       maxWidth="sm"
+      container={document.getElementById('widget-root')}
       aria-labelledby={dialogTitleId}
       aria-describedby={dialogDescriptionId}
     >

--- a/packages/react-sdk/src/components/HelpCenterBar/InfoDialog.tsx
+++ b/packages/react-sdk/src/components/HelpCenterBar/InfoDialog.tsx
@@ -18,7 +18,6 @@ import { getEnvironment } from '@matrix-widget-toolkit/mui';
 import CloseIcon from '@mui/icons-material/Close';
 import {
   Button,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
@@ -33,6 +32,7 @@ import { unstable_useId as useId } from '@mui/utils';
 import { DispatchWithoutAction, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CopyableText } from '../common/CopyableText';
+import { Dialog } from '../common/Dialog';
 
 type InfoDialogProps = {
   open: boolean;
@@ -59,7 +59,6 @@ export function InfoDialog({ open, onClose }: InfoDialogProps) {
       onClose={onClose}
       fullWidth
       maxWidth="sm"
-      container={document.getElementById('widget-root')}
       aria-labelledby={dialogTitleId}
       aria-describedby={dialogDescriptionId}
     >

--- a/packages/react-sdk/src/components/ImportWhiteboardDialog/ImportWhiteboardDialog.tsx
+++ b/packages/react-sdk/src/components/ImportWhiteboardDialog/ImportWhiteboardDialog.tsx
@@ -21,7 +21,6 @@ import {
   Box,
   Button,
   CircularProgress,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
@@ -37,6 +36,7 @@ import {
   WhiteboardDocumentExport,
 } from '../../state';
 import { importWhiteboard } from '../../state/import';
+import { Dialog } from '../common/Dialog';
 import { useImageUpload } from '../ImageUpload';
 import { readNWB, readPDF } from './fileHandlers';
 import { ImportedWhiteboard } from './types';
@@ -213,7 +213,6 @@ export function ImportWhiteboardDialog({
     <Dialog
       aria-labelledby={dialogTitleId}
       aria-describedby={dialogDescriptionId}
-      container={document.getElementById('widget-root')}
       open={open}
       onClose={handleClose}
       fullWidth

--- a/packages/react-sdk/src/components/ImportWhiteboardDialog/ImportWhiteboardDialog.tsx
+++ b/packages/react-sdk/src/components/ImportWhiteboardDialog/ImportWhiteboardDialog.tsx
@@ -213,6 +213,7 @@ export function ImportWhiteboardDialog({
     <Dialog
       aria-labelledby={dialogTitleId}
       aria-describedby={dialogDescriptionId}
+      container={document.getElementById('widget-root')}
       open={open}
       onClose={handleClose}
       fullWidth

--- a/packages/react-sdk/src/components/Layout/useFullscreenMode.test.tsx
+++ b/packages/react-sdk/src/components/Layout/useFullscreenMode.test.tsx
@@ -42,7 +42,7 @@ describe('useFullscreenMode', () => {
         result.current.setFullscreenMode(true);
       });
 
-      expect(document.body.requestFullscreen).toHaveBeenCalled();
+      expect(document.documentElement.requestFullscreen).toHaveBeenCalled();
       expect(result.current.isFullscreenMode).toBe(true);
     },
   );

--- a/packages/react-sdk/src/components/Layout/useFullscreenMode.test.tsx
+++ b/packages/react-sdk/src/components/Layout/useFullscreenMode.test.tsx
@@ -42,7 +42,7 @@ describe('useFullscreenMode', () => {
         result.current.setFullscreenMode(true);
       });
 
-      expect(document.documentElement.requestFullscreen).toHaveBeenCalled();
+      expect(document.body.requestFullscreen).toHaveBeenCalled();
       expect(result.current.isFullscreenMode).toBe(true);
     },
   );

--- a/packages/react-sdk/src/components/Layout/useFullscreenMode.ts
+++ b/packages/react-sdk/src/components/Layout/useFullscreenMode.ts
@@ -55,10 +55,8 @@ export function useFullscreenMode(): UseFullscreenModeResult {
     isFullscreenRequestRunning.current = true;
 
     if (value && !document.fullscreenElement) {
-      const container =
-        document.getElementById('widget-root') ?? document.documentElement;
       try {
-        await container.requestFullscreen();
+        await document.body.requestFullscreen();
       } catch (error) {
         loglevel.error('Error while going fullscreen', error);
       }

--- a/packages/react-sdk/src/components/Layout/useFullscreenMode.ts
+++ b/packages/react-sdk/src/components/Layout/useFullscreenMode.ts
@@ -53,10 +53,12 @@ export function useFullscreenMode(): UseFullscreenModeResult {
     }
 
     isFullscreenRequestRunning.current = true;
+    const container =
+      document.getElementById('widget-root') ?? document.documentElement;
 
     if (value && !document.fullscreenElement) {
       try {
-        await document.body.requestFullscreen();
+        await container.requestFullscreen();
       } catch (error) {
         loglevel.error('Error while going fullscreen', error);
       }

--- a/packages/react-sdk/src/components/common/Dialog/Dialog.tsx
+++ b/packages/react-sdk/src/components/common/Dialog/Dialog.tsx
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-export * from './App';
-export * from './components/common/Dialog';
-export * from './components/common/PageLoader';
-export * from './components/connection-state';
-export * from './components/GuidedTour';
-export * from './components/Layout';
-export * from './components/Snackbar';
-export { DraggableStyles } from './components/Whiteboard/ElementBehaviors/Moveable';
-export * from './components/WhiteboardHotkeysProvider';
-export * from './i18n';
-export * from './lib';
-export * from './model';
-export * from './state';
-export * from './store';
+// eslint-disable-next-line
+import { DialogProps, Dialog as MUIDialog } from '@mui/material';
+import React from 'react';
+
+export const Dialog: React.FC<DialogProps> = ({ children, ...otherProps }) => {
+  return (
+    <MUIDialog
+      container={document.getElementById('widget-root')}
+      {...otherProps}
+    >
+      {children}
+    </MUIDialog>
+  );
+};

--- a/packages/react-sdk/src/components/common/Dialog/index.ts
+++ b/packages/react-sdk/src/components/common/Dialog/index.ts
@@ -14,17 +14,4 @@
  * limitations under the License.
  */
 
-export * from './App';
-export * from './components/common/Dialog';
-export * from './components/common/PageLoader';
-export * from './components/connection-state';
-export * from './components/GuidedTour';
-export * from './components/Layout';
-export * from './components/Snackbar';
-export { DraggableStyles } from './components/Whiteboard/ElementBehaviors/Moveable';
-export * from './components/WhiteboardHotkeysProvider';
-export * from './i18n';
-export * from './lib';
-export * from './model';
-export * from './state';
-export * from './store';
+export { Dialog } from './Dialog';

--- a/packages/react-sdk/src/components/connection-state/ConnectionStateDialog.tsx
+++ b/packages/react-sdk/src/components/connection-state/ConnectionStateDialog.tsx
@@ -16,7 +16,6 @@
 
 import {
   Button,
-  Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
@@ -24,6 +23,7 @@ import {
 } from '@mui/material';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Dialog } from '../common/Dialog';
 import { useConnectionState } from './useConnectionState';
 
 export const ConnectionStateDialog: React.FC = () => {
@@ -53,11 +53,7 @@ export const ConnectionStateDialog: React.FC = () => {
   }
 
   return (
-    <Dialog
-      container={document.getElementById('widget-root')}
-      onClose={handleCloseConnectionStateDialog}
-      open={true}
-    >
+    <Dialog onClose={handleCloseConnectionStateDialog} open={true}>
       <DialogTitle>
         {t('connectionState.dialog.title', 'Your changes are not saved')}
       </DialogTitle>

--- a/packages/react-sdk/src/components/connection-state/ConnectionStateDialog.tsx
+++ b/packages/react-sdk/src/components/connection-state/ConnectionStateDialog.tsx
@@ -53,7 +53,11 @@ export const ConnectionStateDialog: React.FC = () => {
   }
 
   return (
-    <Dialog onClose={handleCloseConnectionStateDialog} open={true}>
+    <Dialog
+      container={document.getElementById('widget-root')}
+      onClose={handleCloseConnectionStateDialog}
+      open={true}
+    >
       <DialogTitle>
         {t('connectionState.dialog.title', 'Your changes are not saved')}
       </DialogTitle>

--- a/packages/react-sdk/src/lib/testUtils/documentTestUtils.tsx
+++ b/packages/react-sdk/src/lib/testUtils/documentTestUtils.tsx
@@ -372,7 +372,7 @@ export function mockFullscreenApi(): void {
     return Promise.resolve();
   });
 
-  document.documentElement.requestFullscreen = vi.fn(function () {
+  document.body.requestFullscreen = vi.fn(function () {
     // @ts-expect-error Ignore TS and linter here for setting a mocked API
     // eslint-disable-next-line
     document.fullscreenElement = {};

--- a/packages/react-sdk/src/lib/testUtils/documentTestUtils.tsx
+++ b/packages/react-sdk/src/lib/testUtils/documentTestUtils.tsx
@@ -372,7 +372,7 @@ export function mockFullscreenApi(): void {
     return Promise.resolve();
   });
 
-  document.body.requestFullscreen = vi.fn(function () {
+  document.documentElement.requestFullscreen = vi.fn(function () {
     // @ts-expect-error Ignore TS and linter here for setting a mocked API
     // eslint-disable-next-line
     document.fullscreenElement = {};


### PR DESCRIPTION
Problem
When the application enters fullscreen mode, the MUI Dialog component does not render correctly on top of the fullscreen content. This issue occurs because the Dialog by default attaches to document.body, which is outside the fullscreen context (widget-root container). As a result, the dialog either becomes invisible or behaves unexpectedly in fullscreen mode.

solution:
Ensure the Dialog renders properly within the fullscreen to explicitly use the container prop of the MUI Dialog, anchoring it to the widget-root container.

Before
https://github.com/user-attachments/assets/661f06df-7173-4671-a52e-cd5035fab4b4

After
https://github.com/user-attachments/assets/5930d195-c36c-47e3-ac34-02ea883fd3c6


**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
