### PR TITLE
Fix invisible small text

### DIFF
--- a/.changeset/brown-mangos-decide.md
+++ b/.changeset/brown-mangos-decide.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+Implement relative padding for shapes with width/height below 40px and ensure text elements remain visible on small sizes.

--- a/packages/react-sdk/src/components/elements/rectangle/getRenderProperties.ts
+++ b/packages/react-sdk/src/components/elements/rectangle/getRenderProperties.ts
@@ -20,10 +20,11 @@ import { ElementRenderProperties } from '../../Whiteboard';
 export function getRenderProperties(
   shape: ShapeElement,
 ): ElementRenderProperties {
-  const padding = 10;
-
   const width = shape.width;
   const height = shape.height;
+
+  const verticalPaddingVertical = height > 40 ? 10 : 2;
+  const horizontalPadding = width > 40 ? 10 : 2;
 
   return {
     strokeColor: shape.strokeColor ?? shape.fillColor,
@@ -32,11 +33,11 @@ export function getRenderProperties(
 
     text: {
       position: {
-        x: shape.position.x + padding,
-        y: shape.position.y + padding,
+        x: shape.position.x + horizontalPadding,
+        y: shape.position.y + verticalPaddingVertical,
       },
-      width: width - padding * 2,
-      height: height - padding * 2,
+      width: width - horizontalPadding * 2,
+      height: height - verticalPaddingVertical * 2,
       alignment: shape.textAlignment ?? 'center',
       bold: shape.textBold ?? false,
       italic: shape.textItalic ?? false,


### PR DESCRIPTION
Implement relative padding for shapes with width/height below 40px and ensure text elements remain visible on small sizes.

https://github.com/user-attachments/assets/9e73ecfe-096c-4b43-acfc-5321f5ba96b4

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
