### PR TITLE
Add placeholder for PDF export when image is not available

### DIFF
--- a/.changeset/beige-bananas-wash.md
+++ b/.changeset/beige-bananas-wash.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': minor
+'@nordeck/matrix-neoboard-widget': minor
+---
+
+Add placeholder for PDF export when image is not available

--- a/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialogDownloadPdf.test.tsx
+++ b/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialogDownloadPdf.test.tsx
@@ -176,6 +176,7 @@ describe('<ExportWhiteboardDialogDownloadPdf />', () => {
         roomName: 'NeoBoard',
         widgetApi: widgetApi,
         whiteboardInstance: whiteboardManager.getActiveWhiteboardInstance(),
+        themePaletteErrorMain: expect.any(String),
       });
     });
   });

--- a/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialogDownloadPdf.tsx
+++ b/packages/react-sdk/src/components/BoardBar/ExportWhiteboardDialogDownloadPdf.tsx
@@ -18,6 +18,7 @@ import { useWidgetApi } from '@matrix-widget-toolkit/react';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import { LoadingButton } from '@mui/lab';
 import { Tooltip, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { unstable_useId as useId, visuallyHidden } from '@mui/utils';
 import { getLogger } from 'loglevel';
 import { Dispatch, PropsWithChildren, useEffect, useState } from 'react';
@@ -86,6 +87,7 @@ function useGeneratePdf(
   roomName: string,
   onError?: Dispatch<string | undefined>,
 ) {
+  const theme = useTheme();
   const widgetApi = useWidgetApi();
 
   const [downloadUrl, setDownloadUrl] = useState<string>();
@@ -108,6 +110,7 @@ function useGeneratePdf(
       roomName,
       authorName,
       widgetApi,
+      themePaletteErrorMain: theme.palette.error.main,
     }).subscribe({
       next: (blob) => {
         url = URL.createObjectURL(blob);
@@ -138,6 +141,7 @@ function useGeneratePdf(
     widgetApi,
     widgetApi.widgetParameters.userId,
     widgetApi.widgetParameters.baseUrl,
+    theme.palette.error.main,
   ]);
 
   return downloadUrl;

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdf.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdf.ts
@@ -24,6 +24,7 @@ export function createWhiteboardPdf(params: {
   roomName: string;
   authorName: string;
   widgetApi: WidgetApi;
+  themePaletteErrorMain: string;
 }): Observable<Blob> {
   const contentObservable = from(createWhiteboardPdfDefinition(params));
 

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfContentSlide.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfContentSlide.ts
@@ -23,7 +23,8 @@ import { createWhiteboardPdfElementShape } from './createWhiteboardPdfElementSha
 
 export async function createWhiteboardPdfContentSlide(
   slideInstance: WhiteboardSlideInstance,
-  files?: Array<WhiteboardFileExport>,
+  files: Array<WhiteboardFileExport>,
+  noImageSvg: string,
 ): Promise<Content> {
   return await Promise.all(
     slideInstance.getElementIds().map(async (elementId) => {
@@ -36,12 +37,14 @@ export async function createWhiteboardPdfContentSlide(
         case 'path':
           return createWhiteboardPdfElementPath(element);
 
-        case 'image':
-          if (!files) {
-            console.error('No files provided for image element', element);
-            return [];
-          }
-          return await createWhiteboardPdfElementImage(element, files!);
+        case 'image': {
+          const file = files.find((f) => f.mxc === element.mxc);
+          return await createWhiteboardPdfElementImage(
+            element,
+            file,
+            noImageSvg,
+          );
+        }
 
         default:
           console.error('Unknown element type', element);

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfContentSlide.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfContentSlide.ts
@@ -20,10 +20,12 @@ import { WhiteboardFileExport } from '../../../state/export/whiteboardDocumentEx
 import { createWhiteboardPdfElementImage } from './createWhiteboardPdfElementImage';
 import { createWhiteboardPdfElementPath } from './createWhiteboardPdfElementPath';
 import { createWhiteboardPdfElementShape } from './createWhiteboardPdfElementShape';
+import { ThemeOptions } from './themeOptions';
 
 export async function createWhiteboardPdfContentSlide(
   slideInstance: WhiteboardSlideInstance,
   files: Array<WhiteboardFileExport>,
+  themeOptions: ThemeOptions,
   noImageSvg: string,
 ): Promise<Content> {
   return await Promise.all(
@@ -42,6 +44,7 @@ export async function createWhiteboardPdfContentSlide(
           return await createWhiteboardPdfElementImage(
             element,
             file,
+            themeOptions,
             noImageSvg,
           );
         }

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfDefinition.test.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfDefinition.test.ts
@@ -94,6 +94,7 @@ describe('createWhiteboardPdfDefinition', () => {
         roomName: 'My Room',
         authorName: 'Alice',
         widgetApi: mockWidgetApi(),
+        themePaletteErrorMain: '#d51928',
       }),
     ).toMatchSnapshot();
   });
@@ -109,6 +110,7 @@ describe('createWhiteboardPdfDefinition', () => {
       roomName: 'My Room',
       authorName: 'Alice',
       widgetApi: mockWidgetApi(),
+      themePaletteErrorMain: '#d51928',
     });
 
     expect(spy).toHaveBeenCalledWith('Noto Emoji');

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfDefinition.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfDefinition.ts
@@ -22,6 +22,7 @@ import { WhiteboardInstance } from '../../../state';
 import { whiteboardHeight, whiteboardWidth } from '../../Whiteboard';
 import { createWhiteboardPdfContentSlide } from './createWhiteboardPdfContentSlide';
 import { forceLoadFontFamily } from './forceLoadFontFamily';
+import { themeOptions } from './themeOptions';
 
 export async function createWhiteboardPdfDefinition({
   whiteboardInstance,
@@ -37,6 +38,9 @@ export async function createWhiteboardPdfDefinition({
   // make sure the font is loaded so the text size calculations are correct
   await forceLoadFontFamily('Noto Emoji');
   const whiteboardExport = await whiteboardInstance.export(widgetApi);
+  const noImageSvg = generateHideImageOutlinedSvg(
+    themeOptions.paletteErrorMain,
+  );
 
   return {
     pageMargins: 0,
@@ -51,7 +55,8 @@ export async function createWhiteboardPdfDefinition({
               stack: [
                 await createWhiteboardPdfContentSlide(
                   slide,
-                  whiteboardExport.whiteboard.files,
+                  whiteboardExport.whiteboard.files ?? [],
+                  noImageSvg,
                 ),
               ],
               pageBreak: idx > 0 ? 'before' : undefined,
@@ -73,4 +78,12 @@ export async function createWhiteboardPdfDefinition({
       author: authorName,
     },
   };
+}
+
+function generateHideImageOutlinedSvg(errorMainColor: string): string {
+  /**
+   * Same as MUI hide_image_outlined_24px.svg: https://github.com/mui/material-ui/blob/master/packages/mui-icons-material/material-icons/hide_image_outlined_24px.svg
+   * But with fill and fill-opacity added.
+   */
+  return `<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24" viewBox="0 0 24 24" width="24" fill="${errorMainColor}" fill-opacity="0.3"><g><rect fill="none" height="24" width="24"/></g><g><g><path d="M19,5v11.17l2,2V5c0-1.1-0.9-2-2-2H5.83l2,2H19z"/><path d="M2.81,2.81L1.39,4.22L3,5.83V19c0,1.1,0.9,2,2,2h13.17l1.61,1.61l1.41-1.41L2.81,2.81z M5,19V7.83l7.07,7.07L11.25,16 L9,13l-3,4h8.17l2,2H5z"/></g></g></svg>`;
 }

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfDefinition.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfDefinition.ts
@@ -22,25 +22,28 @@ import { WhiteboardInstance } from '../../../state';
 import { whiteboardHeight, whiteboardWidth } from '../../Whiteboard';
 import { createWhiteboardPdfContentSlide } from './createWhiteboardPdfContentSlide';
 import { forceLoadFontFamily } from './forceLoadFontFamily';
-import { themeOptions } from './themeOptions';
+import { ThemeOptions } from './themeOptions';
 
 export async function createWhiteboardPdfDefinition({
   whiteboardInstance,
   roomName,
   authorName,
   widgetApi,
+  themePaletteErrorMain,
 }: {
   whiteboardInstance: WhiteboardInstance;
   roomName: string;
   authorName: string;
   widgetApi: WidgetApi;
+  themePaletteErrorMain: string;
 }): Promise<TDocumentDefinitions> {
   // make sure the font is loaded so the text size calculations are correct
   await forceLoadFontFamily('Noto Emoji');
   const whiteboardExport = await whiteboardInstance.export(widgetApi);
-  const noImageSvg = generateHideImageOutlinedSvg(
-    themeOptions.paletteErrorMain,
-  );
+  const themeOptions: ThemeOptions = {
+    paletteErrorMain: themePaletteErrorMain,
+  };
+  const noImageSvg = generateHideImageOutlinedSvg(themePaletteErrorMain);
 
   return {
     pageMargins: 0,
@@ -56,6 +59,7 @@ export async function createWhiteboardPdfDefinition({
                 await createWhiteboardPdfContentSlide(
                   slide,
                   whiteboardExport.whiteboard.files ?? [],
+                  themeOptions,
                   noImageSvg,
                 ),
               ],

--- a/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfElementImage.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createWhiteboardPdfElementImage.ts
@@ -18,12 +18,13 @@ import log from 'loglevel';
 import { Content } from 'pdfmake/interfaces';
 import { ImageElement } from '../../../state';
 import { WhiteboardFileExport } from '../../../state/export/whiteboardDocumentExport';
-import { themeOptions } from './themeOptions';
+import { ThemeOptions } from './themeOptions';
 import { base64ToBlob, canvas, conv2png, image } from './utils';
 
 export async function createWhiteboardPdfElementImage(
   element: ImageElement,
   file: WhiteboardFileExport | undefined,
+  themeOptions: ThemeOptions,
   noImageSvg: string,
 ): Promise<Content> {
   if (file) {
@@ -37,12 +38,13 @@ export async function createWhiteboardPdfElementImage(
   } else {
     log.warn('No file provided, use placeholder for image element', element);
 
-    return createNoImageContent(element, noImageSvg);
+    return createNoImageContent(element, themeOptions, noImageSvg);
   }
 }
 
 async function createNoImageContent(
   element: ImageElement,
+  themeOptions: ThemeOptions,
   noImageSvg: string,
 ): Promise<Content> {
   const position = element.position;

--- a/packages/react-sdk/src/components/BoardBar/pdf/themeOptions.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/themeOptions.ts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-type ThemeOptions = {
+export type ThemeOptions = {
   paletteErrorMain: string;
-};
-
-export const themeOptions: ThemeOptions = {
-  paletteErrorMain: '#d51928',
 };

--- a/packages/react-sdk/src/components/BoardBar/pdf/themeOptions.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/themeOptions.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type ThemeOptions = {
+  paletteErrorMain: string;
+};
+
+export const themeOptions: ThemeOptions = {
+  paletteErrorMain: '#d51928',
+};

--- a/packages/react-sdk/src/components/BoardBar/pdf/utils.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/utils.ts
@@ -23,7 +23,7 @@ import {
   base64ToUint8Array,
   getSVGUnsafe,
 } from '../../../imageUtils';
-import { ImageElement, ShapeElement } from '../../../state';
+import { ImageElement, Point, ShapeElement } from '../../../state';
 import { ElementRenderProperties } from '../../Whiteboard';
 import { getTextSize } from '../../Whiteboard/ElementBehaviors/Text/fitText';
 
@@ -35,7 +35,14 @@ export function canvas(element: CanvasElement): Content {
   };
 }
 
-export function image(element: ImageElement, base64content: string): Content {
+export function image(
+  element: {
+    position: Point;
+    width: number;
+    height: number;
+  },
+  base64content: string,
+): Content {
   const mimeType = base64ToMimeType(base64content);
   const dataURL = 'data:' + mimeType + ';base64,' + base64content;
   return {
@@ -46,7 +53,7 @@ export function image(element: ImageElement, base64content: string): Content {
   };
 }
 
-function base64ToBlob(element: ImageElement, base64: string): Blob {
+export function base64ToBlob(element: ImageElement, base64: string): Blob {
   const decoded = atob(base64);
 
   const fileToImage = (base64: string) => {
@@ -98,10 +105,12 @@ function saveLoadImage(url: string): Promise<HTMLImageElement> {
 }
 
 export async function conv2png(
-  element: ImageElement,
-  base64content: string,
+  element: {
+    width: number;
+    height: number;
+  },
+  blob: Blob,
 ): Promise<string> {
-  const blob = base64ToBlob(element, base64content);
   const blobUrl = URL.createObjectURL(blob);
 
   const img = await saveLoadImage(blobUrl);


### PR DESCRIPTION
If image is not available due to some reason, then a placeholder is added for PDF export.

| NeoBoard  | PDF  |
|---|---|
|  <img width="400" alt="neoboard" src="https://github.com/user-attachments/assets/5032c4cc-56c5-4328-bb82-98dad7e247b0" /> |  <img width="400" alt="pdf" src="https://github.com/user-attachments/assets/2b45bc10-7cbf-40f2-8aaf-6fa8b9868875" /> |


<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
