### PR TITLE
Pasting text creates a rectangle with transparent background

### DIFF
--- a/.changeset/dragon-tiger-pagoda.md
+++ b/.changeset/dragon-tiger-pagoda.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+Pasting text creates a rectangle with a transparent instead of a white background

--- a/packages/react-sdk/src/components/Shortcuts/ClipboardShortcuts/ClipboardShortcuts.test.tsx
+++ b/packages/react-sdk/src/components/Shortcuts/ClipboardShortcuts/ClipboardShortcuts.test.tsx
@@ -218,7 +218,7 @@ describe('<CopyAndPasteShortcuts>', () => {
     expect(activeElementId).not.toBe('element-1');
     const activeElement = activeSlide.getElement(activeElementId!);
     expect(activeElement).toEqual({
-      fillColor: '#FFFFFF',
+      fillColor: 'transparent',
       height: 300,
       kind: 'rectangle',
       position: {

--- a/packages/react-sdk/src/components/Shortcuts/ClipboardShortcuts/serialization.test.ts
+++ b/packages/react-sdk/src/components/Shortcuts/ClipboardShortcuts/serialization.test.ts
@@ -76,7 +76,7 @@ describe('deserializeFromClipboard', () => {
     expect(content).toEqual({
       elements: [
         {
-          fillColor: '#FFFFFF',
+          fillColor: 'transparent',
           height: 300,
           kind: 'rectangle',
           position: { x: 660, y: 390 },
@@ -154,7 +154,7 @@ describe('deserializeFromPlainText', () => {
     expect(content).toEqual({
       elements: [
         {
-          fillColor: '#FFFFFF',
+          fillColor: 'transparent',
           height: 300,
           kind: 'rectangle',
           position: { x: 660, y: 390 },

--- a/packages/react-sdk/src/components/Shortcuts/ClipboardShortcuts/serialization.ts
+++ b/packages/react-sdk/src/components/Shortcuts/ClipboardShortcuts/serialization.ts
@@ -99,7 +99,7 @@ export function deserializeFromPlainText(
         height,
         width,
         text,
-        fillColor: '#FFFFFF',
+        fillColor: 'transparent',
       },
     ],
   };


### PR DESCRIPTION
## Before

![2025-01-17_18-23](https://github.com/user-attachments/assets/dc957f51-158b-4293-8577-f618e1edba7e)

## After

![2025-01-17_18-23_1](https://github.com/user-attachments/assets/4f3c4049-9d62-4c4c-b429-f6c9a3f12506)


**:heavy_check_mark: Checklist**

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] Listened to the Splatoon OST remixes while writing the code.
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
