### PR TITLE
Connect shapes with lines / arrows. Move and resize connected elements.

### DIFF
--- a/.changeset/poor-rings-tan.md
+++ b/.changeset/poor-rings-tan.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': minor
+'@nordeck/matrix-neoboard-widget': minor
+---
+
+Connect shapes with lines / arrows. Move and resize connected elements.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,6 @@ jobs:
         with:
           repository: nordeck/matrix-neoboard-standalone
           path: matrix-neoboard-standalone
-          ref: nic/feat/NEO-138-compiler-lib-option
           # required for changesets
           fetch-depth: '0'
           # don't persist the credentials so the changesets action doesn't use the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
         with:
           repository: nordeck/matrix-neoboard-standalone
           path: matrix-neoboard-standalone
+          ref: nic/feat/NEO-138-compiler-lib-option
           # required for changesets
           fetch-depth: '0'
           # don't persist the credentials so the changesets action doesn't use the

--- a/docs/model/crdt-documents.md
+++ b/docs/model/crdt-documents.md
@@ -137,7 +137,7 @@ An Element that has a shape attached, that has a text and a fill color.
 | `textItalic`     | `boolean \| undefined`                                                                             | Should the text have an italic formatting?                               |
 | `textSize`       | `number \| undefined`                                                                              | Font size of the text in CSS pixel unit, `undefined` for auto text size. |
 | `textFontFamily` | `'Inter' \| 'Abel' \| 'Actor' \| 'Adamina' \| 'Chewy' \| 'Gwendolyn' \| 'Pirata One' \| undefined` | The font family of the text. Defaults to `"Inter"`.                      |
-| `connectedPaths` | `string[] \| undefined`                                                                            | Ids of connected path elements. Currently lines can be connected         |
+| `connectedPaths` | `string[] \| undefined`                                                                            | IDs of connected path elements. Currently lines can be connected         |
 
 #### Example
 
@@ -167,8 +167,8 @@ An element that consists of points.
 | `points`                | `Point[]`                        | The points of the path in relative coordinates to its position.                                 |
 | `strokeColor`           | `string`                         | The stroke color of the path as [CSS color value][csscolor].                                    |
 | `endMarker`             | `'arrow-head-line' \| undefined` | An optional marker for the end of a path.                                                       |
-| `connectedElementStart` | `string \| undefined`            | The id of connected element on the first point. Currently shapes can be connected.              |
-| `connectedElementEnd`   | `string \| undefined`            | The id of connected element on the last point. Currently shapes can be connected.               |
+| `connectedElementStart` | `string \| undefined`            | The ID of connected element on the first point. Currently shapes can be connected.              |
+| `connectedElementEnd`   | `string \| undefined`            | The ID of connected element on the last point. Currently shapes can be connected.               |
 
 #### Example
 

--- a/docs/model/crdt-documents.md
+++ b/docs/model/crdt-documents.md
@@ -193,7 +193,8 @@ connections between the elements. These IDs are exported into nwb file and are l
 the same IDs in the CRDT document to the connected elements.
 
 A connection happens when a line end is dropped over a shape's connection point.
-For example, when a line start handle is dropped over the bottom right rectangle the following data is produced:
+For example, when a line start handle is dropped over the bottom right connection point of rectangle
+the following data is produced:
 
 Rectangle shape element with id: `E8LVfJCoYubKA-x2cuc0n`:
 

--- a/docs/model/crdt-documents.md
+++ b/docs/model/crdt-documents.md
@@ -119,25 +119,25 @@ An Element that has a shape attached, that has a text and a fill color.
 
 #### Fields
 
-| Field            | Type                                                                                               | Description                                                              |
-| ---------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `type`           | `'shape'`                                                                                          | Identifies the element as a shape.                                       |
-| `kind`           | `'rectangle' \| 'circle' \| 'ellipse' \| 'triangle'`                                               | The kind of shape, defining its look.                                    |
-| `position`       | `Point`                                                                                            | The position of the shape on the whiteboard canvas.                      |
-| `width`          | `number`                                                                                           | Scaling of the shape on the x-axis.                                      |
-| `height`         | `number`                                                                                           | Scaling of the shape on the y-axis.                                      |
-| `fillColor`      | `string`                                                                                           | The fill color of the shape as [CSS color value][csscolor].              |
-| `strokeColor`    | `string \| undefined`                                                                              | The border color of the shape as [CSS color value][csscolor].            |
-| `strokeWidth`    | `number \| undefined`                                                                              | The border width of the shape in pixels.                                 |
-| `borderRadius`   | `number \| undefined`                                                                              | The border radius of the shape in pixels.                                |
-| `text`           | `YText` / `string`                                                                                 | Text that is displayed in the shape.                                     |
-| `textAlignment`  | `'left' \| 'center' \| 'right' \| undefined`                                                       | The alignment of the text in the shape.                                  |
-| `textColor`      | `string \| undefined`                                                                              | The text color of the shape as [CSS color value][csscolor].              |
-| `textBold`       | `boolean \| undefined`                                                                             | Should the text have a bold formatting?                                  |
-| `textItalic`     | `boolean \| undefined`                                                                             | Should the text have an italic formatting?                               |
-| `textSize`       | `number \| undefined`                                                                              | Font size of the text in CSS pixel unit, `undefined` for auto text size. |
-| `textFontFamily` | `'Inter' \| 'Abel' \| 'Actor' \| 'Adamina' \| 'Chewy' \| 'Gwendolyn' \| 'Pirata One' \| undefined` | The font family of the text. Defaults to `"Inter"`.                      |
-| `connectedPaths` | `string[] \| undefined`                                                                            | IDs of connected path elements. Currently lines can be connected         |
+| Field            | Type                                                                                               | Description                                                                |
+| ---------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `type`           | `'shape'`                                                                                          | Identifies the element as a shape.                                         |
+| `kind`           | `'rectangle' \| 'circle' \| 'ellipse' \| 'triangle'`                                               | The kind of shape, defining its look.                                      |
+| `position`       | `Point`                                                                                            | The position of the shape on the whiteboard canvas.                        |
+| `width`          | `number`                                                                                           | Scaling of the shape on the x-axis.                                        |
+| `height`         | `number`                                                                                           | Scaling of the shape on the y-axis.                                        |
+| `fillColor`      | `string`                                                                                           | The fill color of the shape as [CSS color value][csscolor].                |
+| `strokeColor`    | `string \| undefined`                                                                              | The border color of the shape as [CSS color value][csscolor].              |
+| `strokeWidth`    | `number \| undefined`                                                                              | The border width of the shape in pixels.                                   |
+| `borderRadius`   | `number \| undefined`                                                                              | The border radius of the shape in pixels.                                  |
+| `text`           | `YText` / `string`                                                                                 | Text that is displayed in the shape.                                       |
+| `textAlignment`  | `'left' \| 'center' \| 'right' \| undefined`                                                       | The alignment of the text in the shape.                                    |
+| `textColor`      | `string \| undefined`                                                                              | The text color of the shape as [CSS color value][csscolor].                |
+| `textBold`       | `boolean \| undefined`                                                                             | Should the text have a bold formatting?                                    |
+| `textItalic`     | `boolean \| undefined`                                                                             | Should the text have an italic formatting?                                 |
+| `textSize`       | `number \| undefined`                                                                              | Font size of the text in CSS pixel unit, `undefined` for auto text size.   |
+| `textFontFamily` | `'Inter' \| 'Abel' \| 'Actor' \| 'Adamina' \| 'Chewy' \| 'Gwendolyn' \| 'Pirata One' \| undefined` | The font family of the text. Defaults to `"Inter"`.                        |
+| `connectedPaths` | `string[] \| undefined`                                                                            | The IDs of connected path elements. Currently only lines can be connected. |
 
 #### Example
 
@@ -188,10 +188,14 @@ An element that consists of points.
 
 ### Connected elements
 
-Connection happens when line end is dropped over shape's connection point.
-For example when line start handler is dropped over bottom right rectangle the following data is produced:
+An ID is generated for each element that is added to the CRDT document. These IDs are used as well to store the
+connections between the elements. These IDs are exported into nwb file and are loaded by import to assign
+the same IDs in the CRDT document to the connected elements.
 
-Rectangle shape with element id: `rectangle-id-1`:
+A connection happens when a line end is dropped over a shape's connection point.
+For example, when a line start handle is dropped over the bottom right rectangle the following data is produced:
+
+Rectangle shape element with id: `E8LVfJCoYubKA-x2cuc0n`:
 
 ```json
 {
@@ -202,11 +206,11 @@ Rectangle shape with element id: `rectangle-id-1`:
   "height": 200,
   "width": 200,
   "text": "Hello World",
-  "connectedPaths": ["line-id-1"]
+  "connectedPaths": ["jmU4s3M4aysDWiSVKAXI2"]
 }
 ```
 
-Line element with element id: `line-id-1`:
+Line element element with id: `jmU4s3M4aysDWiSVKAXI2`:
 
 ```json
 {
@@ -218,13 +222,14 @@ Line element with element id: `line-id-1`:
     { "x": 0, "y": 0 },
     { "x": 400, "y": 400 }
   ],
-  "connectedElementStart": "rectangle-id-1"
+  "connectedElementStart": "E8LVfJCoYubKA-x2cuc0n"
 }
 ```
 
-Application considers connections when operations (moving, resizing, etc) on elements are applied.
-For example a line connected to a shape will be automatically resized to be connected to the same point of the shape
-if shape element is moved. It is applied to resize and multiselect cases.
+The application considers connections when operations (moving, resizing, etc) on elements are applied.
+For example a line connected to a shape will be automatically resized and stay connected to the same point
+of the shape when the shape element is moved or resized. This behaviour is also applied when multiple items
+are selected.
 
 ### `ImageElement`
 

--- a/docs/model/crdt-documents.md
+++ b/docs/model/crdt-documents.md
@@ -137,6 +137,7 @@ An Element that has a shape attached, that has a text and a fill color.
 | `textItalic`     | `boolean \| undefined`                                                                             | Should the text have an italic formatting?                               |
 | `textSize`       | `number \| undefined`                                                                              | Font size of the text in CSS pixel unit, `undefined` for auto text size. |
 | `textFontFamily` | `'Inter' \| 'Abel' \| 'Actor' \| 'Adamina' \| 'Chewy' \| 'Gwendolyn' \| 'Pirata One' \| undefined` | The font family of the text. Defaults to `"Inter"`.                      |
+| `connectedPaths` | `string[] \| undefined`                                                                            | Ids of connected path elements. Currently lines can be connected         |
 
 #### Example
 
@@ -158,14 +159,16 @@ An element that consists of points.
 
 #### Fields
 
-| Field         | Type                             | Description                                                                                     |
-| ------------- | -------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `type`        | `'path'`                         | Identifies the element as a path.                                                               |
-| `kind`        | `'line' \| 'polyline'`           | The kind of path, either a straight `line` between two points or a `polyline` with many points. |
-| `position`    | `Point`                          | The position of the path on the whiteboard canvas.                                              |
-| `points`      | `Point[]`                        | The points of the path in relative coordinates to its position.                                 |
-| `strokeColor` | `string`                         | The stroke color of the path as [CSS color value][csscolor].                                    |
-| `endMarker`   | `'arrow-head-line' \| undefined` | An optional marker for the end of a path.                                                       |
+| Field                   | Type                             | Description                                                                                     |
+| ----------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `type`                  | `'path'`                         | Identifies the element as a path.                                                               |
+| `kind`                  | `'line' \| 'polyline'`           | The kind of path, either a straight `line` between two points or a `polyline` with many points. |
+| `position`              | `Point`                          | The position of the path on the whiteboard canvas.                                              |
+| `points`                | `Point[]`                        | The points of the path in relative coordinates to its position.                                 |
+| `strokeColor`           | `string`                         | The stroke color of the path as [CSS color value][csscolor].                                    |
+| `endMarker`             | `'arrow-head-line' \| undefined` | An optional marker for the end of a path.                                                       |
+| `connectedElementStart` | `string \| undefined`            | The id of connected element on the first point. Currently shapes can be connected.              |
+| `connectedElementEnd`   | `string \| undefined`            | The id of connected element on the last point. Currently shapes can be connected.               |
 
 #### Example
 
@@ -182,6 +185,46 @@ An element that consists of points.
   "endMarker": "arrow-head-line"
 }
 ```
+
+### Connected elements
+
+Connection happens when line end is dropped over shape's connection point.
+For example when line start handler is dropped over bottom right rectangle the following data is produced:
+
+Rectangle shape with element id: `rectangle-id-1`:
+
+```json
+{
+  "type": "shape",
+  "kind": "rectangle",
+  "position": { "x": 100, "y": 100 },
+  "fillColor": "#ffffff",
+  "height": 200,
+  "width": 200,
+  "text": "Hello World",
+  "connectedPaths": ["line-id-1"]
+}
+```
+
+Line element with element id: `line-id-1`:
+
+```json
+{
+  "type": "path",
+  "kind": "line",
+  "position": { "x": 300, "y": 300 },
+  "strokeColor": "#ffffff",
+  "points": [
+    { "x": 0, "y": 0 },
+    { "x": 400, "y": 400 }
+  ],
+  "connectedElementStart": "rectangle-id-1"
+}
+```
+
+Application considers connections when operations (moving, resizing, etc) on elements are applied.
+For example a line connected to a shape will be automatically resized to be connected to the same point of the shape
+if shape element is moved. It is applied to resize and multiselect cases.
 
 ### `ImageElement`
 

--- a/docs/model/export-format.md
+++ b/docs/model/export-format.md
@@ -2,9 +2,6 @@
 
 This document describes the data format of the files that can be exported from and imported into the whiteboard.
 The format is JSON-based and contains all slides and elements that are originally stored in the [CRDT Document Model][crdt-documents].
-The file won't include ID (slide or element) of the original document.
-They will be generated when the slides are added into an existing (or new) document.
-The exception is when elements are connected. In this case ids of elements are exported.
 
 ## Document
 

--- a/docs/model/export-format.md
+++ b/docs/model/export-format.md
@@ -2,8 +2,9 @@
 
 This document describes the data format of the files that can be exported from and imported into the whiteboard.
 The format is JSON-based and contains all slides and elements that are originally stored in the [CRDT Document Model][crdt-documents].
-The file won't include any ID (slide or element) of the original document.
+The file won't include ID (slide or element) of the original document.
 They will be generated when the slides are added into an existing (or new) document.
+The exception is when elements are connected. In this case ids of elements are exported.
 
 ## Document
 

--- a/packages/react-sdk/src/components/ConnectionPointProvider/ConnectionPointProvider.tsx
+++ b/packages/react-sdk/src/components/ConnectionPointProvider/ConnectionPointProvider.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createContext,
+  PropsWithChildren,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+type ConnectionPointContextType = {
+  /**
+   * Is true when start or end resize handler (current for a line only) is on drag, false otherwise.
+   */
+  isDragGoing: boolean;
+  setIsDragGoing: (value: boolean) => void;
+
+  /**
+   * Is an element id when handler is over element's connection point, undefined otherwise.
+   */
+  connectElementId: string | undefined;
+  setConnectElementId: (value: string | undefined) => void;
+};
+
+const ConnectionPointContext = createContext<
+  ConnectionPointContextType | undefined
+>(undefined);
+
+export function ConnectionPointProvider({ children }: PropsWithChildren) {
+  const [isDragGoing, setIsDragGoing] = useState(false);
+  const [connectElementId, setConnectElementId] = useState<string>();
+
+  const context = useMemo(
+    () => ({
+      isDragGoing,
+      setIsDragGoing,
+      connectElementId,
+      setConnectElementId,
+    }),
+    [connectElementId, isDragGoing],
+  );
+
+  return (
+    <ConnectionPointContext.Provider value={context}>
+      {children}
+    </ConnectionPointContext.Provider>
+  );
+}
+
+export function useConnectionPoint(): ConnectionPointContextType {
+  const context = useContext(ConnectionPointContext);
+
+  if (!context) {
+    throw new Error(
+      'useConnectionPoint can only be used inside of <ConnectionPointProvider>',
+    );
+  }
+
+  return context;
+}

--- a/packages/react-sdk/src/components/ConnectionPointProvider/ConnectionPointProvider.tsx
+++ b/packages/react-sdk/src/components/ConnectionPointProvider/ConnectionPointProvider.tsx
@@ -24,10 +24,10 @@ import {
 
 type ConnectionPointContextType = {
   /**
-   * Is true when start or end resize handle (current for a line only) is on drag, false otherwise.
+   * Is true when start or end resize handle (currently for a line only) is on drag, false otherwise.
    */
-  isDragGoing: boolean;
-  setIsDragGoing: (value: boolean) => void;
+  isHandleDragging: boolean;
+  setIsHandleDragging: (value: boolean) => void;
 
   /**
    * Is an element id when handle is over element's connection point, undefined otherwise.
@@ -41,17 +41,17 @@ const ConnectionPointContext = createContext<
 >(undefined);
 
 export function ConnectionPointProvider({ children }: PropsWithChildren) {
-  const [isDragGoing, setIsDragGoing] = useState(false);
+  const [isHandleDragging, setIsHandleDragging] = useState(false);
   const [connectElementId, setConnectElementId] = useState<string>();
 
   const context = useMemo(
     () => ({
-      isDragGoing,
-      setIsDragGoing,
+      isHandleDragging,
+      setIsHandleDragging,
       connectElementId,
       setConnectElementId,
     }),
-    [connectElementId, isDragGoing],
+    [connectElementId, isHandleDragging],
   );
 
   return (

--- a/packages/react-sdk/src/components/ConnectionPointProvider/ConnectionPointProvider.tsx
+++ b/packages/react-sdk/src/components/ConnectionPointProvider/ConnectionPointProvider.tsx
@@ -24,13 +24,13 @@ import {
 
 type ConnectionPointContextType = {
   /**
-   * Is true when start or end resize handler (current for a line only) is on drag, false otherwise.
+   * Is true when start or end resize handle (current for a line only) is on drag, false otherwise.
    */
   isDragGoing: boolean;
   setIsDragGoing: (value: boolean) => void;
 
   /**
-   * Is an element id when handler is over element's connection point, undefined otherwise.
+   * Is an element id when handle is over element's connection point, undefined otherwise.
    */
   connectElementId: string | undefined;
   setConnectElementId: (value: string | undefined) => void;

--- a/packages/react-sdk/src/components/ConnectionPointProvider/index.ts
+++ b/packages/react-sdk/src/components/ConnectionPointProvider/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Nordeck IT + Consulting GmbH
+ * Copyright 2025 Nordeck IT + Consulting GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-export * from './Connectable';
-export * from './ContextMenu';
-export * from './Moveable';
-export * from './Resizable';
-export * from './Selection';
-export * from './Text';
-export { getPathElements } from './utils';
+export {
+  ConnectionPointProvider,
+  useConnectionPoint,
+} from './ConnectionPointProvider';

--- a/packages/react-sdk/src/components/ElementOverridesProvider/ElementOverridesProvider.test.tsx
+++ b/packages/react-sdk/src/components/ElementOverridesProvider/ElementOverridesProvider.test.tsx
@@ -421,6 +421,80 @@ describe('useElementOverride', () => {
       },
     });
   });
+
+  it('should clean all the overrides', () => {
+    const { result } = renderHook(
+      () => {
+        const elements = useElementOverrides(['element-1', 'element-2']);
+        const setElementOverride = useSetElementOverride();
+        return { elements, setElementOverride };
+      },
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      result.current.setElementOverride([
+        {
+          elementId: 'element-1',
+          elementOverride: { height: 10 },
+        },
+        {
+          elementId: 'element-2',
+          elementOverride: { width: 10 },
+        },
+      ]);
+    });
+
+    expect(result.current.elements).toEqual({
+      'element-1': {
+        type: 'shape',
+        kind: 'ellipse',
+        fillColor: '#ffffff',
+        textFontFamily: 'Inter',
+        text: 'Element 1',
+        position: { x: 0, y: 1 },
+        height: 10,
+        width: 50,
+      },
+      'element-2': {
+        type: 'shape',
+        kind: 'ellipse',
+        fillColor: '#ffffff',
+        textFontFamily: 'Inter',
+        text: 'Element 2',
+        position: { x: 0, y: 201 },
+        height: 100,
+        width: 10,
+      },
+    });
+
+    act(() => {
+      result.current.setElementOverride(undefined);
+    });
+
+    expect(result.current.elements).toEqual({
+      'element-1': {
+        type: 'shape',
+        kind: 'ellipse',
+        fillColor: '#ffffff',
+        textFontFamily: 'Inter',
+        text: 'Element 1',
+        position: { x: 0, y: 1 },
+        height: 100,
+        width: 50,
+      },
+      'element-2': {
+        type: 'shape',
+        kind: 'ellipse',
+        fillColor: '#ffffff',
+        textFontFamily: 'Inter',
+        text: 'Element 2',
+        position: { x: 0, y: 201 },
+        height: 100,
+        width: 50,
+      },
+    });
+  });
 });
 
 describe('createResetElementOverrides', () => {

--- a/packages/react-sdk/src/components/ElementOverridesProvider/ElementOverridesProvider.tsx
+++ b/packages/react-sdk/src/components/ElementOverridesProvider/ElementOverridesProvider.tsx
@@ -35,6 +35,7 @@ export const ElementOverrideGetterContext =
 export type ElementOverrideUpdate = {
   elementId: string;
   elementOverride: ElementOverride | undefined;
+  pathElementDisconnectElements?: string[];
 };
 
 export function createResetElementOverrides(
@@ -46,7 +47,9 @@ export function createResetElementOverrides(
   }));
 }
 
-export type ElementOverrideSetter = (updates: ElementOverrideUpdate[]) => void;
+export type ElementOverrideSetter = (
+  updates: ElementOverrideUpdate[] | undefined,
+) => void;
 export const ElementOverrideSetterContext =
   createContext<ElementOverrideSetter>(() => {});
 
@@ -60,21 +63,29 @@ export function ElementOverridesProvider({ children }: PropsWithChildren<{}>) {
     [elementOverrides],
   );
 
-  const setElementOverride = useCallback((updates: ElementOverrideUpdate[]) => {
-    setElementOverrides((old) => {
-      const newState = { ...old };
-
-      for (const { elementId, elementOverride } of updates) {
-        if (elementOverride) {
-          newState[elementId] = elementOverride;
-        } else {
-          delete newState[elementId];
-        }
+  const setElementOverride = useCallback(
+    (updates: ElementOverrideUpdate[] | undefined) => {
+      if (updates === undefined) {
+        setElementOverrides({});
+        return;
       }
 
-      return newState;
-    });
-  }, []);
+      setElementOverrides((old) => {
+        const newState = { ...old };
+
+        for (const { elementId, elementOverride } of updates) {
+          if (elementOverride) {
+            newState[elementId] = elementOverride;
+          } else {
+            delete newState[elementId];
+          }
+        }
+
+        return newState;
+      });
+    },
+    [],
+  );
 
   return (
     <ElementOverrideSetterContext.Provider value={setElementOverride}>

--- a/packages/react-sdk/src/components/ElementOverridesProvider/ElementOverridesProvider.tsx
+++ b/packages/react-sdk/src/components/ElementOverridesProvider/ElementOverridesProvider.tsx
@@ -35,7 +35,6 @@ export const ElementOverrideGetterContext =
 export type ElementOverrideUpdate = {
   elementId: string;
   elementOverride: ElementOverride | undefined;
-  pathElementDisconnectElements?: string[];
 };
 
 export function createResetElementOverrides(

--- a/packages/react-sdk/src/components/Layout/Layout.tsx
+++ b/packages/react-sdk/src/components/Layout/Layout.tsx
@@ -27,6 +27,7 @@ import {
 import { usePowerLevels } from '../../store/api/usePowerLevels';
 import { BoardBar } from '../BoardBar';
 import { CollaborationBar } from '../CollaborationBar';
+import { ConnectionPointProvider } from '../ConnectionPointProvider';
 import { DeveloperToolsDialog } from '../DeveloperTools';
 import { ElementOverridesProvider } from '../ElementOverridesProvider';
 import { FullscreenModeBar } from '../FullscreenModeBar';
@@ -113,8 +114,10 @@ export function Layout({ height = '100vh' }: LayoutProps) {
                 <TabPanelStyled value={slideId} key={slideId}>
                   <SlideProvider slideId={slideId}>
                     <ElementOverridesProvider>
-                      <ContentArea />
-                      {uploadDragOverlay}
+                      <ConnectionPointProvider>
+                        <ContentArea />
+                        {uploadDragOverlay}
+                      </ConnectionPointProvider>
                     </ElementOverridesProvider>
                   </SlideProvider>
                 </TabPanelStyled>

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Connectable/ActivationArea.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Connectable/ActivationArea.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ShapeKind } from '../../../../state';
+
+export function ActivationArea({
+  elementId,
+  kind,
+  x,
+  y,
+  width,
+  height,
+}: {
+  elementId: string;
+  kind: ShapeKind;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}) {
+  const shapeMargin = 40;
+
+  if (kind === 'circle' || kind === 'ellipse') {
+    return (
+      <ellipse
+        data-connect-type={`activation-area`}
+        data-connect-element-id={elementId}
+        cx={x + width / 2}
+        cy={y + height / 2}
+        fill="transparent"
+        rx={width / 2 + shapeMargin}
+        ry={height / 2 + shapeMargin}
+      />
+    );
+  } else if (kind === 'rectangle') {
+    return (
+      <rect
+        data-connect-type={`activation-area`}
+        data-connect-element-id={elementId}
+        x={x - shapeMargin}
+        y={y - shapeMargin}
+        width={width + 2 * shapeMargin}
+        height={height + 2 * shapeMargin}
+        fill="transparent"
+      />
+    );
+  } else if (kind === 'triangle') {
+    const { dx, dy } = scaleTriangle(width / 2, height, shapeMargin);
+
+    const p0X = x - dx;
+    const p0Y = y + height + shapeMargin;
+    const p1X = x + width / 2;
+    const p1Y = y - dy;
+    const p2X = x + width + dx;
+    const p2Y = y + height + shapeMargin;
+
+    return (
+      <polygon
+        data-connect-type={`activation-area`}
+        data-connect-element-id={elementId}
+        fill="transparent"
+        points={`${p0X},${p0Y} ${p1X},${p1Y} ${p2X},${p2Y}`}
+      />
+    );
+  } else {
+    return null;
+  }
+}
+
+function scaleTriangle(
+  w: number,
+  h: number,
+  margin: number,
+): { dx: number; dy: number } {
+  const w1 = (w * (h + margin)) / h;
+  const sin =
+    (h + margin) / Math.pow((h + margin) * (h + margin) + w1 * w1, 0.5);
+  const h1 = w1 * sin;
+  const dy = (margin * (h + margin)) / h1;
+  const h2 = (w1 - w) * sin;
+  const dx = ((w1 - w) * (h2 + margin)) / h2;
+  return { dx, dy };
+}

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Connectable/ConnectableElement.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Connectable/ConnectableElement.tsx
@@ -20,6 +20,7 @@ import { isDefined } from '../../../../lib';
 import { ShapeElement } from '../../../../state';
 import { useConnectionPoint } from '../../../ConnectionPointProvider';
 import { useSvgCanvasContext } from '../../SvgCanvas';
+import { ActivationArea } from './ActivationArea';
 
 type ConnectableElementProps = {
   elementId: string;
@@ -28,22 +29,18 @@ type ConnectableElementProps = {
 
 export function ConnectableElement({
   elementId,
-  element,
+  element: {
+    kind,
+    position: { x, y },
+    width,
+    height,
+  },
 }: ConnectableElementProps) {
   const theme = useTheme();
   const { scale } = useSvgCanvasContext();
 
-  const x = element.position.x;
-  const y = element.position.y;
-  const width = element.width;
-  const height = element.height;
-
   const [showConnectionAnchors, setShowConnectionAnchors] =
     useState<boolean>(false);
-
-  const kind = element.kind;
-
-  const shapeMargin = 40;
 
   const areaSize = 20 / scale;
 
@@ -80,14 +77,13 @@ export function ConnectableElement({
 
   return (
     <>
-      <rect
-        data-connect-type={`activation-area`}
-        data-connect-element-id={elementId}
-        x={x - shapeMargin}
-        y={y - shapeMargin}
-        width={width + 2 * shapeMargin}
-        height={height + 2 * shapeMargin}
-        fill="transparent"
+      <ActivationArea
+        elementId={elementId}
+        kind={kind}
+        x={x}
+        y={y}
+        width={width}
+        height={height}
       />
 
       {points.map(([pointX, pointY], idx) => (

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Connectable/ConnectableElement.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Connectable/ConnectableElement.tsx
@@ -42,7 +42,7 @@ export function ConnectableElement({
   const [showConnectionAnchors, setShowConnectionAnchors] =
     useState<boolean>(false);
 
-  const areaSize = 20 / scale;
+  const connectionPointAreaSize = 20 / scale;
 
   const connectionAnchorBorderWidth = 2 / scale;
   const connectionAnchorSize = 5 / scale;
@@ -91,10 +91,10 @@ export function ConnectableElement({
           <rect
             data-connect-type="connection-point-area"
             data-connect-element-id={elementId}
-            x={pointX - areaSize / 2}
-            y={pointY - areaSize / 2}
-            width={areaSize}
-            height={areaSize}
+            x={pointX - connectionPointAreaSize / 2}
+            y={pointY - connectionPointAreaSize / 2}
+            width={connectionPointAreaSize}
+            height={connectionPointAreaSize}
             fill="transparent"
           />
 

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Connectable/ConnectableElement.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Connectable/ConnectableElement.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useTheme } from '@mui/material';
+import { Fragment, useEffect, useMemo, useState } from 'react';
+import { isDefined } from '../../../../lib';
+import { ShapeElement } from '../../../../state';
+import { useConnectionPoint } from '../../../ConnectionPointProvider';
+import { useSvgCanvasContext } from '../../SvgCanvas';
+
+type ConnectableElementProps = {
+  elementId: string;
+  element: ShapeElement;
+};
+
+export function ConnectableElement({
+  elementId,
+  element,
+}: ConnectableElementProps) {
+  const theme = useTheme();
+  const { scale } = useSvgCanvasContext();
+
+  const x = element.position.x;
+  const y = element.position.y;
+  const width = element.width;
+  const height = element.height;
+
+  const [showConnectionAnchors, setShowConnectionAnchors] =
+    useState<boolean>(false);
+
+  const kind = element.kind;
+
+  const shapeMargin = 40;
+
+  const areaSize = 20 / scale;
+
+  const connectionAnchorBorderWidth = 2 / scale;
+  const connectionAnchorSize = 5 / scale;
+  const connectionAnchorCornerRadius = 3 / 2 / scale;
+
+  const { connectElementId } = useConnectionPoint();
+
+  useEffect(() => {
+    setShowConnectionAnchors(elementId === connectElementId);
+  }, [connectElementId, elementId]);
+
+  const points = useMemo(
+    () =>
+      [
+        kind === 'rectangle' ? [x, y] : undefined,
+        [x + width / 2, y],
+        kind === 'rectangle' ? [x + width, y] : undefined,
+        kind !== 'triangle' ? [x, y + height / 2] : undefined,
+        kind !== 'triangle' ? [x + width, y + height / 2] : undefined,
+        kind === 'triangle' ? [x + width / 4, y + height / 2] : undefined,
+        kind === 'triangle' ? [x + (width * 3) / 4, y + height / 2] : undefined,
+        kind === 'rectangle' || kind === 'triangle'
+          ? [x, y + height]
+          : undefined,
+        [x + width / 2, y + height],
+        kind === 'rectangle' || kind === 'triangle'
+          ? [x + width, y + height]
+          : undefined,
+      ].filter(isDefined),
+    [x, y, height, width, kind],
+  );
+
+  return (
+    <>
+      <rect
+        data-connect-type={`activation-area`}
+        data-connect-element-id={elementId}
+        x={x - shapeMargin}
+        y={y - shapeMargin}
+        width={width + 2 * shapeMargin}
+        height={height + 2 * shapeMargin}
+        fill="transparent"
+      />
+
+      {points.map(([pointX, pointY], idx) => (
+        <Fragment key={idx}>
+          <rect
+            data-connect-type="connection-point-area"
+            data-connect-element-id={elementId}
+            x={pointX - areaSize / 2}
+            y={pointY - areaSize / 2}
+            width={areaSize}
+            height={areaSize}
+            fill="transparent"
+          />
+
+          {showConnectionAnchors && (
+            <rect
+              data-connect-type="connection-point"
+              data-connect-element-id={elementId}
+              x={pointX - connectionAnchorSize / 2}
+              y={pointY - connectionAnchorSize / 2}
+              width={connectionAnchorSize}
+              height={connectionAnchorSize}
+              fill="white"
+              stroke={theme.palette.primary.main}
+              strokeWidth={connectionAnchorBorderWidth}
+              rx={connectionAnchorCornerRadius}
+              ry={connectionAnchorCornerRadius}
+            />
+          )}
+        </Fragment>
+      ))}
+    </>
+  );
+}

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Connectable/index.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Connectable/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Nordeck IT + Consulting GmbH
+ * Copyright 2025 Nordeck IT + Consulting GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,4 @@
  * limitations under the License.
  */
 
-export * from './Connectable';
-export * from './ContextMenu';
-export * from './Moveable';
-export * from './Resizable';
-export * from './Selection';
-export * from './Text';
-export { getPathElements } from './utils';
+export { ConnectableElement } from './ConnectableElement';

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Moveable/types.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Moveable/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Nordeck IT + Consulting GmbH
+ * Copyright 2025 Nordeck IT + Consulting GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-export * from './Connectable';
-export * from './ContextMenu';
-export * from './Moveable';
-export * from './Resizable';
-export * from './Selection';
-export * from './Text';
-export { getPathElements } from './utils';
+import { PathElement } from '../../../../state';
+import { BoundingRect } from '../../../../state/crdt/documents/point';
+
+export type ResizableProperties = {
+  boundingRect: BoundingRect;
+  connectingPathElements: Record<string, PathElement>;
+};

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Moveable/utils.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Moveable/utils.ts
@@ -15,15 +15,21 @@
  */
 
 import { clamp } from 'lodash';
+import { isDefined } from '../../../../lib';
 import {
   calculateBoundingRectForElements,
   PathElement,
 } from '../../../../state/crdt/documents/elements';
-import { BoundingRect } from '../../../../state/crdt/documents/point';
+import { BoundingRect, Point } from '../../../../state/crdt/documents/point';
 import { Elements } from '../../../../state/types';
 import { ElementOverrideUpdate } from '../../../ElementOverridesProvider';
-import { computeResizingConnectingPathElements } from '../Resizable';
-import { pathElementGetConnectedNotSelectedElements } from '../utils';
+import { ElementOverride } from '../../../ElementOverridesProvider/ElementOverridesProvider';
+import { snapToGrid } from '../../Grid';
+import { gridCellSize } from '../../constants';
+import {
+  computeResizingConnectingPathElementOverDeltaPoints,
+  computeResizingConnectingPathElements,
+} from '../Resizable';
 
 export function calculateElementOverrideUpdates(
   elements: Elements,
@@ -44,7 +50,7 @@ export function calculateElementOverrideUpdates(
   const rectX = offsetX + deltaX;
   const rectY = offsetY + deltaY;
 
-  const res: ElementOverrideUpdate[] = Object.entries(elements).map(
+  const overrides: ElementOverrideUpdate[] = Object.entries(elements).map(
     ([elemId, element]) => {
       const x = element.position.x + deltaX;
       const y = element.position.y + deltaY;
@@ -61,31 +67,102 @@ export function calculateElementOverrideUpdates(
             ),
           },
         },
-        pathElementDisconnectElements:
-          pathElementGetConnectedNotSelectedElements(element, elements),
       };
     },
   );
 
   if (connectingPathElements && boundingRect) {
-    const otherOvers = computeResizingConnectingPathElements(
-      connectingPathElements,
-      elements,
-      {
-        x: boundingRect.offsetX,
-        y: boundingRect.offsetY,
-        width: boundingRect.width,
-        height: boundingRect.height,
-      },
-      {
-        x: rectX,
-        y: rectY,
-        width: rectWidth,
-        height: rectHeight,
-      },
+    overrides.push(
+      ...computeResizingConnectingPathElements(
+        connectingPathElements,
+        elements,
+        {
+          x: boundingRect.offsetX,
+          y: boundingRect.offsetY,
+          width: boundingRect.width,
+          height: boundingRect.height,
+        },
+        {
+          x: rectX,
+          y: rectY,
+          width: rectWidth,
+          height: rectHeight,
+        },
+      ),
     );
-    res.push(...otherOvers);
   }
 
-  return res;
+  return overrides;
+}
+
+export function snapToGridElementOverrideUpdates(
+  elementOverrideUpdates: ElementOverrideUpdate[],
+  elements: Elements,
+  connectingPathElements: Record<string, PathElement>,
+): ElementOverrideUpdate[] {
+  return elementOverrideUpdates.map(({ elementId, elementOverride }) => {
+    let pathElement: PathElement | undefined;
+    if (elements[elementId]?.type === 'path') {
+      pathElement = elements[elementId];
+    } else if (connectingPathElements[elementId]) {
+      pathElement = connectingPathElements[elementId];
+    }
+
+    if (
+      pathElement &&
+      (pathElement.connectedElementStart || pathElement.connectedElementEnd) &&
+      elementOverride
+    ) {
+      const deltaPoints: (Point | undefined)[] = [];
+      const connectedElements = [
+        pathElement.connectedElementStart,
+        pathElement.connectedElementEnd,
+      ];
+      for (let i = 0; i < connectedElements.length; i++) {
+        const connectedElementId = connectedElements[i];
+
+        const connectedElement = connectedElementId
+          ? elements[connectedElementId]
+          : undefined;
+
+        if (connectedElement) {
+          deltaPoints.push({
+            x:
+              snapToGrid(connectedElement.position.x, gridCellSize) -
+              connectedElement.position.x,
+            y:
+              snapToGrid(connectedElement.position.y, gridCellSize) -
+              connectedElement.position.y,
+          });
+        } else {
+          deltaPoints.push(undefined);
+        }
+      }
+
+      let newOverride: ElementOverride;
+      if (deltaPoints.filter(isDefined).length > 0) {
+        newOverride = computeResizingConnectingPathElementOverDeltaPoints(
+          {
+            position: elementOverride.position ?? pathElement.position,
+            points: elementOverride.points ?? pathElement.points,
+          },
+          deltaPoints,
+        );
+      } else {
+        const x = snapToGrid(pathElement.position.x, gridCellSize);
+        const y = snapToGrid(pathElement.position.y, gridCellSize);
+        newOverride = { position: { x, y } };
+      }
+
+      return {
+        elementId,
+        elementOverride: newOverride,
+      };
+    } else {
+      const element = elements[elementId];
+      const x = snapToGrid(element.position.x, gridCellSize);
+      const y = snapToGrid(element.position.y, gridCellSize);
+      return { elementId, elementOverride: { position: { x, y } } };
+    }
+  });
 }

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeElement.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeElement.test.tsx
@@ -18,7 +18,15 @@ import { MockedWidgetApi, mockWidgetApi } from '@matrix-widget-toolkit/testing';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { ComponentType, PropsWithChildren } from 'react';
 import { useStore } from 'react-redux';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import {
   WhiteboardTestingContextProvider,
   mockImageElement,
@@ -29,6 +37,7 @@ import {
 } from '../../../../lib/testUtils/documentTestUtils';
 import { WhiteboardSlideInstance } from '../../../../state';
 import { StoreType } from '../../../../store';
+import { ConnectionPointProvider } from '../../../ConnectionPointProvider';
 import { ElementOverridesProvider } from '../../../ElementOverridesProvider';
 import { LayoutStateProvider } from '../../../Layout';
 import { SvgCanvas } from '../../SvgCanvas';
@@ -56,6 +65,10 @@ vi.mock('../../SvgCanvas/useMeasure', () => {
       },
     ],
   };
+});
+
+beforeAll(() => {
+  document.elementFromPoint = vi.fn();
 });
 
 describe('<ResizeElement />', () => {
@@ -116,13 +129,17 @@ describe('<ResizeElement />', () => {
         >
           <ExtractStore />
           <ElementOverridesProvider>
-            <SvgCanvas viewportWidth={200} viewportHeight={200}>
-              {children}
-            </SvgCanvas>
+            <ConnectionPointProvider>
+              <SvgCanvas viewportWidth={200} viewportHeight={200}>
+                {children}
+              </SvgCanvas>
+            </ConnectionPointProvider>
           </ElementOverridesProvider>
         </WhiteboardTestingContextProvider>
       </LayoutStateProvider>
     );
+
+    // vi.spyOn(document, 'append123');
   });
 
   afterEach(() => {

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeElement.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeElement.test.tsx
@@ -138,8 +138,6 @@ describe('<ResizeElement />', () => {
         </WhiteboardTestingContextProvider>
       </LayoutStateProvider>
     );
-
-    // vi.spyOn(document, 'append123');
   });
 
   afterEach(() => {

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeElement.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeElement.tsx
@@ -36,11 +36,7 @@ import { useLayoutState } from '../../../Layout';
 import { getRenderProperties } from '../../../elements/line/getRenderProperties';
 import { useSvgCanvasContext } from '../../SvgCanvas';
 import { gridCellSize } from '../../constants';
-import {
-  elementsWithUpdates,
-  getPathElements,
-  lineResizeUpdates,
-} from '../utils';
+import { elementsUpdates, getPathElements, lineResizeUpdates } from '../utils';
 import { DragEvent, ResizeHandle } from './ResizeHandle';
 import { HandlePosition, ResizableProperties } from './types';
 import { computeResizing } from './utils';
@@ -164,36 +160,11 @@ export function ResizeElement({ elementIds }: ResizeElementProps) {
           connectToElementId,
         );
       } else {
-        const newElements = elementsWithUpdates(
+        updates = elementsUpdates(
           slideInstance,
           elements,
           elementOverrideUpdates,
         );
-
-        updates = Object.entries(newElements).map(([elementId, element]) => {
-          return {
-            elementId,
-            patch: {
-              position: element.position,
-              width:
-                element.type === 'shape' || element.type === 'image'
-                  ? element.width
-                  : undefined,
-              height:
-                element.type === 'shape' || element.type === 'image'
-                  ? element.height
-                  : undefined,
-              points: element.type === 'path' ? element.points : undefined,
-              ...(element.type === 'path' && {
-                connectedElementStart: element.connectedElementStart,
-                connectedElementEnd: element.connectedElementEnd,
-              }),
-              ...(element.type === 'shape' && {
-                connectedPaths: element.connectedPaths,
-              }),
-            },
-          };
-        });
       }
 
       slideInstance.updateElements(updates);

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeElement.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeElement.tsx
@@ -214,7 +214,7 @@ export function ResizeElement({ elementIds }: ResizeElementProps) {
       }
 
       setResizableProperties(undefined);
-      setElementOverride(createResetElementOverrides(Object.keys(elements)));
+      setElementOverride(undefined);
     },
     [
       dispatch,

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeElement.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeElement.tsx
@@ -18,13 +18,17 @@ import { Dispatch, useCallback, useState } from 'react';
 import { useUnmount } from 'react-use';
 import {
   calculateBoundingRectForElements,
+  findConnectingPaths,
+  PathElement,
   useWhiteboardSlideInstance,
 } from '../../../../state';
+import { ElementUpdate } from '../../../../state/types';
 import { useAppDispatch } from '../../../../store';
 import { setShapeSize } from '../../../../store/shapeSizesSlide';
+import { useConnectionPoint } from '../../../ConnectionPointProvider';
 import {
-  ElementOverrideUpdate,
   createResetElementOverrides,
+  ElementOverrideUpdate,
   useElementOverrides,
   useSetElementOverride,
 } from '../../../ElementOverridesProvider';
@@ -32,6 +36,11 @@ import { useLayoutState } from '../../../Layout';
 import { getRenderProperties } from '../../../elements/line/getRenderProperties';
 import { useSvgCanvasContext } from '../../SvgCanvas';
 import { gridCellSize } from '../../constants';
+import {
+  elementsWithUpdates,
+  getPathElements,
+  lineResizeUpdates,
+} from '../utils';
 import { DragEvent, ResizeHandle } from './ResizeHandle';
 import { HandlePosition, ResizableProperties } from './types';
 import { computeResizing } from './utils';
@@ -56,6 +65,7 @@ export function ResizeHandleWrapper({
 }: ResizeHandleWrapperProps) {
   const { isShowGrid } = useLayoutState();
   const { viewportWidth, viewportHeight } = useSvgCanvasContext();
+  const { connectElementId } = useConnectionPoint();
 
   const handleDrag = useCallback(
     (event: DragEvent) => {
@@ -66,7 +76,7 @@ export function ResizeHandleWrapper({
           viewportWidth,
           viewportHeight,
           invertLockAspectRatio,
-          isShowGrid ? gridCellSize : undefined,
+          isShowGrid && !connectElementId ? gridCellSize : undefined,
           resizableProperties,
         ),
       );
@@ -79,6 +89,7 @@ export function ResizeHandleWrapper({
       resizableProperties,
       viewportHeight,
       viewportWidth,
+      connectElementId,
     ],
   );
 
@@ -105,6 +116,9 @@ export function ResizeElement({ elementIds }: ResizeElementProps) {
 
   const [resizableProperties, setResizableProperties] =
     useState<ResizableProperties>();
+  const [elementOverrideUpdates, setElementOverrideUpdates] = useState<
+    ElementOverrideUpdate[]
+  >([]);
 
   useUnmount(() => {
     if (resizableProperties) {
@@ -121,52 +135,101 @@ export function ResizeElement({ elementIds }: ResizeElementProps) {
       width: boundingRect.width,
       height: boundingRect.height,
       elements,
+      connectingPathElements: getPathElements(
+        slideInstance,
+        findConnectingPaths(elements),
+      ),
     });
-  }, [activeElements, elements]);
+  }, [activeElements, elements, slideInstance]);
 
-  const handleDragStop = useCallback(() => {
-    slideInstance.updateElements(
-      Object.entries(elements).map(([elementId, element]) => {
-        return {
+  const handleDragStop = useCallback(
+    ({ connectData }: DragEvent) => {
+      let updates: ElementUpdate[];
+      if (
+        Object.values(elements).length === 1 &&
+        Object.values(elements)[0].type === 'path' &&
+        connectData
+      ) {
+        const elementId = Object.keys(elements)[0];
+        const element = Object.values(elements)[0] as PathElement;
+
+        const position = connectData.resizePositionName;
+        const connectToElementId = connectData.connectToElementId;
+
+        updates = lineResizeUpdates(
+          slideInstance,
           elementId,
-          patch: {
-            position: element.position,
-            width:
-              element.type === 'shape' || element.type === 'image'
-                ? element.width
-                : undefined,
-            height:
-              element.type === 'shape' || element.type === 'image'
-                ? element.height
-                : undefined,
-            points: element.type === 'path' ? element.points : undefined,
-          },
-        };
-      }),
-    );
+          element,
+          position,
+          connectToElementId,
+        );
+      } else {
+        const newElements = elementsWithUpdates(
+          slideInstance,
+          elements,
+          elementOverrideUpdates,
+        );
 
-    if (Object.values(elements).length === 1) {
-      const element = Object.values(elements)[0];
-
-      if (element.type === 'shape') {
-        // If the element is a shape, update last size in the store
-
-        const shapeSize = {
-          width: element.width,
-          height: element.height,
-        };
-
-        dispatch(setShapeSize({ kind: element.kind, size: shapeSize }));
+        updates = Object.entries(newElements).map(([elementId, element]) => {
+          return {
+            elementId,
+            patch: {
+              position: element.position,
+              width:
+                element.type === 'shape' || element.type === 'image'
+                  ? element.width
+                  : undefined,
+              height:
+                element.type === 'shape' || element.type === 'image'
+                  ? element.height
+                  : undefined,
+              points: element.type === 'path' ? element.points : undefined,
+              ...(element.type === 'path' && {
+                connectedElementStart: element.connectedElementStart,
+                connectedElementEnd: element.connectedElementEnd,
+              }),
+              ...(element.type === 'shape' && {
+                connectedPaths: element.connectedPaths,
+              }),
+            },
+          };
+        });
       }
-    }
 
-    setResizableProperties(undefined);
-    setElementOverride(createResetElementOverrides(elementIds));
-  }, [dispatch, elementIds, elements, setElementOverride, slideInstance]);
+      slideInstance.updateElements(updates);
+
+      if (Object.values(elements).length === 1) {
+        const element = Object.values(elements)[0];
+
+        if (element.type === 'shape') {
+          // If the element is a shape, update last size in the store
+
+          const shapeSize = {
+            width: element.width,
+            height: element.height,
+          };
+
+          dispatch(setShapeSize({ kind: element.kind, size: shapeSize }));
+        }
+      }
+
+      setResizableProperties(undefined);
+      setElementOverride(createResetElementOverrides(Object.keys(elements)));
+    },
+    [
+      dispatch,
+      setElementOverride,
+      slideInstance,
+      elementOverrideUpdates,
+      elements,
+    ],
+  );
 
   const handleDrag = useCallback(
-    (elementOverrideUpdates: ElementOverrideUpdate[]) =>
-      setElementOverride(elementOverrideUpdates),
+    (elementOverrideUpdates: ElementOverrideUpdate[]) => {
+      setElementOverride(elementOverrideUpdates);
+      setElementOverrideUpdates(elementOverrideUpdates);
+    },
     [setElementOverride],
   );
 
@@ -189,6 +252,7 @@ export function ResizeElement({ elementIds }: ResizeElementProps) {
             name: 'start',
             x: renderProperties.points.start.x,
             y: renderProperties.points.start.y,
+            elementId: elementIds[0],
           }}
           onDrag={handleDrag}
           onDragStart={handleDragStart}
@@ -200,6 +264,7 @@ export function ResizeElement({ elementIds }: ResizeElementProps) {
             name: 'end',
             x: renderProperties.points.end.x,
             y: renderProperties.points.end.y,
+            elementId: elementIds[0],
           }}
           onDrag={handleDrag}
           onDragStart={handleDragStart}

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeHandle.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeHandle.tsx
@@ -16,11 +16,13 @@
 
 import { Dispatch, RefObject, useCallback, useRef } from 'react';
 import { DraggableCore, DraggableData, DraggableEvent } from 'react-draggable';
+import { Point } from '../../../../state';
+import { useConnectionPoint } from '../../../ConnectionPointProvider';
 import { useSvgCanvasContext } from '../../SvgCanvas';
-import { HandlePosition } from './types';
+import { HandlePosition, LineElementHandlePositionName } from './types';
 import { isLineElementHandlePosition } from './utils';
 
-export function calculateResizeHandlePosition(params: {
+function calculateResizeHandlePosition(params: {
   position: HandlePosition;
   scale: number;
 }): {
@@ -140,12 +142,61 @@ export function calculateResizeHandlePosition(params: {
   }
 }
 
+type ConnectData = {
+  connectElementId: string;
+  connectPoint?: Point;
+};
+
+function findConnectData(
+  data: DraggableData,
+  scale: number,
+): ConnectData | undefined {
+  const element = document.elementFromPoint(data.x * scale, data.y * scale);
+
+  if (!element) {
+    return undefined;
+  }
+
+  const connectType = element.getAttribute('data-connect-type');
+  if (!connectType) {
+    return undefined;
+  }
+
+  const connectElementId =
+    element.getAttribute('data-connect-element-id') ?? undefined;
+  if (!connectElementId) {
+    return undefined;
+  }
+
+  let connectPoint: Point | undefined;
+
+  if (
+    connectType === 'connection-point-area' ||
+    connectType === 'connection-point'
+  ) {
+    const rect = element.getBoundingClientRect();
+    connectPoint = {
+      x: (rect.x + rect.width / 2) / scale,
+      y: (rect.y + rect.height / 2) / scale,
+    };
+  }
+
+  return {
+    connectElementId,
+    connectPoint,
+  };
+}
+
 export type DragEvent = {
   x: number;
   y: number;
-  deltaX: number;
-  deltaY: number;
   lockAspectRatio: boolean;
+  connectData?: DragConnectData;
+};
+
+export type DragConnectData = {
+  resizePositionName: LineElementHandlePositionName;
+  connectToElementId?: string;
 };
 
 export type ResizeHandleProps = {
@@ -158,6 +209,8 @@ export type ResizeHandleProps = {
 export function ResizeHandle(props: ResizeHandleProps) {
   const nodeRef = useRef<SVGRectElement>(null);
   const { scale, calculateSvgCoords } = useSvgCanvasContext();
+  const { isDragGoing, setIsDragGoing, setConnectElementId } =
+    useConnectionPoint();
 
   const {
     position: { name },
@@ -176,6 +229,7 @@ export function ResizeHandle(props: ResizeHandleProps) {
       dragEvent: Dispatch<DragEvent> | undefined,
       event: DraggableEvent,
       data: DraggableData,
+      connectData: DragConnectData | undefined,
     ) => {
       if (dragEvent) {
         dragEvent({
@@ -183,9 +237,8 @@ export function ResizeHandle(props: ResizeHandleProps) {
             x: data.x * scale,
             y: data.y * scale,
           }),
-          deltaX: data.deltaX,
-          deltaY: data.deltaY,
           lockAspectRatio: event.shiftKey,
+          connectData,
         });
       }
     },
@@ -194,23 +247,61 @@ export function ResizeHandle(props: ResizeHandleProps) {
 
   const handleDrag = useCallback(
     (event: DraggableEvent, data: DraggableData) => {
-      dispatchDragEvent(onDrag, event, data);
+      let connectPoint: Point | undefined;
+
+      if (isDragGoing) {
+        const connectData = findConnectData(data, scale);
+        setConnectElementId(connectData?.connectElementId);
+        connectPoint = connectData?.connectPoint;
+      }
+
+      const newData: DraggableData = connectPoint
+        ? { ...data, x: connectPoint.x, y: connectPoint.y }
+        : data;
+
+      dispatchDragEvent(onDrag, event, newData, undefined);
     },
-    [onDrag, dispatchDragEvent],
+    [dispatchDragEvent, isDragGoing, onDrag, scale, setConnectElementId],
   );
 
   const handleStart = useCallback(
     (event: DraggableEvent, data: DraggableData) => {
-      dispatchDragEvent(onDragStart, event, data);
+      if (name === 'start' || name === 'end') {
+        setIsDragGoing(true);
+      }
+      dispatchDragEvent(onDragStart, event, data, undefined);
     },
-    [onDragStart, dispatchDragEvent],
+    [dispatchDragEvent, onDragStart, name, setIsDragGoing],
   );
 
   const handleStop = useCallback(
     (event: DraggableEvent, data: DraggableData) => {
-      dispatchDragEvent(onDragStop, event, data);
+      let dragConnectData: DragConnectData | undefined;
+
+      if (name === 'start' || name === 'end') {
+        const connectData = findConnectData(data, scale);
+
+        dragConnectData = {
+          resizePositionName: name,
+          connectToElementId:
+            connectData?.connectElementId && connectData?.connectPoint
+              ? connectData?.connectElementId
+              : undefined,
+        };
+
+        setConnectElementId(undefined);
+        setIsDragGoing(false);
+      }
+      dispatchDragEvent(onDragStop, event, data, dragConnectData);
     },
-    [onDragStop, dispatchDragEvent],
+    [
+      dispatchDragEvent,
+      onDragStop,
+      name,
+      scale,
+      setIsDragGoing,
+      setConnectElementId,
+    ],
   );
 
   const handleMouseDown = useCallback((ev: MouseEvent) => {

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeHandle.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeHandle.tsx
@@ -209,7 +209,7 @@ export type ResizeHandleProps = {
 export function ResizeHandle(props: ResizeHandleProps) {
   const nodeRef = useRef<SVGRectElement>(null);
   const { scale, calculateSvgCoords } = useSvgCanvasContext();
-  const { isDragGoing, setIsDragGoing, setConnectElementId } =
+  const { isHandleDragging, setIsHandleDragging, setConnectElementId } =
     useConnectionPoint();
 
   const {
@@ -249,7 +249,7 @@ export function ResizeHandle(props: ResizeHandleProps) {
     (event: DraggableEvent, data: DraggableData) => {
       let connectPoint: Point | undefined;
 
-      if (isDragGoing) {
+      if (isHandleDragging) {
         const connectData = findConnectData(data, scale);
         setConnectElementId(connectData?.connectElementId);
         connectPoint = connectData?.connectPoint;
@@ -261,17 +261,17 @@ export function ResizeHandle(props: ResizeHandleProps) {
 
       dispatchDragEvent(onDrag, event, newData, undefined);
     },
-    [dispatchDragEvent, isDragGoing, onDrag, scale, setConnectElementId],
+    [dispatchDragEvent, isHandleDragging, onDrag, scale, setConnectElementId],
   );
 
   const handleStart = useCallback(
     (event: DraggableEvent, data: DraggableData) => {
       if (name === 'start' || name === 'end') {
-        setIsDragGoing(true);
+        setIsHandleDragging(true);
       }
       dispatchDragEvent(onDragStart, event, data, undefined);
     },
-    [dispatchDragEvent, onDragStart, name, setIsDragGoing],
+    [dispatchDragEvent, onDragStart, name, setIsHandleDragging],
   );
 
   const handleStop = useCallback(
@@ -290,7 +290,7 @@ export function ResizeHandle(props: ResizeHandleProps) {
         };
 
         setConnectElementId(undefined);
-        setIsDragGoing(false);
+        setIsHandleDragging(false);
       }
       dispatchDragEvent(onDragStop, event, data, dragConnectData);
     },
@@ -299,7 +299,7 @@ export function ResizeHandle(props: ResizeHandleProps) {
       onDragStop,
       name,
       scale,
-      setIsDragGoing,
+      setIsHandleDragging,
       setConnectElementId,
     ],
   );

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/index.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/index.ts
@@ -15,3 +15,7 @@
  */
 
 export { ResizeElement } from './ResizeElement';
+export {
+  computeResizingConnectingPathElementOverDeltaPoints,
+  computeResizingConnectingPathElements,
+} from './utils';

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/types.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Elements } from '../../../../state/types';
+import { Elements, PathElement } from '../../../../state';
 
 export type LineElementHandlePositionName = 'start' | 'end';
 
@@ -22,6 +22,7 @@ export type LineElementHandlePosition = {
   name: LineElementHandlePositionName;
   x: number;
   y: number;
+  elementId: string;
 };
 
 export type HandlePositionName =
@@ -39,6 +40,7 @@ export type HandlePosition =
       name: HandlePositionName;
       containerWidth: number;
       containerHeight: number;
+      elementId?: undefined;
     }
   | LineElementHandlePosition;
 
@@ -50,5 +52,13 @@ export type Dimensions = {
 };
 
 export type ResizableProperties = Dimensions & {
+  /**
+   * Selected elements with applied overrides to resize.
+   */
   elements: Elements;
+
+  /**
+   * Not selected paths connecting selected elements.
+   */
+  connectingPathElements?: Record<string, PathElement>;
 };

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/utils.test.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/utils.test.ts
@@ -480,7 +480,7 @@ describe('computeResizing', () => {
     ({ name, x, y, dragX, dragY, expectedX, expectedY }) => {
       expect(
         computeResizing(
-          { name, x, y },
+          { name, x, y, elementId: 'element-id' },
           { ...event, x: dragX, y: dragY },
           viewportWidth,
           viewportHeight,
@@ -512,7 +512,7 @@ describe('computeResizing', () => {
   it('should not compute resizing of line', () => {
     expect(
       computeResizing(
-        { name: 'start', x: 0, y: 0 },
+        { name: 'start', x: 0, y: 0, elementId: 'element-id' },
         event,
         viewportWidth,
         viewportHeight,

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/utils.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/utils.ts
@@ -23,7 +23,6 @@ import {
 } from '../../../../state';
 import { ElementOverrideUpdate } from '../../../ElementOverridesProvider';
 import { snapToGrid } from '../../Grid';
-import { pathElementGetConnectedNotSelectedElements } from '../utils';
 import { DragEvent } from './ResizeHandle';
 import {
   Dimensions,
@@ -385,10 +384,6 @@ export function computeResizing(
               }))
             : undefined,
       },
-      pathElementDisconnectElements: pathElementGetConnectedNotSelectedElements(
-        element,
-        resizableProperties.elements,
-      ),
     };
   });
 
@@ -510,40 +505,19 @@ function computeResizingConnectingPathElement(
 }
 
 export function computeResizingConnectingPathElementOverDeltaPoints(
-  {
-    elementId,
-    element,
-  }: {
-    elementId: string;
-    element: PathElement;
-  },
-  elements: Elements,
+  elementLinePosition: LinePosition,
   deltaPoints: (Point | undefined)[],
-): ElementOverrideUpdate | undefined {
-  if (!(element.connectedElementStart || element.connectedElementEnd)) {
-    return undefined;
-  }
-
+): LinePosition {
   let linePosition: LinePosition = {
-    position: element.position,
-    points: element.points,
+    ...elementLinePosition,
   };
 
-  const connectedElements = [
-    element.connectedElementStart,
-    element.connectedElementEnd,
-  ];
-  for (let i = 0; i < connectedElements.length; i++) {
-    const connectedElementId = connectedElements[i];
+  for (let i = 0; i < deltaPoints.length; i++) {
     const deltaPoint = deltaPoints[i];
 
-    if (
-      connectedElementId &&
-      elements[connectedElementId] !== undefined &&
-      deltaPoint
-    ) {
-      const pointX = element.position.x + element.points[i].x;
-      const pointY = element.position.y + element.points[i].y;
+    if (deltaPoint) {
+      const pointX = linePosition.position.x + linePosition.points[i].x;
+      const pointY = linePosition.position.y + linePosition.points[i].y;
 
       const newPointX = pointX + deltaPoint.x;
       const newPointY = pointY + deltaPoint.y;
@@ -558,8 +532,5 @@ export function computeResizingConnectingPathElementOverDeltaPoints(
     }
   }
 
-  return {
-    elementId: elementId,
-    elementOverride: linePosition,
-  };
+  return linePosition;
 }

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/utils.test.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/utils.test.ts
@@ -28,7 +28,7 @@ import {
   WhiteboardSlideInstance,
 } from '../../../state';
 import { ElementOverrideUpdate } from '../../ElementOverridesProvider';
-import { elementsWithUpdates, lineResizeUpdates } from './utils';
+import { elementsUpdates, lineResizeUpdates } from './utils';
 
 describe('lineResizeUpdates', () => {
   let slideElements: Elements;
@@ -180,8 +180,8 @@ describe('lineResizeUpdates', () => {
   });
 });
 
-describe('elementsWithUpdates', () => {
-  it('should provide updates elements', () => {
+describe('elementsUpdates', () => {
+  it('should provide elements updates', () => {
     const slideElements: Elements = {
       ['rectangle-id']: mockRectangleElement({
         position: { x: 100, y: 100 },
@@ -253,7 +253,6 @@ describe('elementsWithUpdates', () => {
         elementOverride: {
           position: { x: 300, y: 300 },
         },
-        pathElementDisconnectElements: ['ellipse-id'],
       },
       {
         elementId: 'line-id-2',
@@ -274,38 +273,37 @@ describe('elementsWithUpdates', () => {
     } as WhiteboardSlideInstance;
 
     expect(
-      elementsWithUpdates(slideInstance, elements, elementOverrideUpdates),
-    ).toEqual({
-      ['rectangle-id']: mockRectangleElement({
-        position: { x: 300, y: 100 },
-        width: 200,
-        height: 200,
-        connectedPaths: ['line-id-1', 'line-id-2'],
-      }),
-      ['ellipse-id']: mockEllipseElement({
-        position: { x: 100, y: 500 },
-        width: 200,
-        height: 200,
-        connectedPaths: undefined,
-      }),
-      ['line-id-1']: mockLineElement({
-        position: { x: 300, y: 300 },
-        points: [
-          { x: 0, y: 0 },
-          { x: 100, y: 200 },
-        ],
-        connectedElementStart: 'rectangle-id',
-        connectedElementEnd: undefined,
-      }),
-      ['line-id-2']: mockLineElement({
-        position: { x: 500, y: 300 },
-        points: [
-          { x: 0, y: 0 },
-          { x: 100, y: 200 },
-        ],
-        connectedElementStart: 'rectangle-id',
-        connectedElementEnd: 'triangle-id',
-      }),
-    });
+      elementsUpdates(slideInstance, elements, elementOverrideUpdates),
+    ).toStrictEqual([
+      {
+        elementId: 'rectangle-id',
+        patch: {
+          position: { x: 300, y: 100 },
+        },
+      },
+      {
+        elementId: 'line-id-1',
+        patch: {
+          position: { x: 300, y: 300 },
+          connectedElementEnd: undefined,
+        },
+      },
+      {
+        elementId: 'line-id-2',
+        patch: {
+          position: { x: 500, y: 300 },
+          points: [
+            { x: 0, y: 0 },
+            { x: 100, y: 200 },
+          ],
+        },
+      },
+      {
+        elementId: 'ellipse-id',
+        patch: {
+          connectedPaths: undefined,
+        },
+      },
+    ]);
   });
 });

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/utils.test.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/utils.test.ts
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2025 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  mockEllipseElement,
+  mockLineElement,
+  mockRectangleElement,
+  mockTriangleElement,
+} from '../../../lib/testUtils';
+import {
+  Element,
+  Elements,
+  PathElement,
+  WhiteboardSlideInstance,
+} from '../../../state';
+import { ElementOverrideUpdate } from '../../ElementOverridesProvider';
+import { elementsWithUpdates, lineResizeUpdates } from './utils';
+
+describe('lineResizeUpdates', () => {
+  let slideElements: Elements;
+  let slideInstance: WhiteboardSlideInstance;
+
+  beforeAll(() => {
+    slideElements = {
+      ['rectangle-id']: mockRectangleElement({
+        position: { x: 100, y: 100 },
+        width: 200,
+        height: 200,
+      }),
+      ['line-id-1']: mockLineElement({
+        position: { x: 500, y: 500 },
+        points: [
+          { x: 0, y: 0 },
+          { x: 200, y: 200 },
+        ],
+      }),
+    };
+
+    slideInstance = {
+      getElement(elementId: string): Element | undefined {
+        return slideElements[elementId];
+      },
+    } as WhiteboardSlideInstance;
+  });
+
+  it('should provide updates when line is resized and no connection point', () => {
+    const element: PathElement = mockLineElement({
+      position: { x: 400, y: 400 },
+      points: [
+        { x: 0, y: 0 },
+        { x: 300, y: 300 },
+      ],
+    });
+    expect(
+      lineResizeUpdates(
+        slideInstance,
+        'line-id-1',
+        element,
+        'start',
+        undefined,
+      ),
+    ).toStrictEqual([
+      {
+        elementId: 'line-id-1',
+        patch: {
+          position: { x: 400, y: 400 },
+          points: [
+            { x: 0, y: 0 },
+            { x: 300, y: 300 },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('should provide updates when line is resized and has connection point', () => {
+    const element: PathElement = mockLineElement({
+      position: { x: 300, y: 300 },
+      points: [
+        { x: 0, y: 0 },
+        { x: 400, y: 400 },
+      ],
+    });
+    expect(
+      lineResizeUpdates(
+        slideInstance,
+        'line-id-1',
+        element,
+        'start',
+        'rectangle-id',
+      ),
+    ).toStrictEqual([
+      {
+        elementId: 'line-id-1',
+        patch: {
+          position: { x: 300, y: 300 },
+          points: [
+            { x: 0, y: 0 },
+            { x: 400, y: 400 },
+          ],
+          connectedElementStart: 'rectangle-id',
+        },
+      },
+      {
+        elementId: 'rectangle-id',
+        patch: {
+          connectedPaths: ['line-id-1'],
+        },
+      },
+    ]);
+  });
+
+  it('should provide updates when line is resized and no connection point but line and shape are connected', () => {
+    slideElements = {
+      ['rectangle-id']: mockRectangleElement({
+        position: { x: 100, y: 100 },
+        width: 200,
+        height: 200,
+        connectedPaths: ['line-id-1'],
+      }),
+      ['line-id-1']: mockLineElement({
+        position: { x: 300, y: 300 },
+        points: [
+          { x: 0, y: 0 },
+          { x: 400, y: 400 },
+        ],
+        connectedElementStart: 'rectangle-id',
+      }),
+    };
+
+    const element: PathElement = mockLineElement({
+      position: { x: 200, y: 200 },
+      points: [
+        { x: 0, y: 0 },
+        { x: 300, y: 300 },
+      ],
+      connectedElementStart: 'rectangle-id',
+    });
+    expect(
+      lineResizeUpdates(
+        slideInstance,
+        'line-id-1',
+        element,
+        'start',
+        undefined,
+      ),
+    ).toStrictEqual([
+      {
+        elementId: 'line-id-1',
+        patch: {
+          position: { x: 200, y: 200 },
+          points: [
+            { x: 0, y: 0 },
+            { x: 300, y: 300 },
+          ],
+          connectedElementStart: undefined,
+        },
+      },
+      {
+        elementId: 'rectangle-id',
+        patch: {
+          connectedPaths: undefined,
+        },
+      },
+    ]);
+  });
+});
+
+describe('elementsWithUpdates', () => {
+  it('should provide updates elements', () => {
+    const slideElements: Elements = {
+      ['rectangle-id']: mockRectangleElement({
+        position: { x: 100, y: 100 },
+        width: 200,
+        height: 200,
+        connectedPaths: ['line-id-1', 'line-id-2'],
+      }),
+      ['ellipse-id']: mockEllipseElement({
+        position: { x: 100, y: 500 },
+        width: 200,
+        height: 200,
+        connectedPaths: ['line-id-1'],
+      }),
+      ['triangle-id']: mockTriangleElement({
+        position: { x: 500, y: 500 },
+        width: 200,
+        height: 200,
+        connectedPaths: ['line-id-2'],
+      }),
+      ['line-id-1']: mockLineElement({
+        position: { x: 100, y: 300 },
+        points: [
+          { x: 0, y: 0 },
+          { x: 100, y: 200 },
+        ],
+        connectedElementStart: 'rectangle-id',
+        connectedElementEnd: 'ellipse-id',
+      }),
+      ['line-id-2']: mockLineElement({
+        position: { x: 300, y: 300 },
+        points: [
+          { x: 0, y: 0 },
+          { x: 300, y: 200 },
+        ],
+        connectedElementStart: 'rectangle-id',
+        connectedElementEnd: 'triangle-id',
+      }),
+    };
+
+    // move rectangle and first line to the right 200 px, prepare arguments
+
+    const elements: Elements = {
+      ['rectangle-id']: mockRectangleElement({
+        position: { x: 300, y: 100 },
+        width: 200,
+        height: 200,
+        connectedPaths: ['line-id-1', 'line-id-2'],
+      }),
+      ['line-id-1']: mockLineElement({
+        position: { x: 300, y: 300 },
+        points: [
+          { x: 0, y: 0 },
+          { x: 100, y: 200 },
+        ],
+        connectedElementStart: 'rectangle-id',
+        connectedElementEnd: 'ellipse-id',
+      }),
+    };
+
+    const elementOverrideUpdates: ElementOverrideUpdate[] = [
+      {
+        elementId: 'rectangle-id',
+        elementOverride: {
+          position: { x: 300, y: 100 },
+        },
+      },
+      {
+        elementId: 'line-id-1',
+        elementOverride: {
+          position: { x: 300, y: 300 },
+        },
+        pathElementDisconnectElements: ['ellipse-id'],
+      },
+      {
+        elementId: 'line-id-2',
+        elementOverride: {
+          position: { x: 500, y: 300 },
+          points: [
+            { x: 0, y: 0 },
+            { x: 100, y: 200 },
+          ],
+        },
+      },
+    ];
+
+    const slideInstance: WhiteboardSlideInstance = {
+      getElement(elementId: string): Element | undefined {
+        return slideElements[elementId];
+      },
+    } as WhiteboardSlideInstance;
+
+    expect(
+      elementsWithUpdates(slideInstance, elements, elementOverrideUpdates),
+    ).toEqual({
+      ['rectangle-id']: mockRectangleElement({
+        position: { x: 300, y: 100 },
+        width: 200,
+        height: 200,
+        connectedPaths: ['line-id-1', 'line-id-2'],
+      }),
+      ['ellipse-id']: mockEllipseElement({
+        position: { x: 100, y: 500 },
+        width: 200,
+        height: 200,
+        connectedPaths: undefined,
+      }),
+      ['line-id-1']: mockLineElement({
+        position: { x: 300, y: 300 },
+        points: [
+          { x: 0, y: 0 },
+          { x: 100, y: 200 },
+        ],
+        connectedElementStart: 'rectangle-id',
+        connectedElementEnd: undefined,
+      }),
+      ['line-id-2']: mockLineElement({
+        position: { x: 500, y: 300 },
+        points: [
+          { x: 0, y: 0 },
+          { x: 100, y: 200 },
+        ],
+        connectedElementStart: 'rectangle-id',
+        connectedElementEnd: 'triangle-id',
+      }),
+    });
+  });
+});

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/utils.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/utils.ts
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2025 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { uniq } from 'lodash';
+import {
+  disconnectPathElement,
+  disconnectShapeElement,
+  Element,
+  Elements,
+  PathElement,
+  ShapeElement,
+  WhiteboardSlideInstance,
+} from '../../../state';
+import { ElementUpdate } from '../../../state/types';
+import {
+  connectPathElement,
+  connectShapeElement,
+  disconnectPathElementOnPosition,
+} from '../../../state/utils';
+import { ElementOverrideUpdate } from '../../ElementOverridesProvider';
+import { LineElementHandlePositionName } from './Resizable/types';
+
+/**
+ * Provides updates to line resize.
+ * Provides connection changes to line element and connected/disconnected element.
+ *
+ * @param slideInstance slide instance
+ * @param pathElementId path element id
+ * @param pathElement path element (currently line only)
+ * @param position start or end position of line resized
+ * @param connectToElementId if defined an element id to connect to, otherwise disconnect line on position
+ * @return line element position, points updates, connection start and end updates, an element to connect to connection updates
+ */
+export function lineResizeUpdates(
+  slideInstance: WhiteboardSlideInstance,
+  pathElementId: string,
+  pathElement: PathElement,
+  position: LineElementHandlePositionName,
+  connectToElementId: string | undefined,
+): ElementUpdate[] {
+  const patches: ElementUpdate[] = [];
+
+  if (!connectToElementId) {
+    const pathPatch = disconnectPathElementOnPosition(pathElement, position);
+    patches.push({
+      elementId: pathElementId,
+      patch: {
+        position: pathElement.position,
+        points: pathElement.points,
+        ...pathPatch,
+      },
+    });
+
+    let shapeElementData: [string, ShapeElement] | undefined;
+    if (pathElement.connectedElementStart || pathElement.connectedElementEnd) {
+      const shapeElementId =
+        position === 'start'
+          ? pathElement.connectedElementStart
+          : pathElement.connectedElementEnd;
+      if (shapeElementId) {
+        const targetElement = slideInstance.getElement(shapeElementId);
+        if (targetElement?.type === 'shape') {
+          shapeElementData = [shapeElementId, targetElement];
+        }
+      }
+    } else {
+      shapeElementData = undefined;
+    }
+
+    if (shapeElementData) {
+      const [shapeElementId, shapeElement] = shapeElementData;
+      const shapePatch = disconnectShapeElement(shapeElement, [pathElementId]);
+      if (shapePatch) {
+        patches.push({
+          elementId: shapeElementId,
+          patch: shapePatch,
+        });
+      }
+    }
+  } else {
+    const shapeElement = slideInstance.getElement(connectToElementId);
+
+    if (shapeElement && shapeElement.type === 'shape') {
+      const pathPatch = connectPathElement(
+        pathElement,
+        position,
+        connectToElementId,
+      );
+      patches.push({
+        elementId: pathElementId,
+        patch: {
+          position: pathElement.position,
+          points: pathElement.points,
+          ...pathPatch,
+        },
+      });
+
+      const shapePatch = connectShapeElement(shapeElement, pathElementId);
+      if (shapePatch) {
+        patches.push({
+          elementId: connectToElementId,
+          patch: shapePatch,
+        });
+      }
+    }
+  }
+
+  return patches;
+}
+
+/**
+ * Creates elements with all updates applied:
+ *  - original updates because of move or resize elements
+ *  - connecting paths resizing
+ *  - selected lines disconnect to shapes outside of selection
+ *
+ * @param slideInstance slide instance to load elements that are not in original selection but have to be modified
+ * @param elements selected elements with updates
+ * @param elementOverrideUpdates all updates including changes to connecting paths and shapes disconnections
+ * @return elements including connecting paths, extra shapes disconnected
+ */
+export function elementsWithUpdates(
+  slideInstance: WhiteboardSlideInstance,
+  elements: Elements,
+  elementOverrideUpdates: ElementOverrideUpdate[],
+): Elements {
+  const disconnectPathElements: [string, string[]][] =
+    findPathElementsToDisconnect(elementOverrideUpdates);
+  const disconnectLineObject = Object.fromEntries(disconnectPathElements);
+
+  // Selected lines may become disconnected, apply disconnect patch
+  const newOverrideElements: [string, Element][] = Object.entries(elements).map(
+    ([elementId, element]) => {
+      const elementIds: string[] | undefined = disconnectLineObject[elementId];
+      if (!elementIds) {
+        return [elementId, element];
+      }
+
+      if (element.type !== 'path') {
+        return [elementId, element];
+      }
+
+      const elementPatch = disconnectPathElement(element, elementIds);
+      if (!elementPatch) {
+        return [elementId, element];
+      }
+
+      return [
+        elementId,
+        {
+          ...element,
+          ...elementPatch,
+        },
+      ];
+    },
+  );
+
+  // Connecting lines overrides
+  const otherOverrides: [string, Element][] = [];
+  for (const { elementId, elementOverride } of elementOverrideUpdates.filter(
+    (u) => elements[u.elementId] === undefined,
+  )) {
+    const element = slideInstance.getElement(elementId);
+    if (element) {
+      otherOverrides.push([
+        elementId,
+        {
+          ...element,
+          ...elementOverride,
+        },
+      ]);
+    }
+  }
+
+  const disconnectShapeObject: Record<string, string[]> = {};
+  for (const [lineElementId, shapeElementIds] of disconnectPathElements) {
+    for (const shapeElementId of shapeElementIds) {
+      if (disconnectShapeObject[shapeElementId] === undefined) {
+        disconnectShapeObject[shapeElementId] = [];
+      }
+      disconnectShapeObject[shapeElementId].push(lineElementId);
+    }
+  }
+
+  // Shapes that are outside of selection elements and will be disconnected from selected lines
+  const shapeOverrides: [string, Element][] = [];
+  for (const [shapeElementId, disconnectLineIds] of Object.entries(
+    disconnectShapeObject,
+  )) {
+    const shapeElement = slideInstance.getElement(shapeElementId);
+    if (shapeElement && shapeElement.type === 'shape') {
+      const elementPatch = disconnectShapeElement(
+        shapeElement,
+        disconnectLineIds,
+        true,
+      );
+
+      if (elementPatch) {
+        shapeOverrides.push([
+          shapeElementId,
+          {
+            ...shapeElement,
+            ...elementPatch,
+          },
+        ]);
+      }
+    }
+  }
+
+  return Object.fromEntries([
+    ...newOverrideElements,
+    ...otherOverrides,
+    ...shapeOverrides,
+  ]);
+}
+
+function findPathElementsToDisconnect(
+  elementOverrideUpdates: ElementOverrideUpdate[],
+): [string, string[]][] {
+  const res: [string, string[]][] = [];
+
+  for (const {
+    elementId,
+    pathElementDisconnectElements,
+  } of elementOverrideUpdates) {
+    if (
+      pathElementDisconnectElements &&
+      pathElementDisconnectElements.length > 0
+    ) {
+      res.push([elementId, pathElementDisconnectElements]);
+    }
+  }
+
+  return res;
+}
+
+/**
+ * For path element it finds connected but not selected element ids
+ * @param element path element
+ * @param elements ids of elements, undefined otherwise
+ */
+export function pathElementGetConnectedNotSelectedElements(
+  element: Element,
+  elements: Elements,
+): string[] | undefined {
+  let res: string[] | undefined;
+
+  if (
+    element.type === 'path' &&
+    (element.connectedElementStart || element.connectedElementEnd)
+  ) {
+    const elementIds: string[] = uniq(
+      [element.connectedElementStart, element.connectedElementEnd]
+        .filter((eId) => eId !== undefined)
+        .filter((eId) => elements[eId] === undefined),
+    );
+
+    if (elementIds.length > 0) {
+      res = elementIds;
+    }
+  }
+
+  return res;
+}
+
+export function getPathElements(
+  slideInstance: WhiteboardSlideInstance,
+  elementIds: string[],
+): Record<string, PathElement> {
+  const entries: [string, PathElement][] = [];
+
+  for (const elementId of elementIds) {
+    const element = slideInstance.getElement(elementId);
+    if (element && element.type === 'path') {
+      entries.push([elementId, element]);
+    }
+  }
+
+  return Object.fromEntries(entries);
+}

--- a/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.test.tsx
@@ -31,6 +31,7 @@ import {
   WhiteboardInstance,
   WhiteboardSlideInstance,
 } from '../../state';
+import { ConnectionPointProvider } from '../ConnectionPointProvider';
 import { ElementOverridesProvider } from '../ElementOverridesProvider';
 import { LayoutStateProvider, useLayoutState } from '../Layout';
 import { WhiteboardHotkeysProvider } from '../WhiteboardHotkeysProvider';
@@ -89,7 +90,9 @@ describe('<WhiteboardHost/>', () => {
             whiteboardManager={whiteboardManager}
             widgetApi={widgetApi}
           >
-            <ElementOverridesProvider>{children}</ElementOverridesProvider>
+            <ElementOverridesProvider>
+              <ConnectionPointProvider>{children}</ConnectionPointProvider>
+            </ElementOverridesProvider>
           </WhiteboardTestingContextProvider>
         </WhiteboardHotkeysProvider>
       </LayoutStateProvider>

--- a/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
@@ -68,7 +68,7 @@ const WhiteboardHost = ({
     useLayoutState();
   const { activeElementIds } = useActiveElements();
   const overrides = useElementOverrides(activeElementIds);
-  const { isDragGoing } = useConnectionPoint();
+  const { isHandleDragging } = useConnectionPoint();
 
   const [textToolsEnabled, setTextToolsEnabled] = useState(false);
 
@@ -143,7 +143,7 @@ const WhiteboardHost = ({
           </>
         )}
 
-        {isDragGoing &&
+        {isHandleDragging &&
           Object.entries(
             slideInstance.getElements(slideInstance.getElementIds()),
           )

--- a/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
@@ -19,6 +19,7 @@ import { useCallback, useState } from 'react';
 import {
   includesShapeWithText,
   includesTextShape,
+  isShapeElementPair,
   type Point,
   useActiveElements,
   useIsWhiteboardLoading,
@@ -27,6 +28,7 @@ import {
   useSlideIsLocked,
   useWhiteboardSlideInstance,
 } from '../../state';
+import { useConnectionPoint } from '../ConnectionPointProvider';
 import { ElementBar } from '../ElementBar';
 import { useElementOverrides } from '../ElementOverridesProvider';
 import { useLayoutState } from '../Layout';
@@ -34,6 +36,7 @@ import { CursorRenderer } from './CursorRenderer';
 import { DraftPicker } from './Draft/DraftPicker';
 import { ConnectedElement } from './Element';
 import {
+  ConnectableElement,
   ElementBarWrapper,
   ElementBorder,
   ElementOutline,
@@ -65,6 +68,8 @@ const WhiteboardHost = ({
     useLayoutState();
   const { activeElementIds } = useActiveElements();
   const overrides = useElementOverrides(activeElementIds);
+  const { isDragGoing } = useConnectionPoint();
+
   const [textToolsEnabled, setTextToolsEnabled] = useState(false);
 
   const hasElementWithText =
@@ -137,6 +142,19 @@ const WhiteboardHost = ({
             )}
           </>
         )}
+
+        {isDragGoing &&
+          Object.entries(
+            slideInstance.getElements(slideInstance.getElementIds()),
+          )
+            .filter(isShapeElementPair)
+            .map(([elementId, element]) => (
+              <ConnectableElement
+                key={elementId}
+                elementId={elementId}
+                element={element}
+              />
+            ))}
 
         {isShowCollaboratorsCursors && !hideCursors && <CursorRenderer />}
       </SvgCanvas>

--- a/packages/react-sdk/src/state/crdt/documents/elements.test.ts
+++ b/packages/react-sdk/src/state/crdt/documents/elements.test.ts
@@ -44,6 +44,34 @@ describe('isValidElement', () => {
     expect(isValidElement(data)).toBe(true);
   });
 
+  it.each([
+    {
+      connectedElementStart: 'element-id-1',
+    },
+    {
+      connectedElementStart: 'element-id-1',
+      connectedElementEnd: 'element-id-2',
+    },
+    {
+      connectedElementEnd: 'element-id-2',
+    },
+  ])(
+    'should accept path event',
+    ({ connectedElementStart, connectedElementEnd }) => {
+      const data = {
+        type: 'path',
+        position: { x: 1, y: 2 },
+        kind: 'line',
+        points: [],
+        strokeColor: 'red',
+        connectedElementStart,
+        connectedElementEnd,
+      };
+
+      expect(isValidElement(data)).toBe(true);
+    },
+  );
+
   it('should accept additional properties for path event', () => {
     const data = {
       type: 'path',
@@ -68,11 +96,34 @@ describe('isValidElement', () => {
         height: 100,
         fillColor: 'red',
         text: '',
+        connectedPaths: ['element-id-1'],
       };
 
       expect(isValidElement(data)).toBe(true);
     },
   );
+
+  it.each([
+    {
+      connectedPaths: undefined,
+    },
+    {
+      connectedPaths: ['element-1'],
+    },
+  ])('should accept shape event', ({ connectedPaths }) => {
+    const data = {
+      type: 'shape',
+      position: { x: 1, y: 2 },
+      kind: 'rectangle',
+      width: 100,
+      height: 100,
+      fillColor: 'red',
+      text: '',
+      connectedPaths,
+    };
+
+    expect(isValidElement(data)).toBe(true);
+  });
 
   it('should accept additional properties for shape event', () => {
     const data = {

--- a/packages/react-sdk/src/state/crdt/documents/elements.ts
+++ b/packages/react-sdk/src/state/crdt/documents/elements.ts
@@ -88,7 +88,7 @@ const shapeElementSchema = elementBaseSchema
     textItalic: Joi.boolean(),
     textSize: Joi.number().strict(),
     textFontFamily: Joi.string().strict().default('Inter'),
-    connectedPaths: Joi.array().items(Joi.string().empty()),
+    connectedPaths: Joi.array().items(Joi.string()),
   })
   .required();
 

--- a/packages/react-sdk/src/state/crdt/documents/elements.ts
+++ b/packages/react-sdk/src/state/crdt/documents/elements.ts
@@ -64,6 +64,7 @@ export type ShapeElement = ElementBase & {
   textItalic?: boolean;
   textSize?: number;
   textFontFamily: TextFontFamily;
+  connectedPaths?: string[];
 };
 
 const emptyCoordinateSchema = Joi.any().valid(null, 0, '');
@@ -87,6 +88,7 @@ const shapeElementSchema = elementBaseSchema
     textItalic: Joi.boolean(),
     textSize: Joi.number().strict(),
     textFontFamily: Joi.string().strict().default('Inter'),
+    connectedPaths: Joi.array().items(Joi.string().empty()),
   })
   .required();
 
@@ -100,6 +102,8 @@ export type PathElement = ElementBase & {
   points: Point[];
   strokeColor: string;
   endMarker?: EndMarker;
+  connectedElementStart?: string;
+  connectedElementEnd?: string;
 };
 
 const pathElementSchema = elementBaseSchema
@@ -109,6 +113,8 @@ const pathElementSchema = elementBaseSchema
     points: Joi.array().items(pointSchema).required(),
     strokeColor: Joi.string().required(),
     endMarker: Joi.string().valid('arrow-head-line'),
+    connectedElementStart: Joi.string(),
+    connectedElementEnd: Joi.string(),
   })
   .required();
 
@@ -295,4 +301,10 @@ export function includesTextShape(elements: Element[]): boolean {
  */
 export function includesShapeWithText(elements: Element[]): boolean {
   return elements.some(isShapeWithText);
+}
+
+export function isShapeElementPair(
+  pair: [string, Element],
+): pair is [string, ShapeElement] {
+  return pair[1].type === 'shape';
 }

--- a/packages/react-sdk/src/state/crdt/documents/index.ts
+++ b/packages/react-sdk/src/state/crdt/documents/index.ts
@@ -20,6 +20,7 @@ export {
   calculateFittedElementSize,
   includesShapeWithText,
   includesTextShape,
+  isShapeElementPair,
   isShapeWithText,
   isTextShape,
   isValidElement,

--- a/packages/react-sdk/src/state/crdt/documents/operations.test.ts
+++ b/packages/react-sdk/src/state/crdt/documents/operations.test.ts
@@ -673,6 +673,25 @@ describe('generateAddElement', () => {
     expect(getNormalizedElementIds(doc.getData(), slide0)).toEqual([elementId]);
   });
 
+  it('should add element with id', () => {
+    const doc = createWhiteboardDocument();
+
+    const element = mockLineElement();
+    const [changeFn, elementId] = generateAddElement(
+      slide0,
+      element,
+      'element-id-0',
+    );
+
+    doc.performChange(changeFn);
+
+    expect(elementId).toEqual('element-id-0');
+    expect(getElement(doc.getData(), slide0, elementId)?.toJSON()).toEqual(
+      element,
+    );
+    expect(getNormalizedElementIds(doc.getData(), slide0)).toEqual([elementId]);
+  });
+
   it('should throw if the slide does not exist', () => {
     const doc = createWhiteboardDocument();
 

--- a/packages/react-sdk/src/state/crdt/documents/operations.ts
+++ b/packages/react-sdk/src/state/crdt/documents/operations.ts
@@ -244,8 +244,9 @@ export function getNormalizedElementIds(
 export function generateAddElement(
   slideId: string,
   element: Element,
+  elementId?: string,
 ): [ChangeFn<WhiteboardDocument>, string] {
-  const elementId = nanoid();
+  const newElementId = elementId ?? nanoid();
 
   const changeFn = (doc: SharedMap<WhiteboardDocument>) => {
     const slide = getSlide(doc, slideId);
@@ -258,11 +259,11 @@ export function generateAddElement(
 
     const elementMap = new YMap(Object.entries(element)) as SharedMap<Element>;
 
-    slide.get('elements').set(elementId, elementMap);
-    slide.get('elementIds').push([elementId]);
+    slide.get('elements').set(newElementId, elementMap);
+    slide.get('elementIds').push([newElementId]);
   };
 
-  return [changeFn, elementId];
+  return [changeFn, newElementId];
 }
 
 /**

--- a/packages/react-sdk/src/state/export/loadWhiteboardFromExport.ts
+++ b/packages/react-sdk/src/state/export/loadWhiteboardFromExport.ts
@@ -51,8 +51,9 @@ export function generateLoadWhiteboardFromExport(
       const [addSlide, slideId] = generateAddSlide();
       addSlide(doc);
 
-      slide.elements.forEach((element) => {
-        const [addElement] = generateAddElement(slideId, element);
+      slide.elements.forEach((exportElement) => {
+        const { id, ...element } = exportElement;
+        const [addElement] = generateAddElement(slideId, element, id);
         addElement(doc);
       });
 

--- a/packages/react-sdk/src/state/export/whiteboardDocumentExport.ts
+++ b/packages/react-sdk/src/state/export/whiteboardDocumentExport.ts
@@ -19,8 +19,12 @@ import loglevel from 'loglevel';
 import { Element } from '../crdt';
 import { elementSchema } from '../crdt/documents/elements';
 
+export type ElementExport = {
+  id?: string;
+} & Element;
+
 export type SlideExport = {
-  elements: Array<Element>;
+  elements: Array<ElementExport>;
   lock?: {};
 };
 

--- a/packages/react-sdk/src/state/index.ts
+++ b/packages/react-sdk/src/state/index.ts
@@ -17,6 +17,7 @@
 export * from './crdt';
 export * from './export';
 export type {
+  Elements,
   PresentationManager,
   PresentationState,
   WhiteboardInstance,
@@ -51,4 +52,9 @@ export {
   useSlideIsLocked,
   useWhiteboardSlideInstance,
 } from './useWhiteboardSlideInstance';
+export {
+  disconnectPathElement,
+  disconnectShapeElement,
+  findConnectingPaths,
+} from './utils';
 export { createWhiteboardManager } from './whiteboardManagerImpl';

--- a/packages/react-sdk/src/state/utils.test.ts
+++ b/packages/react-sdk/src/state/utils.test.ts
@@ -1,0 +1,507 @@
+/*
+ * Copyright 2025 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { mockLineElement, mockRectangleElement } from '../lib/testUtils';
+import {
+  connectPathElement,
+  connectShapeElement,
+  deleteConnectionData,
+  disconnectPathElement,
+  disconnectPathElementOnPosition,
+  disconnectShapeElement,
+  findConnectingPaths,
+  findConnectingShapes,
+} from './utils';
+
+describe('findConnectingShapes', () => {
+  it('should find no connecting shapes from single shape', () => {
+    expect(
+      findConnectingShapes({
+        'shape-id-0': mockRectangleElement(),
+      }),
+    ).toEqual([]);
+  });
+
+  it('should find no connecting shapes from single path', () => {
+    expect(
+      findConnectingShapes({
+        'path-id-0': mockLineElement(),
+      }),
+    ).toEqual([]);
+  });
+
+  it('should find connecting shapes from single path with connection', () => {
+    expect(
+      findConnectingShapes({
+        'path-id-0': mockLineElement({
+          connectedElementStart: 'shape-id-0',
+        }),
+      }),
+    ).toEqual(['shape-id-0']);
+  });
+
+  it('should find connecting shapes from multiple paths with connection', () => {
+    expect(
+      findConnectingShapes({
+        'path-id-0': mockLineElement({
+          connectedElementStart: 'shape-id-0',
+        }),
+        'path-id-1': mockLineElement({
+          connectedElementStart: 'shape-id-1',
+          connectedElementEnd: 'shape-id-2',
+        }),
+      }),
+    ).toEqual(['shape-id-0', 'shape-id-1', 'shape-id-2']);
+  });
+
+  it('should find connecting shapes from multiple paths with connection pointing to same shape', () => {
+    expect(
+      findConnectingShapes({
+        'path-id-0': mockLineElement({
+          connectedElementStart: 'shape-id-0',
+        }),
+        'path-id-1': mockLineElement({
+          connectedElementStart: 'shape-id-0',
+          connectedElementEnd: 'shape-id-2',
+        }),
+      }),
+    ).toEqual(['shape-id-0', 'shape-id-2']);
+  });
+});
+
+describe('findConnectingPaths', () => {
+  it('should find no connecting paths', () => {
+    expect(
+      findConnectingPaths({
+        'shape-id-0': mockRectangleElement(),
+      }),
+    ).toEqual([]);
+  });
+
+  it('should find connecting paths from single shape', () => {
+    expect(
+      findConnectingPaths({
+        'shape-id-0': mockRectangleElement({
+          connectedPaths: ['path-id-0', 'path-id-1'],
+        }),
+      }),
+    ).toEqual(['path-id-0', 'path-id-1']);
+  });
+
+  it('should find connecting paths from multiple shapes', () => {
+    expect(
+      findConnectingPaths({
+        'shape-id-0': mockRectangleElement({
+          connectedPaths: ['path-id-0', 'path-id-1'],
+        }),
+        'shape-id-1': mockRectangleElement({
+          connectedPaths: ['path-id-2'],
+        }),
+      }),
+    ).toEqual(['path-id-0', 'path-id-1', 'path-id-2']);
+  });
+
+  it('should find connecting paths from multiple shapes and path', () => {
+    expect(
+      findConnectingPaths({
+        'shape-id-0': mockRectangleElement({
+          connectedPaths: ['path-id-0', 'path-id-1'],
+        }),
+        'shape-id-1': mockRectangleElement({
+          connectedPaths: ['path-id-2'],
+        }),
+        'path-id-3': mockLineElement(),
+      }),
+    ).toEqual(['path-id-0', 'path-id-1', 'path-id-2']);
+  });
+
+  it('should find connecting paths from multiple shapes and connecting path selected', () => {
+    expect(
+      findConnectingPaths({
+        'shape-id-0': mockRectangleElement({
+          connectedPaths: ['path-id-0', 'path-id-1'],
+        }),
+        'shape-id-1': mockRectangleElement({
+          connectedPaths: ['path-id-2'],
+        }),
+        'path-id-0': mockLineElement({
+          connectedElementStart: 'shape-id-0',
+        }),
+      }),
+    ).toEqual(['path-id-1', 'path-id-2']);
+  });
+
+  it('should find connecting paths from multiple shapes and connecting path between selected shapes', () => {
+    expect(
+      findConnectingPaths({
+        'shape-id-0': mockRectangleElement({
+          connectedPaths: ['path-id-0', 'path-id-1'],
+        }),
+        'shape-id-1': mockRectangleElement({
+          connectedPaths: ['path-id-0'],
+        }),
+      }),
+    ).toEqual(['path-id-0', 'path-id-1']);
+  });
+});
+
+describe('connectPathElement', () => {
+  it('should connect path start', () => {
+    const patch = connectPathElement(mockLineElement(), 'start', 'shape-id-0');
+    expect(patch).toEqual({
+      connectedElementStart: 'shape-id-0',
+    });
+  });
+
+  it('should connect path end', () => {
+    const patch = connectPathElement(mockLineElement(), 'end', 'shape-id-0');
+    expect(patch).toEqual({
+      connectedElementEnd: 'shape-id-0',
+    });
+  });
+
+  it('should connect path start to another shape', () => {
+    const patch = connectPathElement(
+      mockLineElement({
+        connectedElementStart: 'shape-id-0',
+      }),
+      'start',
+      'shape-id-1',
+    );
+    expect(patch).toEqual({
+      connectedElementStart: 'shape-id-1',
+    });
+  });
+
+  it('should connect path end to another shape', () => {
+    const patch = connectPathElement(
+      mockLineElement({
+        connectedElementEnd: 'shape-id-0',
+      }),
+      'end',
+      'shape-id-1',
+    );
+    expect(patch).toEqual({
+      connectedElementEnd: 'shape-id-1',
+    });
+  });
+
+  it('should not connect path if connected to shape by this end already', () => {
+    const patch = connectPathElement(
+      mockLineElement({
+        connectedElementStart: 'shape-id-0',
+      }),
+      'start',
+      'shape-id-0',
+    );
+    expect(patch).toBeUndefined();
+  });
+
+  it('should connect path by end to shape if connected by start already', () => {
+    const patch = connectPathElement(
+      mockLineElement({
+        connectedElementStart: 'shape-id-0',
+      }),
+      'end',
+      'shape-id-1',
+    );
+    expect(patch).toEqual({
+      connectedElementEnd: 'shape-id-1',
+    });
+  });
+});
+
+describe('connectShapeElement', () => {
+  it('should connect shape', () => {
+    const patch = connectShapeElement(mockRectangleElement(), 'path-id-0');
+    expect(patch).toEqual({
+      connectedPaths: ['path-id-0'],
+    });
+  });
+
+  it('should connect shape if has connection already', () => {
+    const patch = connectShapeElement(
+      mockRectangleElement({
+        connectedPaths: ['path-id-1'],
+      }),
+      'path-id-2',
+    );
+    expect(patch).toEqual({
+      connectedPaths: ['path-id-1', 'path-id-2'],
+    });
+  });
+
+  it('should handle connection to the same path again', () => {
+    const patch = connectShapeElement(
+      mockRectangleElement({
+        connectedPaths: ['path-id-1'],
+      }),
+      'path-id-1',
+    );
+    expect(patch).toEqual({
+      connectedPaths: ['path-id-1', 'path-id-1'],
+    });
+  });
+});
+
+describe('disconnectPathElementOnPosition', () => {
+  it('should disconnect path start', () => {
+    const patch = disconnectPathElementOnPosition(
+      mockLineElement({
+        connectedElementStart: 'element-id-0',
+        connectedElementEnd: 'element-id-1',
+      }),
+      'start',
+    );
+    expect(patch).toStrictEqual({
+      connectedElementStart: undefined,
+    });
+  });
+
+  it('should disconnect path start if no connection on end', () => {
+    const patch = disconnectPathElementOnPosition(
+      mockLineElement({
+        connectedElementStart: 'element-id-0',
+      }),
+      'start',
+    );
+    expect(patch).toStrictEqual({
+      connectedElementStart: undefined,
+    });
+  });
+
+  it('should disconnect path end', () => {
+    const patch = disconnectPathElementOnPosition(
+      mockLineElement({
+        connectedElementStart: 'element-id-0',
+        connectedElementEnd: 'element-id-1',
+      }),
+      'end',
+    );
+    expect(patch).toStrictEqual({
+      connectedElementEnd: undefined,
+    });
+  });
+
+  it('should disconnect path end if no connection on start', () => {
+    const patch = disconnectPathElementOnPosition(
+      mockLineElement({
+        connectedElementEnd: 'element-id-1',
+      }),
+      'end',
+    );
+    expect(patch).toStrictEqual({
+      connectedElementEnd: undefined,
+    });
+  });
+
+  it('should not disconnect path start if no connection', () => {
+    const patch = disconnectPathElementOnPosition(
+      mockLineElement({
+        connectedElementEnd: 'element-id-1',
+      }),
+      'start',
+    );
+    expect(patch).toEqual(undefined);
+  });
+
+  it('should not disconnect path end if not connection', () => {
+    const patch = disconnectPathElementOnPosition(
+      mockLineElement({
+        connectedElementStart: 'element-id-0',
+      }),
+      'end',
+    );
+    expect(patch).toEqual(undefined);
+  });
+});
+
+describe('disconnectPathElement', () => {
+  it('should disconnect path start by element id', () => {
+    const patch = disconnectPathElement(
+      mockLineElement({
+        connectedElementStart: 'element-id-0',
+        connectedElementEnd: 'element-id-1',
+      }),
+      ['element-id-0'],
+    );
+    expect(patch).toStrictEqual({
+      connectedElementStart: undefined,
+    });
+  });
+
+  it('should disconnect path end by element id', () => {
+    const patch = disconnectPathElement(
+      mockLineElement({
+        connectedElementStart: 'element-id-0',
+        connectedElementEnd: 'element-id-1',
+      }),
+      ['element-id-1'],
+    );
+    expect(patch).toStrictEqual({
+      connectedElementEnd: undefined,
+    });
+  });
+
+  it('should disconnect all path elements by ids', () => {
+    const patch = disconnectPathElement(
+      mockLineElement({
+        connectedElementStart: 'element-id-0',
+        connectedElementEnd: 'element-id-1',
+      }),
+      ['element-id-0', 'element-id-1'],
+    );
+    expect(patch).toStrictEqual({
+      connectedElementStart: undefined,
+      connectedElementEnd: undefined,
+    });
+  });
+
+  it('should disconnect all path elements passing undefined', () => {
+    const patch = disconnectPathElement(
+      mockLineElement({
+        connectedElementStart: 'element-id-0',
+        connectedElementEnd: 'element-id-1',
+      }),
+      undefined,
+    );
+    expect(patch).toStrictEqual({
+      connectedElementStart: undefined,
+      connectedElementEnd: undefined,
+    });
+  });
+
+  it('should not disconnect if not connected to element', () => {
+    const patch = disconnectPathElement(
+      mockLineElement({
+        connectedElementStart: 'element-id-0',
+        connectedElementEnd: 'element-id-1',
+      }),
+      ['element-id-2'],
+    );
+    expect(patch).toEqual(undefined);
+  });
+
+  it('should not disconnect if not connected to element and no connections', () => {
+    const patch = disconnectPathElement(mockLineElement(), ['element-id-2']);
+    expect(patch).toEqual(undefined);
+  });
+});
+
+describe('disconnectShapeElement', () => {
+  it('should disconnect shape by element id', () => {
+    const patch = disconnectShapeElement(
+      mockRectangleElement({
+        connectedPaths: ['element-id-0', 'element-id-1'],
+      }),
+      ['element-id-1'],
+    );
+    expect(patch).toEqual({
+      connectedPaths: ['element-id-0'],
+    });
+  });
+
+  it('should disconnect all shape elements by ids', () => {
+    const patch = disconnectShapeElement(
+      mockRectangleElement({
+        connectedPaths: ['element-id-0', 'element-id-1'],
+      }),
+      ['element-id-0', 'element-id-1'],
+    );
+    expect(patch).toStrictEqual({
+      connectedPaths: undefined,
+    });
+  });
+
+  it('should disconnect all shape elements passing undefined', () => {
+    const patch = disconnectShapeElement(
+      mockRectangleElement({
+        connectedPaths: ['element-id-0', 'element-id-1'],
+      }),
+      undefined,
+    );
+    expect(patch).toStrictEqual({
+      connectedPaths: undefined,
+    });
+  });
+
+  it('should not disconnect if not connected to element', () => {
+    const patch = disconnectShapeElement(
+      mockRectangleElement({
+        connectedPaths: ['element-id-0', 'element-id-1'],
+      }),
+      ['element-id-2'],
+    );
+    expect(patch).toEqual(undefined);
+  });
+
+  it('should not disconnect if not connected to element and no connections', () => {
+    const patch = disconnectShapeElement(mockRectangleElement(), [
+      'element-id-2',
+    ]);
+    expect(patch).toEqual(undefined);
+  });
+
+  it('should disconnect element only once', () => {
+    const patch = disconnectShapeElement(
+      mockRectangleElement({
+        connectedPaths: ['element-id-0', 'element-id-1', 'element-id-0'],
+      }),
+      ['element-id-0'],
+    );
+    expect(patch).toEqual({
+      connectedPaths: ['element-id-1', 'element-id-0'],
+    });
+  });
+
+  it('should force to disconnect all passed elements', () => {
+    const patch = disconnectShapeElement(
+      mockRectangleElement({
+        connectedPaths: ['element-id-0', 'element-id-1', 'element-id-0'],
+      }),
+      ['element-id-0'],
+      true,
+    );
+    expect(patch).toEqual({
+      connectedPaths: ['element-id-1'],
+    });
+  });
+});
+
+describe('deleteConnectionData', () => {
+  it('should delete connection data from shape', () => {
+    expect(
+      deleteConnectionData(
+        mockRectangleElement({
+          connectedPaths: ['element-id-0', 'element-id-1'],
+        }),
+      ),
+    ).toEqual(mockRectangleElement());
+  });
+
+  it('should delete connection data from line', () => {
+    expect(
+      deleteConnectionData(
+        mockLineElement({
+          connectedElementStart: 'element-id-0',
+          connectedElementEnd: 'element-id-1',
+        }),
+      ),
+    ).toEqual(mockLineElement());
+  });
+});

--- a/packages/react-sdk/src/state/utils.ts
+++ b/packages/react-sdk/src/state/utils.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2025 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isEqual, uniq } from 'lodash';
+import { Element, PathElement, ShapeElement } from './crdt';
+import { Elements } from './types';
+
+/**
+ * Within selected elements it finds not selected connecting paths.
+ * @param elements selected elements
+ */
+export function findConnectingPaths(elements: Elements): string[] {
+  const elementIds: string[] = [];
+
+  for (const element of Object.values(elements)) {
+    if (element.type === 'shape' && element.connectedPaths) {
+      for (const pathElementId of element.connectedPaths) {
+        if (!elements[pathElementId]) {
+          elementIds.push(pathElementId);
+        }
+      }
+    }
+  }
+
+  return uniq(elementIds);
+}
+
+/**
+ * Within selected elements it finds not selected connecting shapes.
+ * @param elements selected elements
+ */
+export function findConnectingShapes(elements: Elements): string[] {
+  const elementIds: string[] = [];
+
+  for (const element of Object.values(elements)) {
+    if (element.type === 'path') {
+      const connectedElements = [
+        element.connectedElementStart,
+        element.connectedElementEnd,
+      ];
+      for (const shapeElementId of connectedElements) {
+        if (shapeElementId && !elements[shapeElementId]) {
+          elementIds.push(shapeElementId);
+        }
+      }
+    }
+  }
+
+  return uniq(elementIds);
+}
+
+export function connectPathElement(
+  { connectedElementStart, connectedElementEnd }: PathElement,
+  position: 'start' | 'end',
+  shapeElementId: string,
+):
+  | Pick<PathElement, 'connectedElementStart' | 'connectedElementEnd'>
+  | undefined {
+  if (position === 'start' && shapeElementId !== connectedElementStart) {
+    return {
+      connectedElementStart: shapeElementId,
+    };
+  }
+
+  if (position === 'end' && shapeElementId !== connectedElementEnd) {
+    return {
+      connectedElementEnd: shapeElementId,
+    };
+  }
+
+  return undefined;
+}
+
+export function connectShapeElement(
+  { connectedPaths }: ShapeElement,
+  pathElementId: string,
+): Pick<ShapeElement, 'connectedPaths'> | undefined {
+  return {
+    connectedPaths: [...(connectedPaths ?? []), pathElementId],
+  };
+}
+
+export function disconnectPathElementOnPosition(
+  { connectedElementStart, connectedElementEnd }: PathElement,
+  position: 'start' | 'end',
+):
+  | Pick<PathElement, 'connectedElementStart' | 'connectedElementEnd'>
+  | undefined {
+  if (position === 'start' && connectedElementStart !== undefined) {
+    return {
+      connectedElementStart: undefined,
+    };
+  }
+
+  if (position === 'end' && connectedElementEnd !== undefined) {
+    return {
+      connectedElementEnd: undefined,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Create patch to disconnect path element from other elements.
+ * @param pathElement path element
+ * @param elementIds elements to disconnect or undefined it to disconnect all
+ * @return patch with new connected elements or undefined if no changes needed
+ */
+export function disconnectPathElement(
+  { connectedElementStart, connectedElementEnd }: PathElement,
+  elementIds: string[] | undefined,
+):
+  | Pick<PathElement, 'connectedElementStart' | 'connectedElementEnd'>
+  | undefined {
+  if (!connectedElementStart && !connectedElementEnd) {
+    return undefined;
+  }
+
+  if (!elementIds) {
+    return {
+      ...(connectedElementStart && {
+        connectedElementStart: undefined,
+      }),
+      ...(connectedElementEnd && {
+        connectedElementEnd: undefined,
+      }),
+    };
+  }
+
+  if (
+    connectedElementStart &&
+    !elementIds.includes(connectedElementStart) &&
+    connectedElementEnd &&
+    !elementIds.includes(connectedElementEnd)
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(connectedElementStart &&
+      elementIds.includes(connectedElementStart) && {
+        connectedElementStart: undefined,
+      }),
+    ...(connectedElementEnd &&
+      elementIds.includes(connectedElementEnd) && {
+        connectedElementEnd: undefined,
+      }),
+  };
+}
+
+export function disconnectShapeElement(
+  element: ShapeElement,
+  elementIds: string[] | undefined,
+  disconnectDuplicates: boolean = false,
+): Pick<ShapeElement, 'connectedPaths'> | undefined {
+  const connectedPaths = element.connectedPaths;
+  if (!connectedPaths) {
+    return undefined;
+  }
+
+  let newConnectedPaths: string[] | undefined;
+  if (elementIds) {
+    newConnectedPaths = [];
+    const found: Set<string> = new Set<string>();
+    for (let i = 0; i < connectedPaths.length; i++) {
+      const connectedPath = connectedPaths[i];
+      if (
+        elementIds.includes(connectedPath) &&
+        (disconnectDuplicates || !found.has(connectedPath))
+      ) {
+        found.add(connectedPath);
+      } else {
+        newConnectedPaths.push(connectedPath);
+      }
+    }
+
+    if (newConnectedPaths.length == 0) {
+      newConnectedPaths = undefined;
+    }
+  } else {
+    newConnectedPaths = undefined;
+  }
+
+  if (isEqual(connectedPaths, newConnectedPaths)) {
+    return undefined;
+  } else {
+    return {
+      connectedPaths: newConnectedPaths,
+    };
+  }
+}
+
+export function deleteConnectionData(element: Element): Element {
+  if (element.type === 'shape') {
+    const { connectedPaths, ...newElement } = element;
+    return newElement;
+  } else if (element.type === 'path') {
+    const { connectedElementStart, connectedElementEnd, ...newElement } =
+      element;
+    return newElement;
+  } else {
+    return element;
+  }
+}


### PR DESCRIPTION
Provides a way to connect lines with shapes by dragging line start or end handler over the shape area:

https://github.com/user-attachments/assets/cc7a357d-49ad-440a-aca2-ff6000d23f7c

Updates move, resize multiselect operations to work with connected elements:

https://github.com/user-attachments/assets/69c74be8-199f-44e0-8728-913b1adbbf53

In addition:

- Connected elements have their IDs exported in nwb file. These ids are loaded by import to keep the connections.
- Copy-paste, duplication of elements operations currently no not keep connection data.


<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
