### PR TITLE
Use absolute paths for Vitest setup files

### DIFF
--- a/matrix-neoboard-widget/vitest.config.ts
+++ b/matrix-neoboard-widget/vitest.config.ts
@@ -16,7 +16,10 @@
 
 /// <reference types="vitest" />
 
+import path from 'path';
 import { defineConfig } from 'vite';
+
+const __dirname = path.dirname(__filename);
 
 export default defineConfig({
   resolve: {
@@ -31,7 +34,7 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    setupFiles: ['./src/setupTests.ts'],
+    setupFiles: [path.resolve(__dirname, './src/setupTests.ts')],
     exclude: ['build', 'lib'],
     server: {
       deps: {

--- a/packages/react-sdk/vitest.config.ts
+++ b/packages/react-sdk/vitest.config.ts
@@ -16,7 +16,10 @@
 
 /// <reference types="vitest" />
 
+import path from 'path';
 import { defineConfig } from 'vite';
+
+const __dirname = path.dirname(__filename);
 
 export default defineConfig({
   resolve: {
@@ -33,7 +36,7 @@ export default defineConfig({
   test: {
     // Happy-Dom has no support for the blob: scheme. So we need to use jsdom
     environment: 'jsdom',
-    setupFiles: ['./src/setupTests.ts'],
+    setupFiles: [path.resolve(__dirname, './src/setupTests.ts')],
     exclude: ['build', 'lib'],
     server: {
       deps: {


### PR DESCRIPTION
With relative paths it may fail depending on the environment running the tests.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
