### PR TITLE
PDF Export: Don't crash when a board uses the new fonts

### DIFF
--- a/.changeset/web-anything-pets.md
+++ b/.changeset/web-anything-pets.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': minor
+---
+
+Fix PDF export, if the new fonts are used. Use the Inter font for all text.

--- a/packages/react-sdk/src/components/BoardBar/pdf/createFontConfig.ts
+++ b/packages/react-sdk/src/components/BoardBar/pdf/createFontConfig.ts
@@ -38,11 +38,29 @@ export function createFontConfig(): FontConfig {
     italics: 'Roboto-Italic.ttf',
     bolditalics: 'Roboto-MediumItalic.ttf',
   };
+  config.fonts['Abel'] = {
+    normal: 'Inter-400.woff2',
+  };
+  config.fonts['Actor'] = {
+    normal: 'Inter-400.woff2',
+  };
+  config.fonts['Adamina'] = {
+    normal: 'Inter-400.woff2',
+  };
+  config.fonts['Chewy'] = {
+    normal: 'Inter-400.woff2',
+  };
+  config.fonts['Gwendolyn'] = {
+    normal: 'Inter-400.woff2',
+  };
   config.fonts['Inter'] = {
     normal: 'Inter-400.woff2',
   };
   config.fonts['Noto Emoji'] = {
     normal: 'NotoEmoji-Regular.ttf',
+  };
+  config.fonts['Pirata One'] = {
+    normal: 'Inter-400.woff2',
   };
 
   return config;


### PR DESCRIPTION
Fix by adding a font definition for all new font names.

In the PDF, all fonts will use the Inter font.

[Peek 2025-03-10 17-34.webm](https://github.com/user-attachments/assets/ebe8412c-f2f6-4e07-b77b-d9ea84faf67b)

Test file:

```json
{"version":"net.nordeck.whiteboard@v1","whiteboard":{"slides":[{"elements":[{"fillColor":"#ffefc1","height":140,"position":{"x":1040,"y":660},"type":"shape","kind":"rectangle","width":420,"text":"Pirata One","textFontFamily":"Pirata One"},{"fillColor":"#ffefc1","height":140,"position":{"x":460,"y":260},"type":"shape","kind":"rectangle","width":220,"text":"Abel","textFontFamily":"Abel"},{"fillColor":"#ffefc1","height":140,"position":{"x":820,"y":200},"type":"shape","kind":"rectangle","width":220,"text":"Actor","textFontFamily":"Actor"},{"fillColor":"#ffefc1","height":140,"position":{"x":420,"y":700},"type":"shape","kind":"rectangle","width":500,"text":"Adamina","textFontFamily":"Adamina"},{"fillColor":"#ffefc1","height":140,"position":{"x":1220,"y":400},"type":"shape","kind":"rectangle","width":500,"text":"Chewy","textFontFamily":"Chewy"},{"fillColor":"#ffefc1","height":140,"position":{"x":240,"y":480},"type":"shape","kind":"rectangle","width":500,"text":"Gwendolyn","textFontFamily":"Gwendolyn"},{"fillColor":"#ffefc1","height":140,"position":{"x":800,"y":440},"type":"shape","kind":"rectangle","width":320,"text":"Inter","textFontFamily":"Inter"}]}]}}
```

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
