### PR TITLE
Improve the behavior of connecting a line to a shape

### DIFF
--- a/.changeset/real-candies-tan.md
+++ b/.changeset/real-candies-tan.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+Improve the behavior of connecting a line to a shape

--- a/packages/react-sdk/src/components/ConnectionPointProvider/ConnectionPointProvider.tsx
+++ b/packages/react-sdk/src/components/ConnectionPointProvider/ConnectionPointProvider.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { isEqual } from 'lodash';
 import {
   createContext,
   PropsWithChildren,
@@ -30,10 +31,10 @@ type ConnectionPointContextType = {
   setIsHandleDragging: (value: boolean) => void;
 
   /**
-   * Is an element id when handle is over element's connection point, undefined otherwise.
+   * Elements to activate connection to.
    */
-  connectElementId: string | undefined;
-  setConnectElementId: (value: string | undefined) => void;
+  connectElementIds: string[];
+  setConnectElementIds: (value: string[]) => void;
 };
 
 const ConnectionPointContext = createContext<
@@ -42,16 +43,18 @@ const ConnectionPointContext = createContext<
 
 export function ConnectionPointProvider({ children }: PropsWithChildren) {
   const [isHandleDragging, setIsHandleDragging] = useState(false);
-  const [connectElementId, setConnectElementId] = useState<string>();
+  const [connectElementIds, setConnectElementIds] = useState<string[]>([]);
 
   const context = useMemo(
     () => ({
       isHandleDragging,
       setIsHandleDragging,
-      connectElementId,
-      setConnectElementId,
+      connectElementIds,
+      setConnectElementIds: (value: string[]) => {
+        setConnectElementIds((old) => (isEqual(old, value) ? old : value));
+      },
     }),
-    [connectElementId, isHandleDragging],
+    [connectElementIds, isHandleDragging],
   );
 
   return (

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Connectable/ConnectableElement.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Connectable/ConnectableElement.tsx
@@ -22,7 +22,7 @@ import { useConnectionPoint } from '../../../ConnectionPointProvider';
 import { useSvgScaleContext } from '../../SvgScaleContext';
 import { ActivationArea } from './ActivationArea';
 
-type ConnectableElementProps = {
+export type ConnectableElementProps = {
   elementId: string;
   element: ShapeElement;
 };
@@ -48,11 +48,11 @@ export function ConnectableElement({
   const connectionAnchorSize = 5 / scale;
   const connectionAnchorCornerRadius = 3 / 2 / scale;
 
-  const { connectElementId } = useConnectionPoint();
+  const { connectElementIds } = useConnectionPoint();
 
   useEffect(() => {
-    setShowConnectionAnchors(elementId === connectElementId);
-  }, [connectElementId, elementId]);
+    setShowConnectionAnchors(connectElementIds.includes(elementId));
+  }, [connectElementIds, elementId]);
 
   const points = useMemo(
     () =>

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Connectable/index.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Connectable/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { ConnectableElement } from './ConnectableElement';
+export type { ConnectableElementProps } from './ConnectableElement';

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeElement.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeElement.test.tsx
@@ -68,7 +68,7 @@ vi.mock('../../SvgCanvas/useMeasure', () => {
 });
 
 beforeAll(() => {
-  document.elementFromPoint = vi.fn();
+  document.elementsFromPoint = vi.fn().mockReturnValue([]);
 });
 
 describe('<ResizeElement />', () => {

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeElement.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeElement.tsx
@@ -61,7 +61,8 @@ export function ResizeHandleWrapper({
 }: ResizeHandleWrapperProps) {
   const { isShowGrid } = useLayoutState();
   const { viewportWidth, viewportHeight } = useSvgCanvasContext();
-  const { connectElementId } = useConnectionPoint();
+  const { connectElementIds } = useConnectionPoint();
+  const hasConnectElementId = connectElementIds.length > 0;
 
   const handleDrag = useCallback(
     (event: DragEvent) => {
@@ -72,7 +73,7 @@ export function ResizeHandleWrapper({
           viewportWidth,
           viewportHeight,
           invertLockAspectRatio,
-          isShowGrid && !connectElementId ? gridCellSize : undefined,
+          isShowGrid && !hasConnectElementId ? gridCellSize : undefined,
           resizableProperties,
         ),
       );
@@ -85,7 +86,7 @@ export function ResizeHandleWrapper({
       resizableProperties,
       viewportHeight,
       viewportWidth,
-      connectElementId,
+      hasConnectElementId,
     ],
   );
 

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeHandle.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/ResizeHandle.tsx
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+import { last } from 'lodash';
 import { Dispatch, RefObject, useCallback, useRef } from 'react';
 import { DraggableCore, DraggableData, DraggableEvent } from 'react-draggable';
-import { Point } from '../../../../state';
 import { useConnectionPoint } from '../../../ConnectionPointProvider';
 import { useSvgCanvasContext } from '../../SvgCanvas';
 import { useSvgScaleContext } from '../../SvgScaleContext';
+import { findConnectData } from './findConnectData';
 import { HandlePosition, LineElementHandlePositionName } from './types';
 import { isLineElementHandlePosition } from './utils';
 
@@ -143,51 +144,6 @@ function calculateResizeHandlePosition(params: {
   }
 }
 
-type ConnectData = {
-  connectElementId: string;
-  connectPoint?: Point;
-};
-
-function findConnectData(
-  data: DraggableData,
-  scale: number,
-): ConnectData | undefined {
-  const element = document.elementFromPoint(data.x * scale, data.y * scale);
-
-  if (!element) {
-    return undefined;
-  }
-
-  const connectType = element.getAttribute('data-connect-type');
-  if (!connectType) {
-    return undefined;
-  }
-
-  const connectElementId =
-    element.getAttribute('data-connect-element-id') ?? undefined;
-  if (!connectElementId) {
-    return undefined;
-  }
-
-  let connectPoint: Point | undefined;
-
-  if (
-    connectType === 'connection-point-area' ||
-    connectType === 'connection-point'
-  ) {
-    const rect = element.getBoundingClientRect();
-    connectPoint = {
-      x: (rect.x + rect.width / 2) / scale,
-      y: (rect.y + rect.height / 2) / scale,
-    };
-  }
-
-  return {
-    connectElementId,
-    connectPoint,
-  };
-}
-
 export type DragEvent = {
   x: number;
   y: number;
@@ -209,7 +165,7 @@ export type ResizeHandleProps = {
 
 export function ResizeHandle(props: ResizeHandleProps) {
   const nodeRef = useRef<SVGRectElement>(null);
-  const { isHandleDragging, setIsHandleDragging, setConnectElementId } =
+  const { isHandleDragging, setIsHandleDragging, setConnectElementIds } =
     useConnectionPoint();
   const { calculateSvgCoords } = useSvgCanvasContext();
   const { scale } = useSvgScaleContext();
@@ -249,21 +205,24 @@ export function ResizeHandle(props: ResizeHandleProps) {
 
   const handleDrag = useCallback(
     (event: DraggableEvent, data: DraggableData) => {
-      let connectPoint: Point | undefined;
+      let newData: DraggableData = data;
 
       if (isHandleDragging) {
-        const connectData = findConnectData(data, scale);
-        setConnectElementId(connectData?.connectElementId);
-        connectPoint = connectData?.connectPoint;
-      }
+        const { connectElementIds, connectPoint } = findConnectData(
+          data.x,
+          data.y,
+          scale,
+        );
 
-      const newData: DraggableData = connectPoint
-        ? { ...data, x: connectPoint.x, y: connectPoint.y }
-        : data;
+        setConnectElementIds(connectElementIds);
+        if (connectPoint) {
+          newData = { ...data, x: connectPoint.x, y: connectPoint.y };
+        }
+      }
 
       dispatchDragEvent(onDrag, event, newData, undefined);
     },
-    [dispatchDragEvent, isHandleDragging, onDrag, scale, setConnectElementId],
+    [dispatchDragEvent, isHandleDragging, onDrag, scale, setConnectElementIds],
   );
 
   const handleStart = useCallback(
@@ -281,17 +240,20 @@ export function ResizeHandle(props: ResizeHandleProps) {
       let dragConnectData: DragConnectData | undefined;
 
       if (name === 'start' || name === 'end') {
-        const connectData = findConnectData(data, scale);
+        const { connectElementIds, connectPoint } = findConnectData(
+          data.x,
+          data.y,
+          scale,
+        );
 
+        const connectElementId = last(connectElementIds);
         dragConnectData = {
           lineHandlePositionName: name,
           connectToElementId:
-            connectData?.connectElementId && connectData?.connectPoint
-              ? connectData?.connectElementId
-              : undefined,
+            connectElementId && connectPoint ? connectElementId : undefined,
         };
 
-        setConnectElementId(undefined);
+        setConnectElementIds([]);
         setIsHandleDragging(false);
       }
       dispatchDragEvent(onDragStop, event, data, dragConnectData);
@@ -302,7 +264,7 @@ export function ResizeHandle(props: ResizeHandleProps) {
       name,
       scale,
       setIsHandleDragging,
-      setConnectElementId,
+      setConnectElementIds,
     ],
   );
 

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/findConnectData.test.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/findConnectData.test.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2025 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { findConnectData } from './findConnectData';
+
+beforeAll(() => {
+  document.elementsFromPoint = vi.fn().mockReturnValue([]);
+});
+
+describe('findConnectData', () => {
+  it('should find no elements to connect', () => {
+    vi.mocked(document.elementsFromPoint).mockReturnValue([
+      mockElement(),
+      mockElement({ key: 'value' }),
+      mockElement({ key1: 'value1' }),
+    ]);
+    expect(findConnectData(10, 10, 1)).toEqual({ connectElementIds: [] });
+  });
+
+  it('should find elements to connect when hover single activation area', () => {
+    vi.mocked(document.elementsFromPoint).mockReturnValue([
+      mockElement(),
+      mockElement({ key: 'value' }),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-1',
+      }),
+      mockElement({ key2: 'value2' }),
+    ]);
+    expect(findConnectData(10, 10, 1)).toEqual({
+      connectElementIds: ['shape-id-1'],
+    });
+  });
+
+  it('should ignore elements to connect after svg element', () => {
+    vi.mocked(document.elementsFromPoint).mockReturnValue([
+      mockElement({}, 'svg'),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-1',
+      }),
+    ]);
+    expect(findConnectData(10, 10, 1)).toEqual({
+      connectElementIds: [],
+    });
+  });
+
+  it('should find elements to connect when hover several activation areas', () => {
+    vi.mocked(document.elementsFromPoint).mockReturnValue([
+      mockElement(),
+      mockElement({ key: 'value' }),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-1',
+      }),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-2',
+      }),
+      mockElement({ key1: 'value1' }),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-3',
+      }),
+      mockElement({ key2: 'value2' }),
+    ]);
+    expect(findConnectData(10, 10, 1)).toEqual({
+      connectElementIds: ['shape-id-1', 'shape-id-2', 'shape-id-3'],
+    });
+  });
+
+  it('should find elements to connect when hover several activation areas and a shape', () => {
+    vi.mocked(document.elementsFromPoint).mockReturnValue([
+      mockElement(),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-1',
+      }),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-2',
+      }),
+      mockElement({
+        ['data-connect-type']: 'connectable-element',
+      }),
+      mockElement({ key1: 'value1' }),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-3',
+      }),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-4',
+      }),
+      mockElement({
+        ['data-connect-type']: 'connectable-element',
+      }),
+    ]);
+    expect(findConnectData(10, 10, 1)).toEqual({
+      connectElementIds: ['shape-id-1', 'shape-id-2'],
+    });
+  });
+
+  it('should find elements to connect when hover several activation areas and a connection point area', () => {
+    vi.mocked(document.elementsFromPoint).mockReturnValue([
+      mockElement(),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-1',
+      }),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-2',
+      }),
+      mockElement({
+        ['data-connect-type']: 'connection-point-area',
+        ['data-connect-element-id']: 'shape-id-3',
+      }),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-3',
+      }),
+      mockElement({
+        ['data-connect-type']: 'connectable-element',
+      }),
+      mockElement({ key1: 'value1' }),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-4',
+      }),
+    ]);
+    expect(findConnectData(10, 10, 1)).toEqual({
+      connectElementIds: ['shape-id-1', 'shape-id-2', 'shape-id-3'],
+      connectPoint: { x: 20, y: 20 },
+    });
+  });
+
+  it('should find elements to connect when hover several activation areas and a connection point', () => {
+    vi.mocked(document.elementsFromPoint).mockReturnValue([
+      mockElement(),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-1',
+      }),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-2',
+      }),
+      mockElement({
+        ['data-connect-type']: 'connection-point',
+        ['data-connect-element-id']: 'shape-id-3',
+      }),
+      mockElement({
+        ['data-connect-type']: 'connection-point-area',
+        ['data-connect-element-id']: 'shape-id-3',
+      }),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-3',
+      }),
+      mockElement({
+        ['data-connect-type']: 'connectable-element',
+      }),
+      mockElement({ key1: 'value1' }),
+      mockElement({
+        ['data-connect-type']: 'activation-area',
+        ['data-connect-element-id']: 'shape-id-4',
+      }),
+    ]);
+    expect(findConnectData(10, 10, 1)).toEqual({
+      connectElementIds: ['shape-id-1', 'shape-id-2', 'shape-id-3'],
+      connectPoint: { x: 20, y: 20 },
+    });
+  });
+});
+
+function mockElement(
+  attributes: Record<string, string> = {},
+  localName: string = 'rect',
+  domRect: DOMRect = {
+    x: 0,
+    y: 0,
+    width: 40,
+    height: 40,
+  } as unknown as DOMRect,
+): Element {
+  return {
+    localName,
+    getAttribute(qualifiedName: string): string | null {
+      return attributes[qualifiedName] ?? null;
+    },
+    getBoundingClientRect(): DOMRect {
+      return domRect;
+    },
+  } as unknown as Element;
+}

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/findConnectData.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Resizable/findConnectData.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Point } from '../../../../state';
+
+type ConnectData = {
+  /**
+   * Elements to activate connection to.
+   */
+  connectElementIds: string[];
+
+  /**
+   * A connection point.
+   */
+  connectPoint?: Point;
+};
+
+/**
+ * Uses document to find elements around x,y position and a connection point.
+ * @param x viewport x position
+ * @param y viewport y position
+ * @param scale svg scale
+ * @return connect data
+ */
+export function findConnectData(
+  x: number,
+  y: number,
+  scale: number,
+): ConnectData {
+  const elements = document.elementsFromPoint(x * scale, y * scale);
+
+  const connectElementIds: string[] = [];
+  let connectPoint: Point | undefined;
+
+  for (const element of elements) {
+    if (element.localName === 'svg') {
+      // svg element is found
+      break;
+    }
+
+    const connectType = element.getAttribute('data-connect-type');
+    if (connectType === 'connectable-element') {
+      // shape element is found
+      break;
+    }
+
+    if (
+      connectType === 'activation-area' ||
+      connectType === 'connection-point-area' ||
+      connectType === 'connection-point'
+    ) {
+      const connectElementId = element.getAttribute('data-connect-element-id');
+
+      if (connectElementId) {
+        // push element id
+        connectElementIds.push(connectElementId);
+      } else {
+        throw new Error('data-connect-element-id must be defined');
+      }
+    }
+
+    if (
+      connectType === 'connection-point-area' ||
+      connectType === 'connection-point'
+    ) {
+      const rect = element.getBoundingClientRect();
+      connectPoint = {
+        x: (rect.x + rect.width / 2) / scale,
+        y: (rect.y + rect.height / 2) / scale,
+      };
+      // connection point is found
+      break;
+    }
+  }
+
+  return {
+    connectElementIds,
+    connectPoint,
+  };
+}

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.test.tsx
@@ -25,6 +25,7 @@ import {
   mockWhiteboardManager,
 } from '../../../../lib/testUtils/documentTestUtils';
 import { Point, WhiteboardSlideInstance } from '../../../../state';
+import { ConnectionPointProvider } from '../../../ConnectionPointProvider';
 import { LayoutStateProvider, useLayoutState } from '../../../Layout';
 import { WhiteboardHotkeysProvider } from '../../../WhiteboardHotkeysProvider';
 import { SvgCanvas } from '../../SvgCanvas';
@@ -103,9 +104,11 @@ describe('<DragSelect/>', () => {
             whiteboardManager={whiteboardManager}
             widgetApi={widgetApi}
           >
-            <SvgCanvas viewportWidth={200} viewportHeight={200}>
-              {children}
-            </SvgCanvas>
+            <ConnectionPointProvider>
+              <SvgCanvas viewportWidth={200} viewportHeight={200}>
+                {children}
+              </SvgCanvas>
+            </ConnectionPointProvider>
           </WhiteboardTestingContextProvider>
         </WhiteboardHotkeysProvider>
       </LayoutStateProvider>

--- a/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
@@ -19,7 +19,6 @@ import { useCallback, useRef, useState } from 'react';
 import {
   includesShapeWithText,
   includesTextShape,
-  isShapeElementPair,
   type Point,
   useActiveElements,
   useIsWhiteboardLoading,
@@ -28,7 +27,6 @@ import {
   useSlideIsLocked,
   useWhiteboardSlideInstance,
 } from '../../state';
-import { useConnectionPoint } from '../ConnectionPointProvider';
 import { ElementBar } from '../ElementBar';
 import { useElementOverrides } from '../ElementOverridesProvider';
 import { useLayoutState } from '../Layout';
@@ -41,7 +39,6 @@ import { CursorRenderer } from './CursorRenderer';
 import { DraftPicker } from './Draft/DraftPicker';
 import { ConnectedElement } from './Element';
 import {
-  ConnectableElement,
   ElementBarWrapper,
   ElementBorder,
   ElementOutline,
@@ -74,7 +71,6 @@ const WhiteboardHost = ({
     useLayoutState();
   const { activeElementIds } = useActiveElements();
   const overrides = useElementOverrides(activeElementIds);
-  const { isHandleDragging } = useConnectionPoint();
 
   const [textToolsEnabled, setTextToolsEnabled] = useState(false);
 
@@ -155,19 +151,6 @@ const WhiteboardHost = ({
             )}
           </>
         )}
-
-        {isHandleDragging &&
-          Object.entries(
-            slideInstance.getElements(slideInstance.getElementIds()),
-          )
-            .filter(isShapeElementPair)
-            .map(([elementId, element]) => (
-              <ConnectableElement
-                key={elementId}
-                elementId={elementId}
-                element={element}
-              />
-            ))}
 
         {isShowCollaboratorsCursors && !hideCursors && <CursorRenderer />}
       </SvgCanvas>

--- a/packages/react-sdk/src/components/elements/ellipse/Display.tsx
+++ b/packages/react-sdk/src/components/elements/ellipse/Display.tsx
@@ -48,6 +48,7 @@ const EllipseDisplay = ({
   const renderedChild = (
     <g>
       <ellipse
+        data-connect-type={`connectable-element`}
         cx={shape.position.x + cx}
         cy={shape.position.y + cy}
         fill={shape.fillColor}

--- a/packages/react-sdk/src/components/elements/rectangle/Display.tsx
+++ b/packages/react-sdk/src/components/elements/rectangle/Display.tsx
@@ -44,6 +44,7 @@ const RectangleDisplay = ({
   const renderedChild = (
     <g data-testid={dataTestid}>
       <rect
+        data-connect-type={`connectable-element`}
         x={shape.position.x}
         y={shape.position.y}
         fill={shape.fillColor}

--- a/packages/react-sdk/src/components/elements/triangle/Display.tsx
+++ b/packages/react-sdk/src/components/elements/triangle/Display.tsx
@@ -45,6 +45,7 @@ const TriangleDisplay = ({
   const renderedChild = (
     <g>
       <polygon
+        data-connect-type={`connectable-element`}
         fill={shape.fillColor}
         points={`${p0X},${p0Y} ${p1X},${p1Y} ${p2X},${p2Y}`}
         stroke={strokeColor}


### PR DESCRIPTION
Improves existing line to shape connection behavior. Especially in the case when shapes are close and on top of each other. In this case several shapes are activated.


https://github.com/user-attachments/assets/f4bf9da6-7604-4abc-979d-ed6b37ecafbb



<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
