### PR TITLE
Update deployment name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,4 +408,4 @@ jobs:
           KUBE_CONFIG_DATA: ${{ secrets.KUBECONFIG_NEOTOOLSUITE_DEV }}
         with:
           args: |
-            kubectl rollout restart deployment matrix-neoboard-infinite-canvas -n matrix
+            kubectl rollout restart deployment matrix-neoboard-widget-infinite-canvas -n matrix


### PR DESCRIPTION
while the (helm) release is called `matrix-neoboard-infinite-canvas`, the deployment rendered is called `matrix-neoboard-widget-infinite-canvas`
