### PR TITLE
Fix dev CI deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
               inputs: {
                 environment: '${{ secrets.GITOPS_DEPLOY_ENVIRONMENT}}',
                 application: 'matrix-neoboard',
-                tag: 'argo-${{ needs.build.outputs.ARGOCD_SHA }}'
+                tag: '${{ github.sha }}'
               }
             })
 


### PR DESCRIPTION
This reverts a "find-replace-o" from https://github.com/nordeck/matrix-neoboard/commit/2c45d2e9d383e38989a53512599b8adc1b92b015. The referenced CI needs the git version ("tag") rather than docker image tag.