### PR TITLE
Drop and paste elements to the mouse cursor position

### DIFF
--- a/.changeset/good-vans-fly.md
+++ b/.changeset/good-vans-fly.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+Improve drag and drop, copy and paste behaviours to add elements to the mouse cursor position

--- a/packages/react-sdk/src/components/ImageUpload/SlideImageUploadOverlay.test.tsx
+++ b/packages/react-sdk/src/components/ImageUpload/SlideImageUploadOverlay.test.tsx
@@ -35,6 +35,11 @@ import {
 import { WhiteboardSlideInstance } from '../../state';
 import { ImageUploadProvider } from '../ImageUpload';
 import { SnackbarProvider } from '../Snackbar';
+import { whiteboardHeight, whiteboardWidth } from '../Whiteboard';
+import {
+  SvgCanvasContextType,
+  SvgCanvasMockProvider,
+} from '../Whiteboard/SvgCanvas';
 import { SlideImageUploadOverlay } from './SlideImageUploadOverlay';
 import { readFileAsFile } from './imageTestUtils';
 
@@ -61,6 +66,13 @@ describe('SlideImageUploadOverlay', () => {
     slide = whiteboard.getSlide(whiteboard.getActiveSlideId()!);
     consoleSpy = vi.spyOn(console, 'error');
 
+    const value: SvgCanvasContextType = {
+      width: 100,
+      height: 100,
+      viewportWidth: whiteboardWidth,
+      viewportHeight: whiteboardHeight,
+      calculateSvgCoords: vi.fn(),
+    };
     handleDragLeave = vi.fn();
 
     Wrapper = () => {
@@ -71,7 +83,9 @@ describe('SlideImageUploadOverlay', () => {
             widgetApi={widgetApi}
           >
             <ImageUploadProvider>
-              <SlideImageUploadOverlay onDragLeave={handleDragLeave} />
+              <SvgCanvasMockProvider value={value}>
+                <SlideImageUploadOverlay onDragLeave={handleDragLeave} />
+              </SvgCanvasMockProvider>
             </ImageUploadProvider>
           </WhiteboardTestingContextProvider>
         </SnackbarProvider>

--- a/packages/react-sdk/src/components/ImageUpload/SlideImageUploadOverlay.tsx
+++ b/packages/react-sdk/src/components/ImageUpload/SlideImageUploadOverlay.tsx
@@ -17,6 +17,7 @@
 import { Box, styled } from '@mui/material';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSvgCanvasContext } from '../Whiteboard/SvgCanvas';
 import { useSlideImageUpload } from './useSlideImageUpload';
 
 type SlideImageUploadOverlayProps = {
@@ -26,8 +27,10 @@ type SlideImageUploadOverlayProps = {
 export const SlideImageUploadOverlay: React.FC<SlideImageUploadOverlayProps> =
   function ({ onDragLeave }) {
     const { t } = useTranslation('neoboard');
+    const { calculateSvgCoords } = useSvgCanvasContext();
     const { getRootProps, getInputProps } = useSlideImageUpload({
       noClick: true,
+      calculateSvgCoords,
     });
 
     return (

--- a/packages/react-sdk/src/components/ImageUpload/addImagesToSlide.ts
+++ b/packages/react-sdk/src/components/ImageUpload/addImagesToSlide.ts
@@ -15,9 +15,10 @@
  */
 
 import {
-  calculateCentredPosition,
   calculateFittedElementSize,
+  clampElementPosition,
   ImageElement,
+  Point,
   WhiteboardSlideInstance,
 } from '../../state';
 import { whiteboardHeight, whiteboardWidth } from '../Whiteboard';
@@ -26,28 +27,40 @@ import { ImageUploadResult } from './ImageUploadProvider';
 /**
  * Fit and centre and add images to a slide.
  *
+ * @param slide - slide instance
  * @param uploadResult - Information from the image upload
  * @param uploadResult[].mxc - MXC URI of the image {@link https://spec.matrix.org/v1.9/client-server-api/#matrix-content-mxc-uris}
  * @param uploadResult[].fileName - File name
  * @param uploadResult[].imageSize - Image size
+ * @param centerPosition - Image center position
  */
 export function addImagesToSlide(
   slide: WhiteboardSlideInstance,
   uploadResults: ImageUploadResult[],
+  centerPosition: Point,
 ): void {
   const images: ImageElement[] = uploadResults.map((uploadResult) => {
     const fittedSize = calculateFittedElementSize(uploadResult.size, {
       width: whiteboardWidth,
       height: whiteboardHeight,
     });
-    const centredPosition = calculateCentredPosition(fittedSize, {
-      width: whiteboardWidth,
-      height: whiteboardHeight,
-    });
+
+    const position: Point = {
+      x: centerPosition.x - fittedSize.width / 2,
+      y: centerPosition.y - fittedSize.height / 2,
+    };
+
+    const positionClamp = clampElementPosition(
+      position,
+      { width: fittedSize.width, height: fittedSize.height },
+      { width: whiteboardWidth, height: whiteboardHeight },
+    );
+
     return {
       type: 'image',
-      position: centredPosition,
-      ...fittedSize,
+      width: fittedSize.width,
+      height: fittedSize.height,
+      position: positionClamp,
       mxc: uploadResult.mxc,
       fileName: uploadResult.fileName,
     };

--- a/packages/react-sdk/src/components/Layout/Layout.tsx
+++ b/packages/react-sdk/src/components/Layout/Layout.tsx
@@ -33,7 +33,7 @@ import { ElementOverridesProvider } from '../ElementOverridesProvider';
 import { FullscreenModeBar } from '../FullscreenModeBar';
 import { GuidedTour } from '../GuidedTour';
 import { HelpCenterBar } from '../HelpCenterBar';
-import { ImageUploadProvider, useSlideImageDropUpload } from '../ImageUpload';
+import { ImageUploadProvider } from '../ImageUpload';
 import { ImportWhiteboardDialogProvider } from '../ImportWhiteboardDialog/ImportWhiteboardDialogProvider';
 import { PresentBar } from '../PresentBar';
 import { Shortcuts } from '../Shortcuts';
@@ -77,9 +77,6 @@ export function Layout({ height = '100vh' }: LayoutProps) {
   const { state: presentationState } = usePresentationMode();
   const isViewingPresentation = presentationState.type === 'presentation';
 
-  const { handleUploadDragEnter, uploadDragOverlay } =
-    useSlideImageDropUpload();
-
   const handleClose = useCallback(() => {
     setDeveloperToolsVisible(false);
   }, [setDeveloperToolsVisible]);
@@ -112,20 +109,13 @@ export function Layout({ height = '100vh' }: LayoutProps) {
               <SlideOverviewBar />
             </AnimatedSidebar>
 
-            <Box
-              component="main"
-              flex={1}
-              display="flex"
-              position="relative"
-              onDragEnter={handleUploadDragEnter}
-            >
+            <Box component="main" flex={1} display="flex" position="relative">
               {slideIds.map((slideId) => (
                 <TabPanelStyled value={slideId} key={slideId}>
                   <SlideProvider slideId={slideId}>
                     <ElementOverridesProvider>
                       <ConnectionPointProvider>
                         <ContentArea />
-                        {uploadDragOverlay}
                       </ConnectionPointProvider>
                     </ElementOverridesProvider>
                   </SlideProvider>

--- a/packages/react-sdk/src/components/Whiteboard/SvgCanvas/SvgCanvas.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/SvgCanvas/SvgCanvas.tsx
@@ -53,11 +53,13 @@ export type SvgCanvasProps = PropsWithChildren<{
   viewportHeight: number;
   rounded?: boolean;
   additionalChildren?: ReactNode;
+  topLevelChildren?: ReactNode;
   withOutline?: boolean;
   preview?: boolean;
 
   onMouseDown?: MouseEventHandler<SVGSVGElement> | undefined;
   onMouseMove?: (position: Point) => void | undefined;
+  onMouseLeave?: MouseEventHandler<SVGSVGElement>;
   onWheel?: WheelEventHandler;
 }>;
 
@@ -68,9 +70,11 @@ export const SvgCanvas = forwardRef(function SvgCanvas(
     children,
     rounded,
     additionalChildren,
+    topLevelChildren,
     withOutline,
     onMouseDown,
     onMouseMove,
+    onMouseLeave,
     preview,
     onWheel,
   }: SvgCanvasProps,
@@ -129,15 +133,15 @@ export const SvgCanvas = forwardRef(function SvgCanvas(
     : FiniteCanvasWrapper;
 
   return (
-    <CanvasWrapper
-      aspectRatio={aspectRatio}
-      sizeRef={sizeRef}
-      withOutline={withOutline}
-      width={width}
-      height={height}
-      preview={preview}
-    >
-      <SvgCanvasContext.Provider value={value}>
+    <SvgCanvasContext.Provider value={value}>
+      <CanvasWrapper
+        aspectRatio={aspectRatio}
+        sizeRef={sizeRef}
+        withOutline={withOutline}
+        width={width}
+        height={height}
+        preview={preview}
+      >
         <Canvas
           ref={svgRef}
           rounded={rounded}
@@ -167,6 +171,7 @@ export const SvgCanvas = forwardRef(function SvgCanvas(
           viewBox={`0 0 ${viewportWidth} ${viewportHeight}`}
           onMouseDown={onMouseDown}
           onMouseMove={handleMouseMove}
+          onMouseLeave={onMouseLeave}
           onWheel={onWheel}
           transform-origin={infiniteCanvasMode ? 'center center' : undefined}
           transform={
@@ -180,8 +185,9 @@ export const SvgCanvas = forwardRef(function SvgCanvas(
           {children}
         </Canvas>
         {additionalChildren}
-      </SvgCanvasContext.Provider>
-    </CanvasWrapper>
+      </CanvasWrapper>
+      {topLevelChildren}
+    </SvgCanvasContext.Provider>
   );
 });
 

--- a/packages/react-sdk/src/components/Whiteboard/SvgCanvas/context.ts
+++ b/packages/react-sdk/src/components/Whiteboard/SvgCanvas/context.ts
@@ -59,3 +59,10 @@ export const useSvgCanvasContext = (): SvgCanvasContextType => {
 
   return context;
 };
+
+/**
+ * Provides a custom instance of the `SvgCanvas` to the context.
+ *
+ * @remarks Should only be used in tests.
+ */
+export const SvgCanvasMockProvider = SvgCanvasContext.Provider;

--- a/packages/react-sdk/src/components/Whiteboard/SvgCanvas/index.ts
+++ b/packages/react-sdk/src/components/Whiteboard/SvgCanvas/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
-export { useSvgCanvasContext } from './context';
+export { SvgCanvasMockProvider, useSvgCanvasContext } from './context';
+export type { SvgCanvasContextType } from './context';
 export { SvgCanvas } from './SvgCanvas';
 export { useMeasure } from './useMeasure';

--- a/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../state';
 import { ElementBar } from '../ElementBar';
 import { useElementOverrides } from '../ElementOverridesProvider';
+import { useSlideImageDropUpload } from '../ImageUpload';
 import { useLayoutState } from '../Layout';
 import {
   infiniteCanvasMode,
@@ -72,6 +73,9 @@ const WhiteboardHost = ({
   const { activeElementIds } = useActiveElements();
   const overrides = useElementOverrides(activeElementIds);
 
+  const { handleUploadDragEnter, uploadDragOverlay } =
+    useSlideImageDropUpload();
+
   const [textToolsEnabled, setTextToolsEnabled] = useState(false);
 
   const hasElementWithText =
@@ -92,6 +96,7 @@ const WhiteboardHost = ({
       alignContent="space-around"
       position="relative"
       data-guided-tour-target="canvas"
+      onDragEnter={handleUploadDragEnter}
       {...(infiniteCanvasMode ? { width: '100vw', overflow: 'hidden' } : {})}
     >
       <SvgCanvas
@@ -107,14 +112,19 @@ const WhiteboardHost = ({
             </ElementBarWrapper>
           )
         }
+        topLevelChildren={uploadDragOverlay}
         rounded
         withOutline={withOutline}
         onMouseMove={useCallback(
           (position: Point) => {
+            slideInstance.setCursorPosition(position);
             slideInstance.publishCursorPosition(position);
           },
           [slideInstance],
         )}
+        onMouseLeave={useCallback(() => {
+          slideInstance.setCursorPosition(undefined);
+        }, [slideInstance])}
         onWheel={handleWheelZoom}
       >
         {!hideDotGrid && <DotGrid />}

--- a/packages/react-sdk/src/components/Whiteboard/index.ts
+++ b/packages/react-sdk/src/components/Whiteboard/index.ts
@@ -25,5 +25,6 @@ export * from './ElementBehaviors';
 export * from './Grid';
 export { SlidePreview } from './SlidePreview';
 export { SlideSkeleton } from './SlideSkeleton';
+export { useSvgScaleContext } from './SvgScaleContext';
 export type { ElementRenderProperties } from './types';
 export { WhiteboardHostConnected as WhiteboardHost } from './WhiteboardHost';

--- a/packages/react-sdk/src/state/crdt/documents/elements.test.ts
+++ b/packages/react-sdk/src/state/crdt/documents/elements.test.ts
@@ -22,8 +22,8 @@ import {
 } from '../../../lib/testUtils/documentTestUtils';
 import {
   calculateBoundingRectForElements,
-  calculateCentredPosition,
   calculateFittedElementSize,
+  clampElementPosition,
   elementSchema,
   includesTextShape,
   isShapeWithText,
@@ -380,44 +380,6 @@ describe('calculateBoundingRectForElements', () => {
   });
 });
 
-describe('calculateCentredPosition', () => {
-  it('should return 0, 0 if everything is 0', () => {
-    expect(
-      calculateCentredPosition(
-        { width: 0, height: 0 },
-        { width: 0, height: 0 },
-      ),
-    ).toEqual({ x: 0, y: 0 });
-  });
-
-  it('should return 0, 0 if the element and the container have the same size', () => {
-    expect(
-      calculateCentredPosition(
-        { width: 100, height: 50 },
-        { width: 100, height: 50 },
-      ),
-    ).toEqual({ x: 0, y: 0 });
-  });
-
-  it('should calculate the centred position if the element is smaller than the container', () => {
-    expect(
-      calculateCentredPosition(
-        { width: 20, height: 10 },
-        { width: 100, height: 50 },
-      ),
-    ).toEqual({ x: 40, y: 20 });
-  });
-
-  it('should calculate the centred position if the element is larger than the container', () => {
-    expect(
-      calculateCentredPosition(
-        { width: 100, height: 50 },
-        { width: 20, height: 10 },
-      ),
-    ).toEqual({ x: -40, y: -20 });
-  });
-});
-
 describe('calculateFittedElementSize', () => {
   it('should return 0, 0 if everything is 0', () => {
     expect(
@@ -465,6 +427,47 @@ describe('calculateFittedElementSize', () => {
         { width: 100, height: 25 },
       ),
     ).toEqual({ width: 20, height: 25 });
+  });
+});
+
+describe('clampElementPosition', () => {
+  it('should not change position if element fits into container', () => {
+    expect(
+      clampElementPosition(
+        { x: 10, y: 10 },
+        { width: 20, height: 20 },
+        { width: 100, height: 100 },
+      ),
+    ).toEqual({
+      x: 10,
+      y: 10,
+    });
+  });
+
+  it('should clamp to top left corner', () => {
+    expect(
+      clampElementPosition(
+        { x: -10, y: -10 },
+        { width: 20, height: 20 },
+        { width: 100, height: 100 },
+      ),
+    ).toEqual({
+      x: 0,
+      y: 0,
+    });
+  });
+
+  it('should clamp to bottom right corner', () => {
+    expect(
+      clampElementPosition(
+        { x: 95, y: 95 },
+        { width: 20, height: 20 },
+        { width: 100, height: 100 },
+      ),
+    ).toEqual({
+      x: 79,
+      y: 79,
+    });
   });
 });
 

--- a/packages/react-sdk/src/state/crdt/documents/elements.ts
+++ b/packages/react-sdk/src/state/crdt/documents/elements.ts
@@ -17,6 +17,7 @@
 import Joi from 'joi';
 import loglevel from 'loglevel';
 // Do not import from the index file to prevent cyclic dependencies
+import { clamp } from 'lodash';
 import { defaultAcceptedImageTypes } from '../../../components/ImageUpload/consts';
 import {
   BoundingRect,
@@ -237,6 +238,23 @@ export type Size = {
 };
 
 /**
+ * Clamp element position to fit into the container
+ * @param position element position
+ * @param elementSize element size
+ * @param containerSize container size
+ */
+export function clampElementPosition(
+  position: Point,
+  elementSize: Size,
+  containerSize: Size,
+): Point {
+  return {
+    x: clamp(position.x, 0, containerSize.width - elementSize.width - 1),
+    y: clamp(position.y, 0, containerSize.height - elementSize.height - 1),
+  };
+}
+
+/**
  * Calculate the size of an element so that it fits into a container.
  * Maintain the aspect ratio.
  *
@@ -263,23 +281,6 @@ export function calculateFittedElementSize(
   }
 
   return resultSize;
-}
-
-/**
- * Calculate the position of an element so that it is centred inside a container.
- *
- * @param element - Element containing bounding rectangle size
- * @param containerSize - Container size to centre the element inside
- * @returns Centred top left position
- */
-export function calculateCentredPosition(
-  element: Size,
-  containerSize: Size,
-): Point {
-  return {
-    x: Math.round((containerSize.width - element.width) / 2),
-    y: Math.round((containerSize.height - element.height) / 2),
-  };
 }
 
 /**

--- a/packages/react-sdk/src/state/crdt/documents/index.ts
+++ b/packages/react-sdk/src/state/crdt/documents/index.ts
@@ -16,8 +16,8 @@
 
 export {
   calculateBoundingRectForElements,
-  calculateCentredPosition,
   calculateFittedElementSize,
+  clampElementPosition,
   includesShapeWithText,
   includesTextShape,
   isShapeElementPair,

--- a/packages/react-sdk/src/state/types.ts
+++ b/packages/react-sdk/src/state/types.ts
@@ -208,6 +208,10 @@ export type WhiteboardSlideInstance = {
   getElementIds(): string[];
   /** Observe the element ids to react to changes */
   observeElementIds(): Observable<string[]>;
+  /** Set cursor position */
+  setCursorPosition(position: Point | undefined): void;
+  /** Get cursor position */
+  getCursorPosition(): Point | undefined;
   /** Returns the cursors for each connected user. */
   observeCursorPositions(): Observable<Record<string, Point>>;
   /** Broadcast the position of the own user in to all other connected users. */

--- a/packages/react-sdk/src/state/whiteboardSlideInstanceImpl.ts
+++ b/packages/react-sdk/src/state/whiteboardSlideInstanceImpl.ts
@@ -116,6 +116,7 @@ export class WhiteboardSlideInstanceImpl implements WhiteboardSlideInstance {
       distinctUntilChanged(isEqual),
       takeUntil(this.destroySubject),
     );
+  private cursorPosition: Point | undefined;
 
   constructor(
     private readonly communicationChannel: CommunicationChannel | undefined,
@@ -330,6 +331,14 @@ export class WhiteboardSlideInstanceImpl implements WhiteboardSlideInstance {
 
   observeElementIds(): Observable<string[]> {
     return this.elementIdsObservable;
+  }
+
+  setCursorPosition(position: Point | undefined) {
+    this.cursorPosition = position;
+  }
+
+  getCursorPosition(): Point | undefined {
+    return this.cursorPosition;
   }
 
   observeCursorPositions(): Observable<Record<string, Point>> {


### PR DESCRIPTION
Improves existing drag and drop, copy and paste behaviors:

- Elements (text, shapes, images) are pasted to the mouse cursor
- Drag and drop adds images to the mouse cursor

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
