### PR TITLE
Improve PDF import for Infinite Canvas

### DIFF
--- a/.changeset/new-rabbits-heal.md
+++ b/.changeset/new-rabbits-heal.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+Improve PDF import for infinite canvas


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

Importing a PDF in Infinite Canvas mode now shows all the pages in a grid layout, from left to right, top to bottom. Pages that do not fit the current max canvas height are ignored.

<img width="963" alt="Screenshot 2025-05-07 at 12 41 25" src="https://github.com/user-attachments/assets/2e9be91c-382f-475f-a4f1-f14feed575fa" />

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [X] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
