### PR TITLE
Remove Slides, Presentation mode toggles from Infinite Canvas mode, hide Frames tool

### DIFF
--- a/.changeset/hungry-knives-train.md
+++ b/.changeset/hungry-knives-train.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+Hide Slide Overview and Presentation Mode toggles, disable Frames tool

--- a/packages/react-sdk/src/components/BoardBar/BoardBar.tsx
+++ b/packages/react-sdk/src/components/BoardBar/BoardBar.tsx
@@ -16,6 +16,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { Toolbar } from '../common/Toolbar';
+import { infiniteCanvasMode } from '../Whiteboard';
 import { SettingsMenu } from './SettingsMenu';
 import { ShowSlideOverviewToggle } from './ShowSlideOverviewToggle';
 
@@ -30,7 +31,7 @@ export function BoardBar() {
       sx={{ pointerEvents: 'initial', marginRight: 'auto' }}
       data-guided-tour-target="settings"
     >
-      <ShowSlideOverviewToggle />
+      {!infiniteCanvasMode && <ShowSlideOverviewToggle />}
       <SettingsMenu />
     </Toolbar>
   );

--- a/packages/react-sdk/src/components/Layout/Layout.tsx
+++ b/packages/react-sdk/src/components/Layout/Layout.tsx
@@ -177,7 +177,8 @@ function ContentArea() {
           right={0}
         >
           <FullscreenModeBar />
-          {(!isViewingPresentation || canStopPresentation) && <PresentBar />}
+          {!infiniteCanvasMode &&
+            (!isViewingPresentation || canStopPresentation) && <PresentBar />}
         </ToolbarContainer>
       </ToolbarContainer>
 

--- a/packages/react-sdk/src/components/ToolsBar/ToolsBar.test.tsx
+++ b/packages/react-sdk/src/components/ToolsBar/ToolsBar.test.tsx
@@ -206,7 +206,8 @@ describe('<ToolsBar/>', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should show the create frame button, if Infinite Ianvas is enabled', () => {
+  // TODO: enable test when adding frames back in
+  it.skip('should show the create frame button, if Infinite Ianvas is enabled', () => {
     vi.spyOn(whiteboardConstants, 'infiniteCanvasMode', 'get').mockReturnValue(
       true,
     );

--- a/packages/react-sdk/src/components/ToolsBar/ToolsBar.tsx
+++ b/packages/react-sdk/src/components/ToolsBar/ToolsBar.tsx
@@ -32,8 +32,6 @@ import { TriangleIcon } from '../icons/TriangleIcon';
 import { UploadIcon } from '../icons/UploadIcon';
 import { useSlideImageUpload } from '../ImageUpload';
 import { ActiveTool, useLayoutState } from '../Layout';
-import { infiniteCanvasMode } from '../Whiteboard';
-import { FrameButton } from './FrameButton';
 
 export function ToolsBar() {
   const { t } = useTranslation('neoboard');
@@ -131,7 +129,7 @@ export function ToolsBar() {
               onChange={handleRadioClick}
             />
           ))}
-          {infiniteCanvasMode && <FrameButton />}
+          {/*infiniteCanvasMode && <FrameButton />*/}
           <ToolbarButton
             aria-label={t('toolsBar.imageUploadTool', 'Upload image')}
             disabled={isLocked}


### PR DESCRIPTION
Addresses both NEO-1481 & NEO-1482, hiding the slide and presentation mode toggles when running in infinite canvas mode. Also removes frames regardless of the canvas mode.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<img width="802" alt="Screenshot 2025-05-08 at 11 51 05" src="https://github.com/user-attachments/assets/1b3310f2-621c-4367-941b-c576e46594ec" />

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [X] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
