### PR TITLE
Fix sync between cursor position and dragged elements

### DIFF
--- a/.changeset/shy-lizards-call.md
+++ b/.changeset/shy-lizards-call.md
@@ -3,4 +3,4 @@
 '@nordeck/matrix-neoboard-widget': patch
 ---
 
-Fix a moving element not been synchronized with the cursor position
+Fix sync between cursor position and dragged elements

--- a/.changeset/shy-lizards-call.md
+++ b/.changeset/shy-lizards-call.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+Fix a moving element not been synchronized with the cursor position

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Moveable/types.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Moveable/types.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { PathElement } from '../../../../state';
+import { PathElement, Point } from '../../../../state';
 import { BoundingRect } from '../../../../state/crdt/documents/point';
 
 export type ResizableProperties = {
   boundingRect: BoundingRect;
+  boundingRectCursorOffset: Point;
   connectingPathElements: Record<string, PathElement>;
 };

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Moveable/utils.test.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Moveable/utils.test.ts
@@ -49,8 +49,8 @@ describe('calculateElementOverrideUpdates', () => {
     expect(
       calculateElementOverrideUpdates(
         elements,
-        100,
         120,
+        171,
         whiteboardWidth,
         whiteboardHeight,
       ),
@@ -75,7 +75,7 @@ describe('calculateElementOverrideUpdates', () => {
       calculateElementOverrideUpdates(
         elements,
         -155,
-        0,
+        51,
         whiteboardWidth,
         whiteboardHeight,
       ),
@@ -99,8 +99,8 @@ describe('calculateElementOverrideUpdates', () => {
     expect(
       calculateElementOverrideUpdates(
         elements,
-        whiteboardWidth + 155,
-        0,
+        whiteboardWidth,
+        51,
         whiteboardWidth,
         whiteboardHeight,
       ),
@@ -124,7 +124,7 @@ describe('calculateElementOverrideUpdates', () => {
     expect(
       calculateElementOverrideUpdates(
         elements,
-        0,
+        20,
         -155,
         whiteboardWidth,
         whiteboardHeight,
@@ -149,7 +149,7 @@ describe('calculateElementOverrideUpdates', () => {
     expect(
       calculateElementOverrideUpdates(
         elements,
-        0,
+        20,
         whiteboardHeight + 55,
         whiteboardWidth,
         whiteboardHeight,

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Moveable/utils.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Moveable/utils.ts
@@ -34,8 +34,8 @@ import {
 
 export function calculateElementOverrideUpdates(
   elements: Elements,
-  deltaX: number,
-  deltaY: number,
+  rectX: number,
+  rectY: number,
   viewportWidth: number,
   viewportHeight: number,
   connectingPathElements?: Record<string, PathElement>,
@@ -48,8 +48,8 @@ export function calculateElementOverrideUpdates(
     height: rectHeight,
   } = calculateBoundingRectForElements(Object.values(elements));
 
-  const rectX = offsetX + deltaX;
-  const rectY = offsetY + deltaY;
+  const deltaX = rectX - offsetX;
+  const deltaY = rectY - offsetY;
 
   const overrides: ElementOverrideUpdate[] = Object.entries(elements).map(
     ([elemId, element]) => {

--- a/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.test.tsx
@@ -40,6 +40,10 @@ vi.mock('./SvgCanvas/useMeasure', () => ({
   useMeasure: vi.fn().mockReturnValue([vi.fn(), { width: 1920, height: 1080 }]),
 }));
 
+vi.mock('./SvgCanvas/utils', () => ({
+  calculateSvgCoords: (position: Point) => position,
+}));
+
 describe('<WhiteboardHost/>', () => {
   let activeWhiteboard: WhiteboardInstance;
   let activeSlide: WhiteboardSlideInstance;


### PR DESCRIPTION
The element shape could be out of sync with the cursor position when it is moved over the larger board. This PR fixes this issue.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
