### PR TITLE
Fix communication channel to stop visibility handling when destroyed

### DIFF
--- a/.changeset/witty-cooks-flow.md
+++ b/.changeset/witty-cooks-flow.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+Fix communication channel to stop visibility handling when it is destroyed

--- a/packages/react-sdk/src/state/communication/matrixRtcCommunicationChannel.ts
+++ b/packages/react-sdk/src/state/communication/matrixRtcCommunicationChannel.ts
@@ -107,6 +107,7 @@ export class MatrixRtcCommunicationChannel implements CommunicationChannel {
         distinctUntilChanged(),
         switchMap((enableObserveVisibilityState) =>
           observeVisibilityState(visibilityTimeout).pipe(
+            takeUntil(this.destroySubject),
             mergeMap(async (v) => {
               if (v === 'visible') {
                 try {

--- a/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.ts
+++ b/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.ts
@@ -131,6 +131,7 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
         distinctUntilChanged(),
         switchMap((enableObserveVisibilityState) =>
           observeVisibilityState(visibilityTimeout).pipe(
+            takeUntil(this.destroySubject),
             mergeMap(async (v) => {
               if (v === 'visible') {
                 try {


### PR DESCRIPTION
Stops inner observable from emitting subsequent visibility states if communication channel is destroyed.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
