### PR TITLE
Improve touchpad and mouse wheel handing

### DIFF
--- a/.changeset/pretty-pigs-tease.md
+++ b/.changeset/pretty-pigs-tease.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': minor
+'@nordeck/matrix-neoboard-widget': minor
+---
+
+Improve touchpad and mouse wheel zooming and panning

--- a/packages/react-sdk/src/components/Shortcuts/ZoomShortcuts/ZoomShortcuts.tsx
+++ b/packages/react-sdk/src/components/Shortcuts/ZoomShortcuts/ZoomShortcuts.tsx
@@ -22,12 +22,12 @@ import { isMacOS } from '../../common/platform';
 export const ZoomShortcuts: React.FC = function () {
   const { resetZoom, zoomIn, zoomOut } = useZoomControls();
 
-  const macOs = useMemo(() => isMacOS(), []);
+  const macOS = useMemo(() => isMacOS(), []);
 
   const hasKeyModifier = useCallback(
     (event: KeyboardEvent) =>
-      (macOs && event.metaKey) || (!macOs && event.ctrlKey),
-    [macOs],
+      (macOS && event.metaKey) || (!macOS && event.ctrlKey),
+    [macOS],
   );
 
   useHotkeys(

--- a/packages/react-sdk/src/components/Whiteboard/SvgCanvas/SvgCanvas.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/SvgCanvas/SvgCanvas.tsx
@@ -191,6 +191,16 @@ export const SvgCanvas = function ({
     [applyKeyboardNavigation, enableShortcuts],
   );
 
+  // Handle auxiliary mouse button clicks (middle/right click)
+  // To prevent default paste clipboard action on firefox
+  const handleMouseAuxClick: MouseEventHandler<SVGSVGElement> = useCallback(
+    (e) => {
+      e.nativeEvent.preventDefault();
+      e.nativeEvent.stopPropagation();
+    },
+    [],
+  );
+
   const handleMouseMove: MouseEventHandler<SVGSVGElement> = useCallback(
     (e) => {
       const position = calculateSvgCoordsFunc({
@@ -254,6 +264,7 @@ export const SvgCanvas = function ({
           onKeyUp={infiniteCanvasMode ? handleKeyUp : undefined}
           tabIndex={infiniteCanvasMode ? -1 : undefined}
           onMouseLeave={onMouseLeave}
+          onAuxClick={handleMouseAuxClick}
           transform-origin={
             infiniteCanvasMode && !preview ? 'center center' : undefined
           }

--- a/packages/react-sdk/src/components/Whiteboard/SvgCanvas/SvgCanvas.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/SvgCanvas/SvgCanvas.tsx
@@ -195,8 +195,8 @@ export const SvgCanvas = function ({
   // To prevent default paste clipboard action on firefox
   const handleMouseAuxClick: MouseEventHandler<SVGSVGElement> = useCallback(
     (e) => {
-      e.nativeEvent.preventDefault();
-      e.nativeEvent.stopPropagation();
+      e.preventDefault();
+      e.stopPropagation();
     },
     [],
   );

--- a/packages/react-sdk/src/components/Whiteboard/SvgCanvas/useWheelZoom.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/SvgCanvas/useWheelZoom.test.tsx
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2025 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import {
+  ComponentType,
+  PropsWithChildren,
+  RefObject,
+  useRef,
+  WheelEvent,
+} from 'react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  MockedFunction,
+  vi,
+} from 'vitest';
+import { isMacOS } from '../../common/platform';
+import { useSvgScaleContext } from '../SvgScaleContext';
+import { useWheelZoom } from './useWheelZoom';
+import { calculateSvgCoords } from './utils';
+
+// Mock dependencies
+vi.mock('../../common/platform');
+vi.mock('../SvgScaleContext');
+vi.mock('./utils');
+
+// Mock constants
+vi.mock('../constants', () => ({
+  zoomStep: 0.1,
+}));
+
+const mockIsMacOS = isMacOS as MockedFunction<typeof isMacOS>;
+const mockUseSvgScaleContext = useSvgScaleContext as MockedFunction<
+  typeof useSvgScaleContext
+>;
+const mockCalculateSvgCoords = calculateSvgCoords as MockedFunction<
+  typeof calculateSvgCoords
+>;
+
+// Helper function to create mock wheel events
+const createMockWheelEvent = (
+  options: Partial<WheelEvent<SVGSVGElement>> = {},
+): WheelEvent<SVGSVGElement> => {
+  const preventDefault = vi.fn();
+  const stopPropagation = vi.fn();
+
+  return {
+    deltaX: 0,
+    deltaY: 0,
+    clientX: 0,
+    clientY: 0,
+    ctrlKey: false,
+    metaKey: false,
+    preventDefault,
+    stopPropagation,
+    ...options,
+  } as WheelEvent<SVGSVGElement>;
+};
+
+describe('useWheelZoom', () => {
+  let mockSvgElement: HTMLElement;
+  let mockUpdateScale: ReturnType<typeof vi.fn>;
+  let mockUpdateTranslation: ReturnType<typeof vi.fn>;
+  let Wrapper: ComponentType<PropsWithChildren<{}>>;
+  let svgRef: RefObject<SVGSVGElement>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    // Create mock SVG element
+    mockSvgElement = document.createElement('div') as unknown as HTMLElement;
+
+    // Mock context functions
+    mockUpdateScale = vi.fn();
+    mockUpdateTranslation = vi.fn();
+
+    // Setup default mocks
+    mockUseSvgScaleContext.mockReturnValue({
+      scale: 1,
+      setScale: vi.fn(),
+      translation: { x: 0, y: 0 },
+      updateScale: mockUpdateScale,
+      updateTranslation: mockUpdateTranslation,
+      containerDimensions: { width: 800, height: 600 },
+      setContainerDimensions: vi.fn(),
+      transformPointSvgToContainer: vi.fn(),
+      viewportCanvasCenter: { x: 0, y: 0 },
+    });
+
+    mockCalculateSvgCoords.mockReturnValue({ x: 100, y: 200 });
+    mockIsMacOS.mockReturnValue(false); // Default to Linux/Windows
+
+    // Create wrapper that provides a ref to the hook
+    Wrapper = ({ children }: PropsWithChildren<{}>) => {
+      const ref = useRef<SVGSVGElement>(
+        mockSvgElement as unknown as SVGSVGElement,
+      );
+      svgRef = ref;
+      return <div>{children}</div>;
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  describe('Linux/Windows behavior', () => {
+    beforeEach(() => {
+      mockIsMacOS.mockReturnValue(false);
+    });
+
+    it('should zoom in with mouse wheel scroll up (Chrome delta)', () => {
+      const { result } = renderHook(() => useWheelZoom(svgRef), {
+        wrapper: Wrapper,
+      });
+
+      const wheelEvent = createMockWheelEvent({
+        deltaY: -120, // Chrome wheel delta
+        deltaX: 0,
+        clientX: 150,
+        clientY: 250,
+      });
+
+      act(() => {
+        result.current.handleWheelZoom(wheelEvent);
+      });
+
+      expect(mockCalculateSvgCoords).toHaveBeenCalledWith(
+        { x: 150, y: 250 },
+        mockSvgElement,
+      );
+      expect(mockUpdateScale).toHaveBeenCalledWith(
+        0.2, // zoomStep * scale * 2 (Linux multiplier)
+        { x: 100, y: 200 },
+      );
+      expect(mockUpdateTranslation).not.toHaveBeenCalled();
+    });
+
+    it('should zoom out with mouse wheel scroll down (Firefox delta)', () => {
+      const { result } = renderHook(() => useWheelZoom(svgRef), {
+        wrapper: Wrapper,
+      });
+
+      const wheelEvent = createMockWheelEvent({
+        deltaY: 138, // Firefox wheel delta
+        deltaX: 0,
+        clientX: 150,
+        clientY: 250,
+      });
+
+      act(() => {
+        result.current.handleWheelZoom(wheelEvent);
+      });
+
+      expect(mockUpdateScale).toHaveBeenCalledWith(
+        -0.2, // negative for zoom out
+        { x: 100, y: 200 },
+      );
+    });
+
+    it('should pan with touchpad gestures (small deltas)', () => {
+      const { result } = renderHook(() => useWheelZoom(svgRef), {
+        wrapper: Wrapper,
+      });
+
+      const wheelEvent = createMockWheelEvent({
+        deltaX: 30,
+        deltaY: 2, // Small delta, not divisible by 120 or 138
+      });
+
+      act(() => {
+        result.current.handleWheelZoom(wheelEvent);
+      });
+
+      expect(mockUpdateTranslation).toHaveBeenCalledWith(-30, -2);
+      expect(mockUpdateScale).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('macOS behavior', () => {
+    beforeEach(() => {
+      mockIsMacOS.mockReturnValue(true);
+    });
+
+    it('should zoom with Ctrl+trackpad', () => {
+      const { result } = renderHook(() => useWheelZoom(svgRef), {
+        wrapper: Wrapper,
+      });
+
+      const wheelEvent = createMockWheelEvent({
+        deltaY: -10,
+        ctrlKey: true,
+        clientX: 150,
+        clientY: 250,
+      });
+
+      act(() => {
+        result.current.handleWheelZoom(wheelEvent);
+      });
+
+      expect(mockUpdateScale).toHaveBeenCalledWith(
+        0.1, // No 2x multiplier on macOS
+        { x: 100, y: 200 },
+      );
+    });
+
+    it('should zoom with Meta+trackpad', () => {
+      const { result } = renderHook(() => useWheelZoom(svgRef), {
+        wrapper: Wrapper,
+      });
+
+      const wheelEvent = createMockWheelEvent({
+        deltaY: -10,
+        metaKey: true,
+        clientX: 150,
+        clientY: 250,
+      });
+
+      act(() => {
+        result.current.handleWheelZoom(wheelEvent);
+      });
+
+      expect(mockUpdateScale).toHaveBeenCalledWith(0.1, { x: 100, y: 200 });
+    });
+
+    it('should pan by default on trackpad without modifier keys', () => {
+      const { result } = renderHook(() => useWheelZoom(svgRef), {
+        wrapper: Wrapper,
+      });
+
+      const wheelEvent = createMockWheelEvent({
+        deltaX: 15,
+        deltaY: 3, // Small delta (touchpad)
+      });
+
+      act(() => {
+        result.current.handleWheelZoom(wheelEvent);
+      });
+
+      expect(mockUpdateTranslation).toHaveBeenCalledWith(-15, -3);
+      expect(mockUpdateScale).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('wheel zoom progress state', () => {
+    it('should set wheelZoomInProgress to true during zoom', () => {
+      const { result } = renderHook(() => useWheelZoom(svgRef), {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current.wheelZoomInProgress).toBe(false);
+
+      const wheelEvent = createMockWheelEvent({
+        deltaY: -120,
+        clientX: 150,
+        clientY: 250,
+      });
+
+      act(() => {
+        result.current.handleWheelZoom(wheelEvent);
+      });
+
+      expect(result.current.wheelZoomInProgress).toBe(true);
+    });
+
+    it('should reset wheelZoomInProgress after timeout', async () => {
+      const { result } = renderHook(() => useWheelZoom(svgRef), {
+        wrapper: Wrapper,
+      });
+
+      const wheelEvent = createMockWheelEvent({
+        deltaY: -120,
+        clientX: 150,
+        clientY: 250,
+      });
+
+      act(() => {
+        result.current.handleWheelZoom(wheelEvent);
+      });
+
+      expect(result.current.wheelZoomInProgress).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(300); // WHEEL_ZOOM_TIMEOUT
+      });
+
+      expect(result.current.wheelZoomInProgress).toBe(false);
+    });
+  });
+});

--- a/packages/react-sdk/src/components/Whiteboard/SvgCanvas/useWheelZoom.ts
+++ b/packages/react-sdk/src/components/Whiteboard/SvgCanvas/useWheelZoom.ts
@@ -155,7 +155,8 @@ export const useWheelZoom = (
       const isZoom =
         event.ctrlKey ||
         event.metaKey ||
-        (event.deltaX < 1 &&
+        (event.deltaY !== 0 &&
+          event.deltaX < 1 &&
           // This is for mouse wheel zooming - on Linux, the deltas are large values
           // 120 is the delta reported by Chrome
           // 138 is the delta reported by Firefox
@@ -175,7 +176,8 @@ export const useWheelZoom = (
           },
           svgRef.current,
         );
-        const wheelZoomStep = zoomStep * scale;
+        // Increase stepping for Linux browsers
+        const wheelZoomStep = zoomStep * scale * 2;
         updateScale(
           event.deltaY < 0 ? wheelZoomStep : -wheelZoomStep,
           zoomOriginOnCanvas,

--- a/packages/react-sdk/src/components/Whiteboard/SvgCanvas/useWheelZoom.ts
+++ b/packages/react-sdk/src/components/Whiteboard/SvgCanvas/useWheelZoom.ts
@@ -82,11 +82,11 @@ export const useWheelZoom = (
   // Shared zoom logic
   const performZoom = useCallback(
     (event: WheelEvent) => {
-      if (event.deltaY === 0) return;
+      if (event.deltaY === 0 || !svgRef.current) return;
 
       const zoomOriginOnCanvas = calculateSvgCoords(
         { x: event.clientX, y: event.clientY },
-        svgRef.current!,
+        svgRef.current,
       );
 
       const zoomMultiplier = macOS ? 1 : 2;


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

This PR improves touchpad and mouse wheel handing.

This is now done using system-dependend heuristics.

Because you can't tell if the events are triggered by the mouse wheel or a touchpad and the event deltas very a lot between browsers and operating systems, this implementation supports:

- zoom in / out when using a mouse wheel
- two finger swipe gestures in the touchpad do up/down/left/right panning
- up and down two finger swipe gestures in the touchpad with a modifier key pressed (control or meta) do zoom in / out

where supported (macOS and Linux+Firefox):

- two finger pinching gestures in the touchpad do zoom in / out

**NOTE**
 - this also fixes a bug where middle mouse button / wheel clicking would paste the clipboard contents in the whiteboard

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
