### PR TITLE
Cleanup secrets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,11 +411,11 @@ jobs:
           script: |
             github.rest.actions.createWorkflowDispatch({
               owner: 'nordeck',
-              repo: '${{ secrets.GITOPS_DEPLOY_REPOSITORY }}',
+              repo: '${{ vars.GITOPS_DEPLOY_REPOSITORY }}',
               workflow_id: 'deployment.yml',
               ref: 'main',
               inputs: {
-                environment: '${{ secrets.GITOPS_DEPLOY_ENVIRONMENT}}',
+                environment: '${{ vars.GITOPS_DEPLOY_ENVIRONMENT}}',
                 application: 'matrix-neoboard',
                 tag: '${{ github.sha }}'
               }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,10 +207,6 @@ jobs:
           path: matrix-neoboard-standalone
           # required for changesets
           fetch-depth: '0'
-          # don't persist the credentials so the changesets action doesn't use the
-          # github actions token but the git token provided via environment variable
-          persist-credentials: false
-          ssh-key: ${{ secrets.STANDALONE_DEPLOY_KEY }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
`STANDALONE_DEPLOY_KEY` is no longer needed, as the `matrix-neoboard-standalone` repository is no longer private. Additionally, `GITOPS_DEPLOY_REPOSITORY` and `GITOPS_DEPLOY_ENVIRONMENT` can be converted to repository-scoped variables, as they do not contain sensitive information.

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
