### PR TITLE
bump some major CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         with:
           fetch-depth: 0 # need main branch to diff against
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
       - uses: actions/setup-python@v5
         with:
           python-version: '3.14'
@@ -448,7 +448,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
       - name: Create Kubeconfig
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       docker-tag: ${{ steps.meta.outputs.version }}
       ARGOCD_SHA: ${{ steps.get_argo_cd_sha.outputs.ARGOCD_SHA }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # required for changesets
           fetch-depth: '0'
@@ -153,7 +153,7 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # need main branch to diff against
       - name: Set up Helm
@@ -192,7 +192,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: matrix-neoboard
           # required for changesets
@@ -201,7 +201,7 @@ jobs:
           # github actions token but the git token provided via environment variable
           persist-credentials: false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: nordeck/matrix-neoboard-standalone
           path: matrix-neoboard-standalone
@@ -278,7 +278,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -329,7 +329,7 @@ jobs:
           private_key: ${{ secrets.GH_APP_OS_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ steps.generate_token.outputs.token }}
 
@@ -432,10 +432,10 @@ jobs:
     timeout-minutes: 5
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Checkout valhalla for values
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: dev
           sparse-checkout: |

--- a/.github/workflows/deploy_demo.yaml
+++ b/.github/workflows/deploy_demo.yaml
@@ -14,10 +14,10 @@ jobs:
     timeout-minutes: 5
     steps:
       # Clone repo to get the helm charts
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Checkout valhalla for values
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: dev
           sparse-checkout: |

--- a/.github/workflows/deploy_demo.yaml
+++ b/.github/workflows/deploy_demo.yaml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
       - name: Create Kubeconfig
         run: |

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -14,10 +14,10 @@ jobs:
     timeout-minutes: 5
     steps:
       # Clone repo to get the helm charts
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Checkout valhalla for values
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: dev
           sparse-checkout: |

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
       - name: Create Kubeconfig
         run: |

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -17,7 +17,7 @@ jobs:
       CHART_NAME: matrix-neoboard-widget
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Login to ghcr.io
         uses: docker/login-action@v3


### PR DESCRIPTION
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4.

This version bumps them to [what renovate says](https://github.com/nordeck/matrix-neoboard/pull/934/files).

Just an internal change, so skipping changeset.