### PR TITLE
perf: cache fitText results and skip no-op ResizeObserver updates

### DIFF
--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/fitText.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/fitText.ts
@@ -20,16 +20,13 @@ const minFontSize = 10;
 const maxFontSize = 800;
 const maxSteps = 10;
 
-type TextSizeResult = {
-  fontSize: number;
-  paddingTop: number;
-  paddingHorizontal: number;
-};
-
-// Cache keyed by all inputs that affect the binary-search result.
+// Cache keyed by all inputs that affect the binary-search result, storing only
+// the fontSize. paddingTop depends on element.clientHeight after layout and is
+// always recomputed live — caching it would return stale values if the same key
+// is used in a context with different layout state (e.g. test environments).
 // Avoids re-running 10× DOM style mutations + getBoundingClientRect on every render
 // when nothing has changed (e.g. idle dashboard with many text elements).
-const textSizeCache = new Map<string, TextSizeResult>();
+const fontSizeCache = new Map<string, number>();
 
 function buildCacheKey(
   width: number,
@@ -130,10 +127,7 @@ export function getTextSize(
   height = Math.round(height);
 
   const cacheKey = buildCacheKey(width, height, content, opts);
-  const cached = textSizeCache.get(cacheKey);
-  if (cached) {
-    return cached;
-  }
+  const cachedFontSize = fontSizeCache.get(cacheKey);
 
   const { textElement: element, wrapperElement } = getTemporaryElement();
 
@@ -169,6 +163,8 @@ export function getTextSize(
   let fontSize: number;
   if (opts.fontSize !== undefined) {
     fontSize = opts.fontSize;
+  } else if (cachedFontSize !== undefined) {
+    fontSize = cachedFontSize;
   } else {
     // Do a binary search to find the best matching text size, in a few steps
     let stepSize = maxFontSize - minFontSize;
@@ -192,16 +188,16 @@ export function getTextSize(
     }
 
     fontSize = Math.round(fontSize);
+    fontSizeCache.set(cacheKey, fontSize);
   }
 
   element.style.fontSize = `${fontSize}px`;
 
-  // calculate the padding to center the text in the box
+  // calculate the padding to center the text in the box — always computed live
+  // from the DOM so it reflects the actual rendered height at this font size.
   const paddingTop = Math.max(0, (height - element.clientHeight) / 2);
 
   element.innerText = '';
 
-  const result: TextSizeResult = { fontSize, paddingTop, paddingHorizontal };
-  textSizeCache.set(cacheKey, result);
-  return result;
+  return { fontSize, paddingTop, paddingHorizontal };
 }

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/fitText.ts
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/fitText.ts
@@ -20,6 +20,31 @@ const minFontSize = 10;
 const maxFontSize = 800;
 const maxSteps = 10;
 
+type TextSizeResult = {
+  fontSize: number;
+  paddingTop: number;
+  paddingHorizontal: number;
+};
+
+// Cache keyed by all inputs that affect the binary-search result.
+// Avoids re-running 10× DOM style mutations + getBoundingClientRect on every render
+// when nothing has changed (e.g. idle dashboard with many text elements).
+const textSizeCache = new Map<string, TextSizeResult>();
+
+function buildCacheKey(
+  width: number,
+  height: number,
+  content: { innerHTML?: string; innerText: string },
+  opts: {
+    disableLigatures?: boolean;
+    fontSize?: number;
+    fontWeightBold?: boolean;
+    fontStyleItalic?: boolean;
+  },
+): string {
+  return `${width}|${height}|${content.innerHTML ?? content.innerText}|${opts.fontSize}|${opts.fontWeightBold}|${opts.fontStyleItalic}|${opts.disableLigatures}`;
+}
+
 export function fitText(
   element: HTMLElement,
   fontSize?: number,
@@ -104,6 +129,12 @@ export function getTextSize(
   width = Math.round(width);
   height = Math.round(height);
 
+  const cacheKey = buildCacheKey(width, height, content, opts);
+  const cached = textSizeCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
   const { textElement: element, wrapperElement } = getTemporaryElement();
 
   if (opts.fontSize === undefined) {
@@ -170,5 +201,7 @@ export function getTextSize(
 
   element.innerText = '';
 
-  return { fontSize, paddingTop, paddingHorizontal };
+  const result: TextSizeResult = { fontSize, paddingTop, paddingHorizontal };
+  textSizeCache.set(cacheKey, result);
+  return result;
 }

--- a/packages/react-sdk/src/lib/useMeasure.ts
+++ b/packages/react-sdk/src/lib/useMeasure.ts
@@ -15,7 +15,7 @@
  */
 
 import { noop } from 'lodash';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useIsomorphicLayoutEffect } from 'react-use';
 import { UseMeasureRect, UseMeasureResult } from 'react-use/lib/useMeasure';
@@ -34,10 +34,14 @@ const defaultState: UseMeasureRect = {
 /**
  * Copy of https://github.com/streamich/react-use/blob/master/src/useMeasure.ts
  * but with flushSync to fix glitches after React 18 update.
+ *
+ * Extended to skip setRect when dimensions haven't actually changed, preventing
+ * spurious React re-renders (and the cascading fitText calls they trigger).
  */
 function useBrowserMeasure<E extends Element = Element>(): UseMeasureResult<E> {
   const [element, ref] = useState<E | null>(null);
   const [rect, setRect] = useState<UseMeasureRect>(defaultState);
+  const prevRect = useRef<UseMeasureRect>(defaultState);
 
   const observer = useMemo(
     () =>
@@ -48,7 +52,24 @@ function useBrowserMeasure<E extends Element = Element>(): UseMeasureResult<E> {
           if (entries[0]) {
             const { x, y, width, height, top, left, bottom, right } =
               entries[0].contentRect;
-            setRect({ x, y, width, height, top, left, bottom, right });
+            const prev = prevRect.current;
+            // Skip state update when nothing actually changed to avoid triggering
+            // downstream useLayoutEffects (e.g. fitText) on every observer fire.
+            if (
+              prev.x === x &&
+              prev.y === y &&
+              prev.width === width &&
+              prev.height === height &&
+              prev.top === top &&
+              prev.left === left &&
+              prev.bottom === bottom &&
+              prev.right === right
+            ) {
+              return;
+            }
+            const next = { x, y, width, height, top, left, bottom, right };
+            prevRect.current = next;
+            setRect(next);
           }
         });
       }),
@@ -59,9 +80,9 @@ function useBrowserMeasure<E extends Element = Element>(): UseMeasureResult<E> {
     if (!element) return;
     observer.observe(element);
     return () => {
-      observer.disconnect();
+      observer.unobserve(element);
     };
-  }, [element]);
+  }, [element, observer]);
 
   return [ref, rect];
 }


### PR DESCRIPTION
- Add a small Map cache in fitText.ts keyed by it's inputs to skip the binary search if there is identical input.
- In useMeasure.ts compare the contentReact against the previous values to prevent not needed re-renders
- Improve the observer cleanup code

This hopefully fixes this:

<img width="2880" height="1582" alt="grafik" src="https://github.com/user-attachments/assets/9e2573ac-6602-468e-8775-5ecef82a8564" />


<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
