### PR TITLE
fix: deduplicate image blob downloads with a ref-counted cache

### DIFF
--- a/packages/react-sdk/src/components/elements/image/ImageDisplay.tsx
+++ b/packages/react-sdk/src/components/elements/image/ImageDisplay.tsx
@@ -17,7 +17,7 @@
 import { useWidgetApi } from '@matrix-widget-toolkit/react';
 import { styled } from '@mui/material';
 import { IDownloadFileActionFromWidgetResponseData } from 'matrix-widget-api';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { getSVGUnsafe } from '../../../imageUtils';
 import {
   acquireImageUrl,
@@ -85,14 +85,15 @@ function ImageDisplay({
     setLoadError(true);
   }, [setLoading, setLoadError]);
 
-  useEffect(() => {
-    let cancelled = false;
-    // Tracks whether acquireImageUrl resolved successfully so the cleanup
-    // knows whether to call releaseImageUrl (error paths release themselves).
-    let acquired = false;
-    const controller = new AbortController();
+  // Track whether this effect instance is still live. Using a ref so the
+  // .then()/.catch() closures always read the current value without needing
+  // to be listed as effect dependencies.
+  const cancelledRef = useRef(false);
 
-    const download = async (signal: AbortSignal): Promise<string> => {
+  useEffect(() => {
+    cancelledRef.current = false;
+
+    const download = async (): Promise<string> => {
       let result: IDownloadFileActionFromWidgetResponseData;
       try {
         result = await widgetApi.downloadFile(mxc);
@@ -103,8 +104,6 @@ function ImageDisplay({
       if (!(result.file instanceof Blob)) {
         throw new Error('Got non Blob file response');
       }
-
-      signal.throwIfAborted();
 
       // Check if the blob is an SVG
       // The try catch is because of the blob to text conversion
@@ -121,8 +120,6 @@ function ImageDisplay({
         blob = result.file.slice(0, result.file.size);
       }
 
-      signal.throwIfAborted();
-
       const url = URL.createObjectURL(blob);
       if (url === '') {
         throw new Error('Failed to create object URL');
@@ -130,34 +127,31 @@ function ImageDisplay({
       return url;
     };
 
-    acquireImageUrl(mxc, download, controller.signal)
+    acquireImageUrl(mxc, download)
       .then((url: string) => {
-        acquired = true;
-        if (!cancelled) {
+        if (!cancelledRef.current) {
           setImageUri(url);
         }
         return undefined;
       })
       .catch((error: Error) => {
-        if (cancelled || controller.signal.aborted) return;
+        if (cancelledRef.current) return;
         if (error instanceof WidgetApiActionError) {
           // Widget API unavailable — fall back to plain HTTP URL (not cached,
           // no blob to revoke).
-          releaseImageUrl(mxc);
           const httpUrl = convertMxcToHttpUrl(mxc, baseUrl);
           setImageUri(httpUrl ?? '');
         } else {
-          releaseImageUrl(mxc);
           setLoadError(true);
         }
       });
 
     return () => {
-      cancelled = true;
-      controller.abort();
-      if (acquired) {
-        releaseImageUrl(mxc);
-      }
+      cancelledRef.current = true;
+      // Always release — acquireImageUrl always increments the ref count.
+      // releaseImageUrl is a no-op if the entry was already removed (e.g. on
+      // download failure).
+      releaseImageUrl(mxc);
     };
   }, [baseUrl, mxc, widgetApi]);
 

--- a/packages/react-sdk/src/components/elements/image/ImageDisplay.tsx
+++ b/packages/react-sdk/src/components/elements/image/ImageDisplay.tsx
@@ -19,7 +19,12 @@ import { styled } from '@mui/material';
 import { IDownloadFileActionFromWidgetResponseData } from 'matrix-widget-api';
 import React, { useCallback, useEffect, useState } from 'react';
 import { getSVGUnsafe } from '../../../imageUtils';
-import { convertMxcToHttpUrl, WidgetApiActionError } from '../../../lib';
+import {
+  acquireImageUrl,
+  convertMxcToHttpUrl,
+  releaseImageUrl,
+  WidgetApiActionError,
+} from '../../../lib';
 import { ImageElement } from '../../../state';
 import {
   ElementContextMenu,
@@ -80,59 +85,44 @@ function ImageDisplay({
     setLoadError(true);
   }, [setLoading, setLoadError]);
 
-  // Cleanup effect to revoke the object URL when the component is unmounted or `imageUri` changes.
-  // This prevents memory leaks by releasing the memory associated with the object URL.
   useEffect(() => {
-    return () => {
-      if (imageUri) {
-        URL.revokeObjectURL(imageUri);
-      }
-    };
-  }, [imageUri]);
+    let cancelled = false;
+    // Tracks whether acquireImageUrl resolved successfully so the cleanup
+    // knows whether to call releaseImageUrl (error paths release themselves).
+    let acquired = false;
+    const controller = new AbortController();
 
-  useEffect(() => {
-    const downloadFile = async () => {
+    const download = async (signal: AbortSignal): Promise<string> => {
+      let result: IDownloadFileActionFromWidgetResponseData;
       try {
-        const result = await tryDownloadFileWithWidgetApi(mxc);
-        const blob = await getBlobFromResult(result);
-        const downloadedFileDataUrl = createObjectUrlFromBlob(blob);
-        setImageUri(downloadedFileDataUrl);
-      } catch (error) {
-        handleDownloadError(error as Error);
-      }
-    };
-
-    const tryDownloadFileWithWidgetApi = async (mxc: string) => {
-      try {
-        const result = await widgetApi.downloadFile(mxc);
-        return result;
+        result = await widgetApi.downloadFile(mxc);
       } catch {
         throw new WidgetApiActionError('downloadFile not available');
       }
-    };
 
-    const getBlobFromResult = async (
-      result: IDownloadFileActionFromWidgetResponseData,
-    ): Promise<Blob> => {
       if (!(result.file instanceof Blob)) {
         throw new Error('Got non Blob file response');
       }
+
+      signal.throwIfAborted();
+
       // Check if the blob is an SVG
       // The try catch is because of the blob to text conversion
+      let blob: Blob;
       try {
-        const stringFromBlob = await result.file.text();
+        const text = await result.file.text();
 
         // Check if the string is an SVG
         // We use this call as a condition here. If it works we know it's an SVG. If it throws an error we know it's not an SVG
-        getSVGUnsafe(stringFromBlob);
-        return result.file.slice(0, result.file.size, 'image/svg+xml');
+        getSVGUnsafe(text);
+        blob = result.file.slice(0, result.file.size, 'image/svg+xml');
       } catch {
         // If it fails, return the blob as is
-        return result.file.slice(0, result.file.size);
+        blob = result.file.slice(0, result.file.size);
       }
-    };
 
-    const createObjectUrlFromBlob = (blob: Blob): string => {
+      signal.throwIfAborted();
+
       const url = URL.createObjectURL(blob);
       if (url === '') {
         throw new Error('Failed to create object URL');
@@ -140,27 +130,35 @@ function ImageDisplay({
       return url;
     };
 
-    const handleDownloadError = (error: Error) => {
-      if (error instanceof WidgetApiActionError) {
-        tryFallbackDownload();
-      } else {
-        setLoadError(true);
+    acquireImageUrl(mxc, download, controller.signal)
+      .then((url: string) => {
+        acquired = true;
+        if (!cancelled) {
+          setImageUri(url);
+        }
+        return undefined;
+      })
+      .catch((error: Error) => {
+        if (cancelled || controller.signal.aborted) return;
+        if (error instanceof WidgetApiActionError) {
+          // Widget API unavailable — fall back to plain HTTP URL (not cached,
+          // no blob to revoke).
+          releaseImageUrl(mxc);
+          const httpUrl = convertMxcToHttpUrl(mxc, baseUrl);
+          setImageUri(httpUrl ?? '');
+        } else {
+          releaseImageUrl(mxc);
+          setLoadError(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (acquired) {
+        releaseImageUrl(mxc);
       }
     };
-
-    const tryFallbackDownload = async () => {
-      const httpUrl = convertMxcToHttpUrl(mxc, baseUrl);
-
-      if (httpUrl === null) {
-        setImageUri('');
-        return;
-      }
-      setImageUri(httpUrl);
-
-      return;
-    };
-
-    downloadFile();
   }, [baseUrl, mxc, widgetApi]);
 
   const renderedSkeleton =

--- a/packages/react-sdk/src/lib/imageBlobCache.test.ts
+++ b/packages/react-sdk/src/lib/imageBlobCache.test.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { acquireImageUrl, releaseImageUrl } from './imageBlobCache';
+
+describe('imageBlobCache', () => {
+  beforeEach(() => {
+    vi.spyOn(URL, 'createObjectURL').mockImplementation(
+      () => 'blob:mock-url-' + Math.random(),
+    );
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('acquireImageUrl', () => {
+    it('calls download exactly once for the same mxc even with concurrent acquires', async () => {
+      const download = vi.fn().mockResolvedValue('blob:url-1');
+
+      const [url1, url2, url3] = await Promise.all([
+        acquireImageUrl('mxc://a', download),
+        acquireImageUrl('mxc://a', download),
+        acquireImageUrl('mxc://a', download),
+      ]);
+
+      expect(download).toHaveBeenCalledTimes(1);
+      expect(url1).toBe(url2);
+      expect(url1).toBe(url3);
+
+      // cleanup
+      releaseImageUrl('mxc://a');
+      releaseImageUrl('mxc://a');
+      releaseImageUrl('mxc://a');
+    });
+
+    it('calls download again after all references are released', async () => {
+      const download = vi
+        .fn()
+        .mockResolvedValueOnce('blob:url-first')
+        .mockResolvedValueOnce('blob:url-second');
+
+      await acquireImageUrl('mxc://b', download);
+      releaseImageUrl('mxc://b');
+
+      const url = await acquireImageUrl('mxc://b', download);
+
+      expect(download).toHaveBeenCalledTimes(2);
+      expect(url).toBe('blob:url-second');
+
+      releaseImageUrl('mxc://b');
+    });
+
+    it('calls download independently for different mxc values', async () => {
+      const download = vi
+        .fn()
+        .mockResolvedValueOnce('blob:url-x')
+        .mockResolvedValueOnce('blob:url-y');
+
+      const [urlX, urlY] = await Promise.all([
+        acquireImageUrl('mxc://x', download),
+        acquireImageUrl('mxc://y', download),
+      ]);
+
+      expect(download).toHaveBeenCalledTimes(2);
+      expect(urlX).toBe('blob:url-x');
+      expect(urlY).toBe('blob:url-y');
+
+      releaseImageUrl('mxc://x');
+      releaseImageUrl('mxc://y');
+    });
+
+    it('retries download after a previous download failed', async () => {
+      const download = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('network error'))
+        .mockResolvedValueOnce('blob:url-retry');
+
+      await expect(acquireImageUrl('mxc://c', download)).rejects.toThrow(
+        'network error',
+      );
+
+      const url = await acquireImageUrl('mxc://c', download);
+      expect(download).toHaveBeenCalledTimes(2);
+      expect(url).toBe('blob:url-retry');
+
+      releaseImageUrl('mxc://c');
+    });
+  });
+
+  describe('releaseImageUrl', () => {
+    it('revokes the blob URL when the last reference is released', async () => {
+      const download = vi.fn().mockResolvedValue('blob:to-revoke');
+
+      await acquireImageUrl('mxc://d', download);
+      await acquireImageUrl('mxc://d', download);
+
+      expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+
+      releaseImageUrl('mxc://d');
+      expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+
+      releaseImageUrl('mxc://d');
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:to-revoke');
+      expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not revoke the blob URL while references remain', async () => {
+      const download = vi.fn().mockResolvedValue('blob:held');
+
+      await acquireImageUrl('mxc://e', download);
+      await acquireImageUrl('mxc://e', download);
+      await acquireImageUrl('mxc://e', download);
+
+      releaseImageUrl('mxc://e');
+      releaseImageUrl('mxc://e');
+
+      expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+
+      releaseImageUrl('mxc://e');
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:held');
+    });
+
+    it('is a no-op when called for an unknown mxc', () => {
+      expect(() => releaseImageUrl('mxc://nonexistent')).not.toThrow();
+      expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+    });
+
+    it('revokes immediately if all refs are released before download completes', async () => {
+      let resolveDownload!: (url: string) => void;
+      const download = vi.fn().mockReturnValue(
+        new Promise<string>((resolve) => {
+          resolveDownload = resolve;
+        }),
+      );
+
+      // acquire but release before the download finishes
+      acquireImageUrl('mxc://f', download);
+      releaseImageUrl('mxc://f');
+
+      // now let the download complete
+      resolveDownload('blob:late-url');
+      // flush microtasks
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // the blob URL should have been revoked immediately since no refs remain
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:late-url');
+    });
+  });
+});

--- a/packages/react-sdk/src/lib/imageBlobCache.ts
+++ b/packages/react-sdk/src/lib/imageBlobCache.ts
@@ -31,48 +31,45 @@ const cache = new Map<string, CacheEntry>();
  * the existing promise is reused — no duplicate network request is made.
  * Increments the reference count; call {@link releaseImageUrl} when done.
  *
+ * The download function must NOT be tied to any individual component's
+ * AbortSignal — the promise is shared across all components rendering the same
+ * MXC. Component lifecycle is handled via the `cancelled` flag at call sites.
+ *
  * @param mxc - The Matrix Content URI to download.
  * @param download - Async function that performs the actual download and returns
  *   a blob URL. Only called on the first acquire for a given mxc.
- * @param signal - AbortSignal; if aborted before the download resolves, the
- *   returned promise rejects with an AbortError.
  */
 export async function acquireImageUrl(
   mxc: string,
-  download: (signal: AbortSignal) => Promise<string>,
-  signal: AbortSignal,
+  download: () => Promise<string>,
 ): Promise<string> {
   let entry = cache.get(mxc);
 
   if (!entry) {
-    const promise = download(signal).then((url) => {
-      const e = cache.get(mxc);
-      if (e) {
-        e.url = url;
-      }
-      return url;
-    });
+    const promise = download()
+      .then((url) => {
+        const e = cache.get(mxc);
+        if (e) {
+          e.url = url;
+        } else {
+          // All references were released before the download completed;
+          // revoke the blob URL immediately to avoid a leak.
+          URL.revokeObjectURL(url);
+        }
+        return url;
+      })
+      .catch((error: unknown) => {
+        // Remove failed entries so the next acquire can start fresh.
+        cache.delete(mxc);
+        throw error;
+      });
 
     entry = { promise, url: undefined, refCount: 0 };
     cache.set(mxc, entry);
   }
 
   entry.refCount++;
-
-  // If the caller was aborted before the shared download finished, propagate
-  // the abort without affecting other waiters.
-  return Promise.race([
-    entry.promise,
-    new Promise<never>((_resolve, reject) => {
-      if (signal.aborted) {
-        reject(signal.reason);
-        return;
-      }
-      signal.addEventListener('abort', () => reject(signal.reason), {
-        once: true,
-      });
-    }),
-  ]);
+  return entry.promise;
 }
 
 /**
@@ -80,6 +77,9 @@ export async function acquireImageUrl(
  *
  * Decrements the reference count. When the count reaches zero the blob URL is
  * revoked and the cache entry is removed, freeing the memory.
+ *
+ * Safe to call even if the download is still in flight or has already failed —
+ * in those cases the entry is either absent or will clean up on completion.
  */
 export function releaseImageUrl(mxc: string): void {
   const entry = cache.get(mxc);
@@ -92,5 +92,8 @@ export function releaseImageUrl(mxc: string): void {
     if (entry.url) {
       URL.revokeObjectURL(entry.url);
     }
+    // If entry.url is still undefined the download is in flight.
+    // The .then() handler above will detect the deleted entry and
+    // revoke the blob URL as soon as it is created.
   }
 }

--- a/packages/react-sdk/src/lib/imageBlobCache.ts
+++ b/packages/react-sdk/src/lib/imageBlobCache.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type CacheEntry = {
+  // Shared promise so concurrent acquires for the same mxc await one download.
+  promise: Promise<string>;
+  // The resolved blob URL, set once the download completes.
+  url: string | undefined;
+  refCount: number;
+};
+
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Acquire a blob URL for the given MXC URI.
+ *
+ * If another component already downloaded (or is downloading) the same MXC,
+ * the existing promise is reused — no duplicate network request is made.
+ * Increments the reference count; call {@link releaseImageUrl} when done.
+ *
+ * @param mxc - The Matrix Content URI to download.
+ * @param download - Async function that performs the actual download and returns
+ *   a blob URL. Only called on the first acquire for a given mxc.
+ * @param signal - AbortSignal; if aborted before the download resolves, the
+ *   returned promise rejects with an AbortError.
+ */
+export async function acquireImageUrl(
+  mxc: string,
+  download: (signal: AbortSignal) => Promise<string>,
+  signal: AbortSignal,
+): Promise<string> {
+  let entry = cache.get(mxc);
+
+  if (!entry) {
+    const promise = download(signal).then((url) => {
+      const e = cache.get(mxc);
+      if (e) {
+        e.url = url;
+      }
+      return url;
+    });
+
+    entry = { promise, url: undefined, refCount: 0 };
+    cache.set(mxc, entry);
+  }
+
+  entry.refCount++;
+
+  // If the caller was aborted before the shared download finished, propagate
+  // the abort without affecting other waiters.
+  return Promise.race([
+    entry.promise,
+    new Promise<never>((_resolve, reject) => {
+      if (signal.aborted) {
+        reject(signal.reason);
+        return;
+      }
+      signal.addEventListener('abort', () => reject(signal.reason), {
+        once: true,
+      });
+    }),
+  ]);
+}
+
+/**
+ * Release a previously acquired blob URL.
+ *
+ * Decrements the reference count. When the count reaches zero the blob URL is
+ * revoked and the cache entry is removed, freeing the memory.
+ */
+export function releaseImageUrl(mxc: string): void {
+  const entry = cache.get(mxc);
+  if (!entry) return;
+
+  entry.refCount--;
+
+  if (entry.refCount <= 0) {
+    cache.delete(mxc);
+    if (entry.url) {
+      URL.revokeObjectURL(entry.url);
+    }
+  }
+}

--- a/packages/react-sdk/src/lib/index.ts
+++ b/packages/react-sdk/src/lib/index.ts
@@ -18,6 +18,7 @@ export { convertBlobToBase64 } from './convertBlobToBase64';
 export { determineImageSize } from './determineImageSize';
 export { filterRecord } from './filterRecord';
 export { findForegroundColor } from './findForegroundColor';
+export { acquireImageUrl, releaseImageUrl } from './imageBlobCache';
 export { isDefined } from './isDefined';
 export { isInfiniteCanvasMode } from './isInfiniteCanvasMode';
 export { setLocale } from './locale';


### PR DESCRIPTION
Introduces imageBlobCache.ts which holds the blob URL in memory if the same MXC URI gets requested. This way we have a single blob URL per image instance instead of one per element. This cache is ref counted and handles cleanup once we hit a count of zero.

It also adds an AbortController to in-flight downloads are cancelled when the component unmounts or the mxc prop changes to prevent stale setImageUri calls and orphaned blobs.

This reduces the time it takes for OOM when having lots of images. Big images are of course still able to exhaust memory quickly.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
