### PR TITLE
fix: explicitly track and unsubscribe per-peer-connection subscription

### DIFF
--- a/.changeset/slick-memes-hammer.md
+++ b/.changeset/slick-memes-hammer.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+Fix peer connection cleanup in the communication channels: the MatrixRTC channel no longer accumulates closed peer connections across reconnects, and the WebRTC channel closes remaining peer connections on destroy even when no session-left event is received.

--- a/packages/react-sdk/src/state/communication/matrixRtcCommunicationChannel.test.ts
+++ b/packages/react-sdk/src/state/communication/matrixRtcCommunicationChannel.test.ts
@@ -28,7 +28,10 @@ import {
   vi,
 } from 'vitest';
 import { mockDocumentVisibilityState } from '../../lib/testUtils/domTestUtils';
-import { PeerConnectionStatistics } from './connection';
+import {
+  MatrixRtcPeerConnection,
+  PeerConnectionStatistics,
+} from './connection';
 import { PeerConnection } from './connection/types';
 import { MatrixRtcSessionManagerImpl, RTCFocus } from './discovery';
 import AutoDiscovery from './discovery/autodiscovery';
@@ -258,6 +261,35 @@ describe('MatrixRtcCommunicationChannel', () => {
     await vi.waitFor(() => {
       expect(sessionManager.leave).toHaveBeenCalled();
     });
+  });
+
+  it('should not accumulate peer connections across reconnects', async () => {
+    await vi.waitFor(() => {
+      expect(MatrixRtcPeerConnection).toHaveBeenCalledTimes(1);
+    });
+
+    mockPeerConnection.close.mockClear();
+
+    // Trigger three reconnections via focus updates.
+    activeFocusSubject.next(mockActiveFocus);
+    await vi.waitFor(() => {
+      expect(MatrixRtcPeerConnection).toHaveBeenCalledTimes(2);
+    });
+
+    activeFocusSubject.next(mockActiveFocus);
+    await vi.waitFor(() => {
+      expect(MatrixRtcPeerConnection).toHaveBeenCalledTimes(3);
+    });
+
+    activeFocusSubject.next(mockActiveFocus);
+    await vi.waitFor(() => {
+      expect(MatrixRtcPeerConnection).toHaveBeenCalledTimes(4);
+    });
+
+    // Each reconnect must close only the single active peer connection. Without
+    // pruning the array, disconnect() re-closes every previously created
+    // connection, so close() ends up being called 1 + 2 + 3 = 6 times.
+    expect(mockPeerConnection.close).toHaveBeenCalledTimes(3);
   });
 
   it('should leave after destroying', async () => {

--- a/packages/react-sdk/src/state/communication/matrixRtcCommunicationChannel.ts
+++ b/packages/react-sdk/src/state/communication/matrixRtcCommunicationChannel.ts
@@ -207,6 +207,7 @@ export class MatrixRtcCommunicationChannel implements CommunicationChannel {
 
     this.statistics.sessions = [];
     this.peerConnections.forEach((c) => c.close());
+    this.peerConnections.length = 0;
   }
 
   private async initFocusBackend(focus: RTCFocus): Promise<void> {

--- a/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.test.ts
+++ b/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.test.ts
@@ -288,6 +288,22 @@ describe('WebRtcCommunicationChannel', () => {
       });
     });
 
+    it('should close peer connections when destroyed even without a session-left event', async () => {
+      joinedSubject.next(anotherSession);
+      await waitForSessionExists();
+
+      // Simulate a leave that does not emit a session-left event for the
+      // remote peer (e.g. the channel is destroyed while a peer is still
+      // connected). The peer connection must still be closed.
+      sessionManager.leave.mockImplementation(async () => {});
+
+      channel.destroy();
+
+      await waitFor(() => {
+        expect(peerConnection.close).toHaveBeenCalled();
+      });
+    });
+
     it('should leave after destroying', async () => {
       joinedSubject.next(anotherSession);
       await waitForSessionExists();

--- a/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.ts
+++ b/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.ts
@@ -61,8 +61,8 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
     emptyCommunicationChannelStatistics();
   private readonly peerConnections: PeerConnection[] = [];
   // Subscriptions created per peer connection in handleSessionJoined, keyed by
-  // connectionId. Stored so they can be explicitly unsubscribed when the peer
-  // leaves or the channel is destroyed, as a safety net alongside the
+  // session.sessionId. Stored so they can be explicitly unsubscribed when the
+  // peer leaves or the channel is destroyed, as a safety net alongside the
   // observable completion that close() triggers.
   private readonly peerConnectionSubscriptions = new Map<
     string,
@@ -127,10 +127,9 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
         );
 
         if (index >= 0) {
-          const connectionId = this.peerConnections[index].getConnectionId();
           this.peerConnections[index].close();
           this.peerConnections.splice(index, 1);
-          this.unsubscribePeerConnection(connectionId);
+          this.unsubscribePeerConnection(session.sessionId);
         }
       });
 
@@ -283,8 +282,6 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
     );
     this.peerConnections.push(peerConnection);
 
-    const connectionId = peerConnection.getConnectionId();
-
     const messagesSub = peerConnection
       .observeMessages()
       .pipe(takeUntil(this.destroySubject))
@@ -296,16 +293,16 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
       .subscribe({
         next: (peerConnectionStatistics) => {
           this.addPeerConnectionStatistics(
-            connectionId,
+            peerConnection.getConnectionId(),
             peerConnectionStatistics,
           );
         },
         complete: () => {
-          this.addPeerConnectionStatistics(connectionId);
+          this.addPeerConnectionStatistics(peerConnection.getConnectionId());
         },
       });
 
-    this.peerConnectionSubscriptions.set(connectionId, [
+    this.peerConnectionSubscriptions.set(session.sessionId, [
       messagesSub,
       statisticsSub,
     ]);

--- a/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.ts
+++ b/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.ts
@@ -22,6 +22,7 @@ import {
   NEVER,
   Observable,
   Subject,
+  Subscription,
   distinctUntilChanged,
   filter,
   firstValueFrom,
@@ -59,6 +60,14 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
   private readonly statistics: CommunicationChannelStatistics =
     emptyCommunicationChannelStatistics();
   private readonly peerConnections: PeerConnection[] = [];
+  // Subscriptions created per peer connection in handleSessionJoined, keyed by
+  // connectionId. Stored so they can be explicitly unsubscribed when the peer
+  // leaves or the channel is destroyed, as a safety net alongside the
+  // observable completion that close() triggers.
+  private readonly peerConnectionSubscriptions = new Map<
+    string,
+    Subscription[]
+  >();
   private turnServers: TurnServer | undefined;
 
   constructor(
@@ -118,8 +127,10 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
         );
 
         if (index >= 0) {
+          const connectionId = this.peerConnections[index].getConnectionId();
           this.peerConnections[index].close();
           this.peerConnections.splice(index, 1);
+          this.unsubscribePeerConnection(connectionId);
         }
       });
 
@@ -174,9 +185,23 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
   destroy() {
     this.logger.log('Destroying communication channel');
 
+    // Unsubscribe any peer connection subscriptions not yet cleaned up by
+    // session-left events (e.g. if destroy is called before the peer leaves).
+    for (const connectionId of this.peerConnectionSubscriptions.keys()) {
+      this.unsubscribePeerConnection(connectionId);
+    }
+
     this.messagesSubject.complete();
     this.statisticsSubject.complete();
     this.destroySubject.next();
+  }
+
+  private unsubscribePeerConnection(connectionId: string): void {
+    const subs = this.peerConnectionSubscriptions.get(connectionId);
+    if (subs) {
+      subs.forEach((s) => s.unsubscribe());
+      this.peerConnectionSubscriptions.delete(connectionId);
+    }
   }
 
   getStatistics(): CommunicationChannelStatistics {
@@ -258,21 +283,32 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
     );
     this.peerConnections.push(peerConnection);
 
-    peerConnection
+    const connectionId = peerConnection.getConnectionId();
+
+    const messagesSub = peerConnection
       .observeMessages()
+      .pipe(takeUntil(this.destroySubject))
       .subscribe((m) => this.messagesSubject.next(m));
 
-    peerConnection.observeStatistics().subscribe({
-      next: (peerConnectionStatistics) => {
-        this.addPeerConnectionStatistics(
-          peerConnection.getConnectionId(),
-          peerConnectionStatistics,
-        );
-      },
-      complete: () => {
-        this.addPeerConnectionStatistics(peerConnection.getConnectionId());
-      },
-    });
+    const statisticsSub = peerConnection
+      .observeStatistics()
+      .pipe(takeUntil(this.destroySubject))
+      .subscribe({
+        next: (peerConnectionStatistics) => {
+          this.addPeerConnectionStatistics(
+            connectionId,
+            peerConnectionStatistics,
+          );
+        },
+        complete: () => {
+          this.addPeerConnectionStatistics(connectionId);
+        },
+      });
+
+    this.peerConnectionSubscriptions.set(connectionId, [
+      messagesSub,
+      statisticsSub,
+    ]);
   }
 
   private addPeerConnectionStatistics(

--- a/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.ts
+++ b/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.ts
@@ -22,7 +22,6 @@ import {
   NEVER,
   Observable,
   Subject,
-  Subscription,
   distinctUntilChanged,
   filter,
   firstValueFrom,
@@ -60,14 +59,6 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
   private readonly statistics: CommunicationChannelStatistics =
     emptyCommunicationChannelStatistics();
   private readonly peerConnections: PeerConnection[] = [];
-  // Subscriptions created per peer connection in handleSessionJoined, keyed by
-  // session.sessionId. Stored so they can be explicitly unsubscribed when the
-  // peer leaves or the channel is destroyed, as a safety net alongside the
-  // observable completion that close() triggers.
-  private readonly peerConnectionSubscriptions = new Map<
-    string,
-    Subscription[]
-  >();
   private turnServers: TurnServer | undefined;
 
   constructor(
@@ -129,7 +120,6 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
         if (index >= 0) {
           this.peerConnections[index].close();
           this.peerConnections.splice(index, 1);
-          this.unsubscribePeerConnection(session.sessionId);
         }
       });
 
@@ -184,23 +174,15 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
   destroy() {
     this.logger.log('Destroying communication channel');
 
-    // Unsubscribe any peer connection subscriptions not yet cleaned up by
-    // session-left events (e.g. if destroy is called before the peer leaves).
-    for (const connectionId of this.peerConnectionSubscriptions.keys()) {
-      this.unsubscribePeerConnection(connectionId);
-    }
+    // Close any peer connections that are still open (e.g. if destroy is
+    // called before the peers leave). Closing completes the peer connection
+    // subjects, which also tears down the per-peer subscriptions.
+    this.peerConnections.forEach((peerConnection) => peerConnection.close());
+    this.peerConnections.length = 0;
 
     this.messagesSubject.complete();
     this.statisticsSubject.complete();
     this.destroySubject.next();
-  }
-
-  private unsubscribePeerConnection(connectionId: string): void {
-    const subs = this.peerConnectionSubscriptions.get(connectionId);
-    if (subs) {
-      subs.forEach((s) => s.unsubscribe());
-      this.peerConnectionSubscriptions.delete(connectionId);
-    }
   }
 
   getStatistics(): CommunicationChannelStatistics {
@@ -282,12 +264,12 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
     );
     this.peerConnections.push(peerConnection);
 
-    const messagesSub = peerConnection
+    peerConnection
       .observeMessages()
       .pipe(takeUntil(this.destroySubject))
       .subscribe((m) => this.messagesSubject.next(m));
 
-    const statisticsSub = peerConnection
+    peerConnection
       .observeStatistics()
       .pipe(takeUntil(this.destroySubject))
       .subscribe({
@@ -301,11 +283,6 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
           this.addPeerConnectionStatistics(peerConnection.getConnectionId());
         },
       });
-
-    this.peerConnectionSubscriptions.set(session.sessionId, [
-      messagesSub,
-      statisticsSub,
-    ]);
   }
 
   private addPeerConnectionStatistics(

--- a/packages/react-sdk/src/state/whiteboardManagerImpl.test.ts
+++ b/packages/react-sdk/src/state/whiteboardManagerImpl.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { MockedWidgetApi, mockWidgetApi } from '@matrix-widget-toolkit/testing';
+import { NEVER } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockWhiteboard } from '../lib/testUtils/matrixTestUtils';
 import { createStore } from '../store';
@@ -29,16 +30,8 @@ vi.mock('./communication/connection', async (importOriginal) => {
     ...original,
     WebRtcPeerConnection: vi.fn().mockImplementation(() => {
       return {
-        observeMessages: () => {
-          return {
-            subscribe: () => {},
-          };
-        },
-        observeStatistics: () => {
-          return {
-            subscribe: () => {},
-          };
-        },
+        observeMessages: () => NEVER,
+        observeStatistics: () => NEVER,
       };
     }),
   };


### PR DESCRIPTION
handleSessionJoined creates two RxJS subscriptions (observeMessages, observeStatistics) per peer connection without storing them. While WebRtcPeerConnection.close() completes both subjects (causing auto-unsubscription in normal flow), if destroy() is called before a peer cleanly disconnects the subscriptions are orphaned.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
