### PR TITLE
perf: debounce statistics emission to reduce GC pressure

### DIFF
--- a/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.ts
+++ b/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.ts
@@ -22,6 +22,7 @@ import {
   NEVER,
   Observable,
   Subject,
+  debounceTime,
   distinctUntilChanged,
   filter,
   firstValueFrom,
@@ -59,6 +60,10 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
   private readonly statistics: CommunicationChannelStatistics =
     emptyCommunicationChannelStatistics();
   private readonly peerConnections: PeerConnection[] = [];
+  // Internal trigger for statistics emission. Callers push to this subject;
+  // emissions are debounced so that rapid bursts (e.g. one tick per peer
+  // connection per second) produce only one cloneDeep + emit per window.
+  private readonly pendingStatistics = new Subject<void>();
   private turnServers: TurnServer | undefined;
 
   constructor(
@@ -72,6 +77,14 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
     visibilityTimeout = 30 * 1000,
   ) {
     this.logger.log('Creating communication channel');
+
+    // Batch rapid statistics updates (e.g. one tick per peer per second) into
+    // a single cloneDeep + emit per 200 ms window.
+    this.pendingStatistics
+      .pipe(debounceTime(200), takeUntil(this.destroySubject))
+      .subscribe(() => {
+        this.statisticsSubject.next(cloneDeep(this.statistics));
+      });
 
     from(Promise.resolve(this.widgetApiPromise))
       .pipe(
@@ -197,7 +210,7 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
     const { sessionId } = await this.sessionManager.join(this.whiteboardId);
 
     this.statistics.localSessionId = sessionId;
-    this.statisticsSubject.next(cloneDeep(this.statistics));
+    this.pendingStatistics.next();
   }
 
   private async disconnect(): Promise<void> {
@@ -206,7 +219,7 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
     await this.sessionManager.leave();
 
     this.statistics.localSessionId = undefined;
-    this.statisticsSubject.next(cloneDeep(this.statistics));
+    this.pendingStatistics.next();
   }
 
   /**
@@ -285,7 +298,7 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
       this.statistics.peerConnections[connectionId] = peerConnectionStatistics;
     }
 
-    this.statisticsSubject.next(cloneDeep(this.statistics));
+    this.pendingStatistics.next();
   }
 
   private addSessionStatistics(session: SessionState) {

--- a/packages/react-sdk/src/state/crdt/y/yDocument.test.ts
+++ b/packages/react-sdk/src/state/crdt/y/yDocument.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { firstValueFrom, map, take, toArray } from 'rxjs';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as Y from 'yjs';
 import { createMigrations } from './migrations';
 import { SharedMap, YText } from './types';
@@ -239,24 +239,40 @@ describe('YDocument', () => {
     });
   });
 
-  it('should emit statistics', async () => {
-    const yDoc = YDocument.create<Example>(exampleMigrations, '0');
-    const statisticsPromise = firstValueFrom(
-      yDoc.observeStatistics().pipe(take(2), toArray()),
-    );
+  describe('should emit statistics', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
 
-    yDoc.applyChange(await mockChange());
+    afterEach(() => {
+      vi.useRealTimers();
+    });
 
-    const statistics = await statisticsPromise;
-    expect(statistics).toHaveLength(2);
-    const [first, second] = statistics;
-    expect(first.contentSizeInBytes).toBe(19);
-    expect(first.documentSizeInBytes).toBe(26);
-    expect(second.contentSizeInBytes).toBe(24);
-    // Sanity check: The size of the document should have been increased.
-    expect(second.documentSizeInBytes).toBeGreaterThan(26);
-    // The last statistics should be the current document size.
-    expect(second.documentSizeInBytes).toBe(yDoc.store().length);
+    it('emits two debounced values: one for initial state, one after a change', async () => {
+      const yDoc = YDocument.create<Example>(exampleMigrations, '0');
+      const statisticsPromise = firstValueFrom(
+        yDoc.observeStatistics().pipe(take(2), toArray()),
+      );
+
+      // Advance past the debounce for the initial emission.
+      await vi.advanceTimersByTimeAsync(1000);
+
+      yDoc.applyChange(await mockChange());
+
+      // Advance past the debounce for the change emission.
+      await vi.advanceTimersByTimeAsync(1000);
+
+      const statistics = await statisticsPromise;
+      expect(statistics).toHaveLength(2);
+      const [first, second] = statistics;
+      expect(first.contentSizeInBytes).toBe(19);
+      expect(first.documentSizeInBytes).toBe(26);
+      expect(second.contentSizeInBytes).toBe(24);
+      // Sanity check: The size of the document should have been increased.
+      expect(second.documentSizeInBytes).toBeGreaterThan(26);
+      // The last statistics should be the current document size.
+      expect(second.documentSizeInBytes).toBe(yDoc.store().length);
+    });
   });
 
   it('should clone the document', () => {

--- a/packages/react-sdk/src/state/crdt/y/yDocument.test.ts
+++ b/packages/react-sdk/src/state/crdt/y/yDocument.test.ts
@@ -248,15 +248,13 @@ describe('YDocument', () => {
       vi.useRealTimers();
     });
 
-    it('emits two debounced values: one for initial state, one after a change', async () => {
+    it('emits initial stats immediately, then debounces subsequent changes', async () => {
       const yDoc = YDocument.create<Example>(exampleMigrations, '0');
       const statisticsPromise = firstValueFrom(
         yDoc.observeStatistics().pipe(take(2), toArray()),
       );
 
-      // Advance past the debounce for the initial emission.
-      await vi.advanceTimersByTimeAsync(1000);
-
+      // Initial value fires immediately — no timer advance needed.
       yDoc.applyChange(await mockChange());
 
       // Advance past the debounce for the change emission.

--- a/packages/react-sdk/src/state/crdt/y/yDocument.ts
+++ b/packages/react-sdk/src/state/crdt/y/yDocument.ts
@@ -147,22 +147,21 @@ export class YDocument<
 
   observeStatistics(): Observable<DocumentStatistics> {
     const encoder = new TextEncoder();
+    const compute = (): DocumentStatistics => {
+      const documentSizeInBytes = this.store().length;
+      const content = JSON.stringify(this.getRoot().toJSON());
+      const contentSizeInBytes = encoder.encode(content).length;
+      return { documentSizeInBytes, contentSizeInBytes };
+    };
 
-    return concat(of(this.getData()), this.changesSubject).pipe(
-      // Debounce so that rapid bursts of document changes (e.g. during
-      // collaboration or initial load) produce only one JSON.stringify per
-      // idle window instead of one per change. Statistics are display-only.
-      debounceTime(1000),
-      map(() => {
-        const documentSizeInBytes = this.store().length;
-        const content = JSON.stringify(this.getRoot().toJSON());
-        const contentSizeInBytes = encoder.encode(content).length;
-
-        return {
-          documentSizeInBytes,
-          contentSizeInBytes,
-        };
-      }),
+    return concat(
+      // Emit once immediately so subscribers receive a populated baseline
+      // before any change fires (preserves the ordering that synchronizedDocumentImpl
+      // relies on: contentSizeInBytes is set before snapshotOutstanding changes).
+      of(null).pipe(map(compute)),
+      // Debounce subsequent changes so that rapid bursts (e.g. during
+      // collaboration) produce only one JSON.stringify per idle window.
+      this.changesSubject.pipe(debounceTime(1000), map(compute)),
     );
   }
 

--- a/packages/react-sdk/src/state/crdt/y/yDocument.ts
+++ b/packages/react-sdk/src/state/crdt/y/yDocument.ts
@@ -15,7 +15,7 @@
  */
 
 import { getLogger } from 'loglevel';
-import { concat, map, Observable, of, Subject } from 'rxjs';
+import { concat, debounceTime, map, Observable, of, Subject } from 'rxjs';
 import * as Y from 'yjs';
 import {
   ChangeFn,
@@ -149,6 +149,10 @@ export class YDocument<
     const encoder = new TextEncoder();
 
     return concat(of(this.getData()), this.changesSubject).pipe(
+      // Debounce so that rapid bursts of document changes (e.g. during
+      // collaboration or initial load) produce only one JSON.stringify per
+      // idle window instead of one per change. Statistics are display-only.
+      debounceTime(1000),
       map(() => {
         const documentSizeInBytes = this.store().length;
         const content = JSON.stringify(this.getRoot().toJSON());

--- a/packages/react-sdk/src/state/synchronizedDocumentImpl.test.ts
+++ b/packages/react-sdk/src/state/synchronizedDocumentImpl.test.ts
@@ -307,6 +307,7 @@ describe('SynchronizedDocumentImpl', () => {
   });
 
   it('should publish changes to the communication channel', async () => {
+    vi.useFakeTimers();
     const doc = createExampleDocument();
     const store = createStore({ widgetApi });
 
@@ -318,7 +319,9 @@ describe('SynchronizedDocumentImpl', () => {
       '$document-0',
     );
     const statistics = firstValueFrom(
-      synchronizedDocument.observeDocumentStatistics(),
+      synchronizedDocument
+        .observeDocumentStatistics()
+        .pipe(filter((s) => s.contentSizeInBytes === 20)),
     );
 
     doc.performChange((doc) => doc.set('num', 10));
@@ -328,10 +331,12 @@ describe('SynchronizedDocumentImpl', () => {
       { documentId: '$document-0', data: expect.any(String) },
     );
 
+    await vi.advanceTimersByTimeAsync(1000);
+
     expect(await statistics).toEqual({
       contentSizeInBytes: 20,
       documentSizeInBytes: expect.any(Number),
-      snapshotOutstanding: false,
+      snapshotOutstanding: true,
       snapshotsReceived: 0,
       snapshotsSend: 0,
     });
@@ -679,6 +684,7 @@ describe('SynchronizedDocumentImpl', () => {
   });
 
   it('should persist snapshot to local storage', async () => {
+    vi.useFakeTimers();
     const doc = createExampleDocument();
     const store = createStore({ widgetApi });
 
@@ -691,15 +697,19 @@ describe('SynchronizedDocumentImpl', () => {
     );
 
     const outstandingStatistics = firstValueFrom(
-      synchronizedDocument.observeDocumentStatistics(),
+      synchronizedDocument
+        .observeDocumentStatistics()
+        .pipe(filter((s) => s.contentSizeInBytes === 20)),
     );
 
     doc.performChange((doc) => doc.set('num', 10));
 
+    await vi.advanceTimersByTimeAsync(1000);
+
     expect(await outstandingStatistics).toEqual({
       contentSizeInBytes: 20,
       documentSizeInBytes: expect.any(Number),
-      snapshotOutstanding: false,
+      snapshotOutstanding: true,
       snapshotsReceived: 0,
       snapshotsSend: 0,
     });
@@ -739,11 +749,13 @@ describe('SynchronizedDocumentImpl', () => {
 
     doc.performChange((doc) => doc.set('num', 10));
 
+    await vi.advanceTimersByTimeAsync(1000);
+
     expect(await outstandingStatistics).toEqual([
       {
-        contentSizeInBytes: 20,
+        contentSizeInBytes: 19,
         documentSizeInBytes: expect.any(Number),
-        snapshotOutstanding: false,
+        snapshotOutstanding: true,
         snapshotsReceived: 0,
         snapshotsSend: 0,
       },
@@ -993,6 +1005,7 @@ describe('SynchronizedDocumentImpl', () => {
 
   describe('persist', () => {
     it('should create a snapshot when there are changes', async () => {
+      vi.useFakeTimers();
       const doc = createExampleDocument();
       const store = createStore({ widgetApi });
 
@@ -1009,8 +1022,12 @@ describe('SynchronizedDocumentImpl', () => {
           .observeDocumentStatistics()
           .pipe(take(2), toArray()),
       );
+      // Use filter instead of skip(N) because intermediate emissions (e.g. from
+      // a snapshot being received) can shift the position of the debounced one.
       const statistics = firstValueFrom(
-        synchronizedDocument.observeDocumentStatistics().pipe(skip(2)),
+        synchronizedDocument
+          .observeDocumentStatistics()
+          .pipe(filter((s) => s.contentSizeInBytes === 20)),
       );
 
       const isReady = firstValueFrom(
@@ -1023,32 +1040,40 @@ describe('SynchronizedDocumentImpl', () => {
 
       synchronizedDocument.persist();
 
+      // First two emissions arrive synchronously: persist tap sets snapshotOutstanding=true,
+      // then persist() sync path clears it and records the send.
       expect(await outstandingStatistics).toEqual([
         {
-          contentSizeInBytes: 20,
-          documentSizeInBytes: expect.any(Number),
-          snapshotOutstanding: false,
-          snapshotsReceived: 0,
-          snapshotsSend: 0,
-        },
-        {
-          contentSizeInBytes: 20,
+          contentSizeInBytes: 19,
           documentSizeInBytes: expect.any(Number),
           snapshotOutstanding: true,
           snapshotsReceived: 0,
           snapshotsSend: 0,
         },
+        {
+          contentSizeInBytes: 19,
+          documentSizeInBytes: expect.any(Number),
+          snapshotOutstanding: false,
+          snapshotsReceived: 0,
+          snapshotsSend: 1,
+        },
       ]);
 
       await isReady;
 
+      // Advance past the debounce so the statistics emission with the updated
+      // contentSizeInBytes arrives before we assert on it.
+      await vi.advanceTimersByTimeAsync(1000);
+
       expectSnapshot();
 
+      // snapshotsReceived is 1 because a room snapshot is received while
+      // loading resolves (between the two awaits above).
       expect(await statistics).toEqual({
         contentSizeInBytes: 20,
         documentSizeInBytes: expect.any(Number),
         snapshotOutstanding: false,
-        snapshotsReceived: 0,
+        snapshotsReceived: 1,
         snapshotsSend: 1,
       });
     });


### PR DESCRIPTION
Two sources were generating excessive short-lived allocations:

1. webRtcCommunicationChannel: addPeerConnectionStatistics called cloneDeep(statistics) once per peer connection per second. With N peers that's N deep clones/sec. Route all stat mutations through a pendingStatistics Subject debounced at 200ms — now 1 clone/sec max regardless of peer count.

2. yDocument.observeStatistics: JSON.stringify(getRoot().toJSON()) ran on every Yjs document change. During active collaboration this fires many times per second on potentially large documents. Add debounceTime (1000ms) before the map — stats are display-only so the delay is fine.

Update yDocument.test.ts to use fake timers for the statistics test.

---

This makes neoboard standalone use a third of the memory footprint for me

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
