### PR TITLE
perf: reduce selection overhead with Set lookups and pointer throttle

### DIFF
--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.test.tsx
@@ -147,6 +147,7 @@ describe('<DragSelect/>', () => {
 
   afterEach(() => {
     widgetApi.stop();
+    vi.useRealTimers();
   });
 
   it('should clear the drag select start coordinates on pointer up', () => {
@@ -189,6 +190,7 @@ describe('<DragSelect/>', () => {
   });
 
   it('should select elements intersecting the selection in the order they are selected', () => {
+    vi.useFakeTimers();
     render(<DragSelect />, { wrapper: Wrapper });
 
     // Select an area with only element-1 inside
@@ -202,6 +204,9 @@ describe('<DragSelect/>', () => {
     });
 
     expect(activeSlide.getActiveElementIds()).toEqual(['element-1']);
+
+    // Advance past the 16ms throttle gate before the next move
+    vi.advanceTimersByTime(20);
 
     // Now extend the selection to the corner where element-0 is located
     vi.mocked(svgUtils.calculateSvgCoords).mockReturnValue({ x: 0, y: 0 });

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.tsx
@@ -15,7 +15,14 @@
  */
 
 import { styled, useTheme } from '@mui/material';
-import { PointerEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  PointerEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { filterRecord } from '../../../../lib';
 import {
   Point,
@@ -124,10 +131,13 @@ export function DragSelect() {
     setDragSelectStartCoords();
   }, [setDragSelectStartCoords]);
 
+  const lastMoveRef = useRef(0);
   const handlePointerMove = useCallback(
     (event: PointerEvent<SVGRectElement>) => {
-      const point = calculateSvgCoords({ x: event.clientX, y: event.clientY });
-      setEndCoords(point);
+      const now = Date.now();
+      if (now - lastMoveRef.current < 16) return;
+      lastMoveRef.current = now;
+      setEndCoords(calculateSvgCoords({ x: event.clientX, y: event.clientY }));
     },
     [calculateSvgCoords],
   );

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.tsx
@@ -43,6 +43,9 @@ const NoInteraction = styled('g')({
   pointerEvents: 'none',
 });
 
+// Throttle pointer move updates to 60fps (1000ms / 60 ≈ 16ms per frame)
+const POINTER_MOVE_THROTTLE_MS = Math.round(1000 / 60);
+
 export function DragSelect() {
   const theme = useTheme();
   const slideInstance = useWhiteboardSlideInstance();
@@ -135,7 +138,7 @@ export function DragSelect() {
   const handlePointerMove = useCallback(
     (event: PointerEvent<SVGRectElement>) => {
       const now = Date.now();
-      if (now - lastMoveRef.current < 16) return;
+      if (now - lastMoveRef.current < POINTER_MOVE_THROTTLE_MS) return;
       lastMoveRef.current = now;
       setEndCoords(calculateSvgCoords({ x: event.clientX, y: event.clientY }));
     },

--- a/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Box } from '@mui/material';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   findActiveAndAttachedElementIds,
   includesShapeWithText,
@@ -73,11 +73,7 @@ const WhiteboardHost = ({
   const slideInstance = useWhiteboardSlideInstance();
   const { isShowCollaboratorsCursors, dragSelectStartCoords } =
     useLayoutState();
-  const { activeElementIds } = useActiveElements();
-  const activeElementSet = useMemo(
-    () => new Set(activeElementIds),
-    [activeElementIds],
-  );
+  const { activeElementIds, activeElementSet } = useActiveElements();
 
   const activeAndAttachedElementIds = findActiveAndAttachedElementIds(
     activeElementIds,

--- a/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Box } from '@mui/material';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
   findActiveAndAttachedElementIds,
   includesShapeWithText,
@@ -74,6 +74,10 @@ const WhiteboardHost = ({
   const { isShowCollaboratorsCursors, dragSelectStartCoords } =
     useLayoutState();
   const { activeElementIds } = useActiveElements();
+  const activeElementSet = useMemo(
+    () => new Set(activeElementIds),
+    [activeElementIds],
+  );
 
   const activeAndAttachedElementIds = findActiveAndAttachedElementIds(
     activeElementIds,
@@ -144,7 +148,7 @@ const WhiteboardHost = ({
 
         {elementIds.map((elementId) => {
           const override = getElementOverride(elementId);
-          const isSelected = activeElementIds.includes(elementId);
+          const isSelected = activeElementSet.has(elementId);
 
           return (
             <ConnectedElement

--- a/packages/react-sdk/src/state/useWhiteboardSlideInstance.test.tsx
+++ b/packages/react-sdk/src/state/useWhiteboardSlideInstance.test.tsx
@@ -392,7 +392,10 @@ describe('useActiveElements', () => {
       wrapper: Wrapper,
     });
 
-    expect(result.current).toEqual({ activeElementIds: [] });
+    expect(result.current).toEqual({
+      activeElementIds: [],
+      activeElementSet: new Set(),
+    });
   });
 
   it('should return selected elements', () => {
@@ -406,6 +409,7 @@ describe('useActiveElements', () => {
 
     expect(result.current).toEqual({
       activeElementIds: ['element-0', 'element-1'],
+      activeElementSet: new Set(['element-0', 'element-1']),
     });
   });
 
@@ -414,7 +418,10 @@ describe('useActiveElements', () => {
       wrapper: Wrapper,
     });
 
-    expect(result.current).toEqual({ activeElementIds: [] });
+    expect(result.current).toEqual({
+      activeElementIds: [],
+      activeElementSet: new Set(),
+    });
 
     act(() => {
       activeWhiteboardInstance
@@ -424,6 +431,7 @@ describe('useActiveElements', () => {
 
     expect(result.current).toEqual({
       activeElementIds: ['element-0', 'element-1'],
+      activeElementSet: new Set(['element-0', 'element-1']),
     });
   });
 });

--- a/packages/react-sdk/src/state/useWhiteboardSlideInstance.tsx
+++ b/packages/react-sdk/src/state/useWhiteboardSlideInstance.tsx
@@ -118,6 +118,7 @@ type ActiveElement = {
 
 type ActiveElements = {
   activeElementIds: string[];
+  activeElementSet: ReadonlySet<string>;
 };
 
 /**
@@ -156,7 +157,12 @@ export function useActiveElements(): ActiveElements {
     observable,
   );
 
-  return { activeElementIds };
+  const activeElementSet = useMemo(
+    () => new Set(activeElementIds),
+    [activeElementIds],
+  );
+
+  return { activeElementIds, activeElementSet };
 }
 
 export function useSlideIsLocked(slideId?: string): boolean {

--- a/packages/react-sdk/src/state/whiteboardSlideInstanceImpl.ts
+++ b/packages/react-sdk/src/state/whiteboardSlideInstanceImpl.ts
@@ -754,9 +754,8 @@ export class WhiteboardSlideInstanceImpl implements WhiteboardSlideInstance {
   }
 
   getActiveElementIds(): string[] {
-    return this.activeElementIds.filter((activeElementId) =>
-      this.getElementIds().includes(activeElementId),
-    );
+    const elementIdSet = new Set(this.getElementIds());
+    return this.activeElementIds.filter((id) => elementIdSet.has(id));
   }
 
   observeActiveElementId(): Observable<string | undefined> {


### PR DESCRIPTION
Replace O(n) includes() checks with O(1) Set.has() in WhiteboardHost, change getActiveElementIds() from O(n×m) to O(n+m) via Set filtering, and cap drag-select pointer events at ~60fps via a Date.now() time-gate to avoid redundant intersection calculations.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
