### PR TITLE
perf: memoize per-cursor renders to avoid full list re-renders

### DIFF
--- a/packages/react-sdk/src/components/Whiteboard/CursorRenderer/CursorRenderer.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/CursorRenderer/CursorRenderer.tsx
@@ -15,13 +15,30 @@
  */
 
 import { Grow, styled } from '@mui/material';
+import React from 'react';
 import { TransitionGroup } from 'react-transition-group';
-import { useActiveCursors } from '../../../state';
+import { Point, useActiveCursors } from '../../../state';
 import { useUserDetails } from '../../../store';
 import { Cursor } from './Cursor';
 
 const NoInteraction = styled('g')({
   pointerEvents: 'none',
+});
+
+const CursorEntry = React.memo(function CursorEntry({
+  userId,
+  position,
+  displayName,
+}: {
+  userId: string;
+  position: Point;
+  displayName: string;
+}) {
+  return (
+    <Grow timeout={200}>
+      <Cursor userId={userId} position={position} displayName={displayName} />
+    </Grow>
+  );
 });
 
 export function CursorRenderer() {
@@ -39,13 +56,12 @@ export function CursorRenderer() {
           const displayName = getUserDisplayName(userId);
 
           return (
-            <Grow timeout={200} key={userId}>
-              <Cursor
-                userId={userId}
-                position={position}
-                displayName={displayName}
-              />
-            </Grow>
+            <CursorEntry
+              key={userId}
+              userId={userId}
+              position={position}
+              displayName={displayName}
+            />
           );
         })}
       </TransitionGroup>


### PR DESCRIPTION
Extract CursorEntry as a React.memo component so only the cursor that actually moved re-renders instead of all cursors re-rendering whenever any single cursor position changes.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
