### PR TITLE
fix(webrtc): serialize visibility-driven connect/disconnect with concatMap

### DIFF
--- a/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.test.ts
+++ b/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.test.ts
@@ -189,7 +189,9 @@ describe('WebRtcCommunicationChannel', () => {
       // Make the tab visible again
       mockDocumentVisibilityState('visible');
 
-      expect(sessionManager.join).toHaveBeenCalledTimes(2);
+      await vi.waitFor(() => {
+        expect(sessionManager.join).toHaveBeenCalledTimes(2);
+      });
       expect(sessionManager.join).toHaveBeenCalledWith('whiteboard-id');
     });
 

--- a/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.ts
+++ b/packages/react-sdk/src/state/communication/webRtcCommunicationChannel.ts
@@ -22,13 +22,13 @@ import {
   NEVER,
   Observable,
   Subject,
+  concatMap,
   distinctUntilChanged,
   filter,
   firstValueFrom,
   from,
   interval,
   map,
-  mergeMap,
   switchMap,
   takeUntil,
   timeout,
@@ -103,7 +103,7 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
           // Wait with unsubscribing the session left events till we processed
           // all of then, which is after completing the disconnect
           this.destroySubject.pipe(
-            mergeMap(async () => {
+            switchMap(async () => {
               this.logger.log(
                 'Communication channel destroyed, disconnecting…',
               );
@@ -132,7 +132,7 @@ export class WebRtcCommunicationChannel implements CommunicationChannel {
         switchMap((enableObserveVisibilityState) =>
           observeVisibilityState(visibilityTimeout).pipe(
             takeUntil(this.destroySubject),
-            mergeMap(async (v) => {
+            concatMap(async (v) => {
               if (v === 'visible') {
                 try {
                   this.logger.log('Visibility changed to visible, connecting…');


### PR DESCRIPTION
Replace mergeMap with concatMap in the visibility state handler of WebRtcCommunicationChannel. mergeMap allowed concurrent connect() and disconnect() calls when the browser tab was shown/hidden in rapid succession, leaving peer connections in broken or duplicate states. concatMap serializes these async operations so each completes fully before the next begins.

Also replaces mergeMap with switchMap for the one-shot destroy-signal handler (semantically equivalent for a single-emission source).

Updates the reconnect test assertion to use vi.waitFor() since concatMap processes the queued event one microtask tick later than mergeMap did.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
