### PR TITLE
fix(whiteboard): prune stale cursor entries from scan accumulator

### DIFF
--- a/packages/react-sdk/src/state/whiteboardSlideInstanceImpl.ts
+++ b/packages/react-sdk/src/state/whiteboardSlideInstanceImpl.ts
@@ -132,13 +132,18 @@ export class WhiteboardSlideInstanceImpl implements WhiteboardSlideInstance {
         filter((m) => m.content.slideId === this.slideId),
         scan(
           (acc, m) => {
-            return {
+            const now = Date.now();
+            const next = {
               ...acc,
               [m.senderUserId]: {
                 position: m.content.position as Point,
-                timestamp: Date.now(),
+                timestamp: now,
               },
             };
+            // Prune stale entries so the accumulator stays bounded
+            return Object.fromEntries(
+              Object.entries(next).filter(([, v]) => v.timestamp + 5000 > now),
+            );
           },
           {} as Record<string, { position: Point; timestamp: number }>,
         ),


### PR DESCRIPTION
Cursor positions were only filtered from the observable output, but stale entries for users who left a session remained in the scan() accumulator indefinitely. In long-running collaborative sessions with many join/leave cycles this caused unbounded accumulator growth.

Now stale entries (older than 5 seconds) are removed from the accumulator itself on every new cursor message, keeping it bounded to only currently active users.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
