### PR TITLE
fix(presentation): atomically capture edit mode before updating state

### DIFF
--- a/packages/react-sdk/src/state/presentationManagerImpl.ts
+++ b/packages/react-sdk/src/state/presentationManagerImpl.ts
@@ -140,12 +140,13 @@ export class PresentationManagerImpl implements PresentationManager {
             if (content.view) {
               this.setCurrentPresenter(senderSessionId);
 
-              // clear the undo manager unless the user is already in edit mode
-              if (!this.isEditMode && content.view.isEditMode) {
+              const wasEditMode = this.isEditMode;
+              this.setEditMode(content.view.isEditMode);
+
+              // clear the undo manager only when transitioning into edit mode
+              if (!wasEditMode && content.view.isEditMode) {
                 whiteboardInstance.clearUndoManager();
               }
-
-              this.setEditMode(content.view.isEditMode);
               const frameId = content.view.frameId;
               whiteboardInstance.setActiveFrameElementId(frameId);
             } else {


### PR DESCRIPTION
When a PRESENT_FRAME message was received, isEditMode was read to decide whether to clear the undo manager, then updated separately. Out-of-order messages from the network could cause the transition check to fire at the wrong time, silently clearing a user's undo history.

Fix: capture the previous value before calling setEditMode() so the transition check compares old vs new state atomically.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
