### PR TITLE
perf(react-sdk): stabilize context provider values with useMemo

### DIFF
--- a/packages/react-sdk/src/components/ElementAttachFrameProvider/ElementAttachFrameProvider.tsx
+++ b/packages/react-sdk/src/components/ElementAttachFrameProvider/ElementAttachFrameProvider.tsx
@@ -96,14 +96,21 @@ export function ElementAttachFrameProvider({
     [elementAttachFrame, attachedElementsMovedByFrame, connectingPathIds],
   );
 
+  const setterContext = useMemo<ElementAttachFrameSetterContextType>(
+    () => ({
+      setElementAttachFrame,
+      setAttachedElementsMovedByFrame,
+      setConnectingPathIds,
+    }),
+    [
+      setElementAttachFrame,
+      setAttachedElementsMovedByFrame,
+      setConnectingPathIds,
+    ],
+  );
+
   return (
-    <ElementAttachFrameSetterContext.Provider
-      value={{
-        setElementAttachFrame,
-        setAttachedElementsMovedByFrame,
-        setConnectingPathIds,
-      }}
-    >
+    <ElementAttachFrameSetterContext.Provider value={setterContext}>
       <ElementAttachFrameGetterContext.Provider value={context}>
         {children}
       </ElementAttachFrameGetterContext.Provider>

--- a/packages/react-sdk/src/components/ImageUpload/ImageUploadProvider.tsx
+++ b/packages/react-sdk/src/components/ImageUpload/ImageUploadProvider.tsx
@@ -16,7 +16,13 @@
 
 import { useWidgetApi } from '@matrix-widget-toolkit/react';
 import { TFunction } from 'i18next';
-import { PropsWithChildren, createContext, useCallback, useRef } from 'react';
+import {
+  PropsWithChildren,
+  createContext,
+  useCallback,
+  useMemo,
+  useRef,
+} from 'react';
 import { ErrorCode, FileRejection } from 'react-dropzone';
 import { useTranslation } from 'react-i18next';
 import { uint8ArrayToMimeType } from '../../imageUtils';
@@ -213,8 +219,13 @@ export function ImageUploadProvider({ children }: PropsWithChildren<{}>) {
     ],
   );
 
+  const ctx = useMemo(
+    () => ({ handleDrop, maxUploadSizeBytes }),
+    [handleDrop, maxUploadSizeBytes],
+  );
+
   return (
-    <ImageUploadContext.Provider value={{ handleDrop, maxUploadSizeBytes }}>
+    <ImageUploadContext.Provider value={ctx}>
       {children}
     </ImageUploadContext.Provider>
   );

--- a/packages/react-sdk/src/components/ImportWhiteboardDialog/ImportWhiteboardDialogProvider.tsx
+++ b/packages/react-sdk/src/components/ImportWhiteboardDialog/ImportWhiteboardDialogProvider.tsx
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { PropsWithChildren, createContext, useCallback, useState } from 'react';
+import {
+  PropsWithChildren,
+  createContext,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import { FileRejection, useDropzone } from 'react-dropzone';
 import { ImportWhiteboardDialog } from './ImportWhiteboardDialog';
 import { ImportedWhiteboard } from './types';
@@ -60,11 +66,6 @@ export function ImportWhiteboardDialogProvider({
     [setOpenImportWhiteboardDialog, setImportedData],
   );
 
-  const showImportWhiteboardDialog = (atSlideIndex?: number) => {
-    setAtSlideIndex(atSlideIndex);
-    inputRef.current?.click();
-  };
-
   const {
     getInputProps,
     getRootProps,
@@ -83,12 +84,21 @@ export function ImportWhiteboardDialogProvider({
     noKeyboard: true,
   });
 
+  const showImportWhiteboardDialog = useCallback(
+    (atSlideIndex?: number) => {
+      setAtSlideIndex(atSlideIndex);
+      inputRef.current?.click();
+    },
+    [inputRef],
+  );
+
+  const ctx = useMemo(
+    () => ({ showImportWhiteboardDialog }),
+    [showImportWhiteboardDialog],
+  );
+
   return (
-    <ImportWhiteboardDialogContext.Provider
-      value={{
-        showImportWhiteboardDialog,
-      }}
-    >
+    <ImportWhiteboardDialogContext.Provider value={ctx}>
       <div {...getRootProps()}></div>
       {/* We are hiding it for screen readers and instead expect the dialog to be used */}
       <input

--- a/packages/react-sdk/src/components/Snackbar/SnackbarProvider.tsx
+++ b/packages/react-sdk/src/components/Snackbar/SnackbarProvider.tsx
@@ -113,15 +113,12 @@ export function SnackbarProvider({ children }: PropsWithChildren<{}>) {
     theme.palette.text.primary,
   ]);
 
+  const ctx = useMemo(
+    () => ({ showSnackbar, clearSnackbar: handleClose, snackbarProps }),
+    [showSnackbar, handleClose, snackbarProps],
+  );
+
   return (
-    <SnackbarContext.Provider
-      value={{
-        showSnackbar,
-        clearSnackbar: handleClose,
-        snackbarProps,
-      }}
-    >
-      {children}
-    </SnackbarContext.Provider>
+    <SnackbarContext.Provider value={ctx}>{children}</SnackbarContext.Provider>
   );
 }

--- a/packages/react-sdk/src/components/connection-state/ConnectionStateProvider.tsx
+++ b/packages/react-sdk/src/components/connection-state/ConnectionStateProvider.tsx
@@ -249,16 +249,25 @@ export const ConnectionStateProvider: React.FC<PropsWithChildren> = function ({
     setSnapshotLoadDialogOpen(false);
   }, [setSnapshotLoadDialogOpen]);
 
+  const ctx = useMemo(
+    () => ({
+      handleCloseConnectionStateDialog,
+      connectionState,
+      connectionStateDialogOpen,
+      handleCloseSnapshotLoadDialog,
+      snapshotLoadDialogOpen,
+    }),
+    [
+      handleCloseConnectionStateDialog,
+      connectionState,
+      connectionStateDialogOpen,
+      handleCloseSnapshotLoadDialog,
+      snapshotLoadDialogOpen,
+    ],
+  );
+
   return (
-    <ConnectionStateContext.Provider
-      value={{
-        handleCloseConnectionStateDialog,
-        connectionState,
-        connectionStateDialogOpen,
-        handleCloseSnapshotLoadDialog,
-        snapshotLoadDialogOpen,
-      }}
-    >
+    <ConnectionStateContext.Provider value={ctx}>
       {children}
     </ConnectionStateContext.Provider>
   );


### PR DESCRIPTION
Five context providers were building their value objects inline, causing all context consumers to re-render on every provider render regardless of whether the data actually changed. Wrap each provider value in useMemo so consumer subtrees only re-render when the relevant state changes.

Also stabilizes showImportWhiteboardDialog with useCallback so the ImportWhiteboardDialogContext value reference is truly stable.

Providers fixed:
- ElementAttachFrameProvider (setter context)
- ImportWhiteboardDialogProvider
- ImageUploadProvider
- SnackbarProvider
- ConnectionStateProvider

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
