### PR TITLE
perf(react-sdk): stabilize setTextToolsEnabled via ref in TextEditor

### DIFF
--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Text/TextEditor.tsx
@@ -132,14 +132,17 @@ export function TextEditor({
   const [isEditMode, setEditMode] = useState(editModeOnMount);
   usePauseHotkeysScope(HOTKEY_SCOPE_WHITEBOARD, isEditMode && editable);
 
+  const setTextToolsEnabledRef = useRef(setTextToolsEnabled);
+  setTextToolsEnabledRef.current = setTextToolsEnabled;
+
   useEffect(() => {
     if (!editable && isEditMode) {
       onBlur();
 
       setEditMode(false);
-      setTextToolsEnabled(false);
+      setTextToolsEnabledRef.current(false);
     }
-  }, [editable, isEditMode, onBlur, setTextToolsEnabled]);
+  }, [editable, isEditMode, onBlur]);
 
   const handleDoubleClick = useCallback(
     (event: MouseEvent) => {
@@ -149,12 +152,12 @@ export function TextEditor({
 
       if (editable) {
         setEditMode(true);
-        setTextToolsEnabled(true);
+        setTextToolsEnabledRef.current(true);
       } else {
         event.preventDefault();
       }
     },
-    [editable, isEditMode, setTextToolsEnabled],
+    [editable, isEditMode],
   );
 
   const handleFocus = useCallback(() => {
@@ -181,11 +184,11 @@ export function TextEditor({
       if (textRef.current) {
         fitText(textRef.current, fontSize, contentBold, contentItalic);
         if (!isEmptyText(textRef.current.innerText)) {
-          setTextToolsEnabled(true);
+          setTextToolsEnabledRef.current(true);
         }
       }
     });
-  }, [fontSize, contentBold, contentItalic, setTextToolsEnabled]);
+  }, [fontSize, contentBold, contentItalic]);
 
   const handleKeyUp = useCallback(() => {
     if (textRef.current) {


### PR DESCRIPTION
setTextToolsEnabled is a prop with a default of () => {} - a new function reference on every render. Including it in useEffect and useCallback deps caused those hooks to re-run on every render regardless of actual changes.

Switch to the ref-for-event-handler pattern: always write the latest prop into a ref and call through the ref in effects and callbacks, so none of them need setTextToolsEnabled in their deps array.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
