### PR TITLE
perf(react-sdk): lazy state initializer and stable shade picker key

### DIFF
--- a/packages/react-sdk/src/components/ElementBar/ColorPickerButton/ShadePicker.tsx
+++ b/packages/react-sdk/src/components/ElementBar/ColorPickerButton/ShadePicker.tsx
@@ -57,7 +57,7 @@ export const ShadePicker: React.FC<ShadePickerProps> = function ({
 
     return (
       <Box
-        key={index}
+        key={shade}
         role="radio"
         aria-label={shadeLabels[index]}
         aria-checked={shade === activeColor}

--- a/packages/react-sdk/src/state/useDistinctObserveBehaviorSubject.ts
+++ b/packages/react-sdk/src/state/useDistinctObserveBehaviorSubject.ts
@@ -27,7 +27,7 @@ import { ObservableBehaviorSubject } from './types';
 export function useDistinctObserveBehaviorSubject<T>(
   subject: ObservableBehaviorSubject<T>,
 ): T {
-  const [value, setValue] = useState(subject.getValue());
+  const [value, setValue] = useState(() => subject.getValue());
 
   useEffect(() => {
     const subscription = subject


### PR DESCRIPTION
useDistinctObserveBehaviorSubject: wrap subject.getValue() in an arrow function so React only calls it on mount, not on every render.

ShadePicker: use the shade hex value as the list key instead of the array index, so React correctly reconciles items if the shade list ever reorders.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
