### PR TITLE
fix: clipboard shortcuts not working in presentation mode & edit mode is enabled

### DIFF
--- a/.changeset/green-islands-fall.md
+++ b/.changeset/green-islands-fall.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+fix clipboard shortcuts not working in presentation mode when edit mode is enabled

--- a/packages/react-sdk/src/components/Shortcuts/ClipboardShortcuts/ClipboardShortcuts.test.tsx
+++ b/packages/react-sdk/src/components/Shortcuts/ClipboardShortcuts/ClipboardShortcuts.test.tsx
@@ -64,7 +64,7 @@ describe('<CopyAndPasteShortcuts>', () => {
   let whiteboardManager: Mocked<WhiteboardManager>;
   let activeWhiteboardInstance: WhiteboardInstance;
   let activeSlide: WhiteboardSlideInstance;
-  let setPresentationMode: (enable: boolean) => void;
+  let setPresentationMode: (enable: boolean, enableEdit?: boolean) => void;
 
   beforeEach(() => {
     ({ whiteboardManager, setPresentationMode } = mockWhiteboardManager({
@@ -193,6 +193,60 @@ describe('<CopyAndPasteShortcuts>', () => {
     });
   });
 
+  it('should copy if the presentation mode is active and is in edit mode', () => {
+    setPresentationMode(true, true);
+    activeSlide.setActiveElementIds(['element-2', 'element-1']);
+
+    render(<ClipboardShortcuts />, { wrapper: Wrapper });
+
+    const clipboardData = fireClipboardEvent('copy');
+
+    expect(clipboardData.setData).toHaveBeenCalledWith(
+      'text/plain',
+      'Hello World 1 Hello World 2',
+    );
+    expect(clipboardData.setData).toHaveBeenCalledWith(
+      'text/html',
+      expect.stringContaining('<span data-meta='),
+    );
+    expect(clipboardData.getData('text/plain')).toEqual(
+      'Hello World 1 Hello World 2',
+    );
+    expect(clipboardData.getData('text/html')).toContain('<span data-meta=');
+    expect(
+      Object.entries(
+        deserializeFromHtml(clipboardData.getData('text/html')).elements ?? {},
+      ),
+    ).toEqual([
+      [
+        'element-1',
+        {
+          type: 'shape',
+          kind: 'ellipse',
+          position: { x: 0, y: 1 },
+          fillColor: '#ffffff',
+          textFontFamily: 'Inter',
+          height: 100,
+          width: 50,
+          text: 'Hello World 1',
+        },
+      ],
+      [
+        'element-2',
+        {
+          type: 'shape',
+          kind: 'ellipse',
+          position: { x: 0, y: 1 },
+          fillColor: '#ffffff',
+          textFontFamily: 'Inter',
+          height: 100,
+          width: 50,
+          text: 'Hello World 2',
+        },
+      ],
+    ]);
+  });
+
   it.each([
     ['only frame is selected', ['frame-0']],
     ['frame with attached element is selected', ['frame-0', 'element-1']],
@@ -279,8 +333,8 @@ describe('<CopyAndPasteShortcuts>', () => {
     expect(clipboardData.setData).not.toHaveBeenCalled();
   });
 
-  it('should ignore copy if the presentation mode is active', () => {
-    setPresentationMode(true);
+  it('should ignore copy if the presentation mode is active and is not in edit mode', () => {
+    setPresentationMode(true, false);
 
     render(<ClipboardShortcuts />, { wrapper: Wrapper });
 

--- a/packages/react-sdk/src/components/Shortcuts/ClipboardShortcuts/ClipboardShortcuts.tsx
+++ b/packages/react-sdk/src/components/Shortcuts/ClipboardShortcuts/ClipboardShortcuts.tsx
@@ -73,7 +73,7 @@ export function ClipboardShortcuts() {
   const enableShortcuts = activeScopes.includes(HOTKEY_SCOPE_WHITEBOARD);
   const slideInstance = useWhiteboardSlideInstance();
   const { state: presentationState } = usePresentationMode();
-  const isViewingPresentation =
+  const isOnlyViewingPresentation =
     presentationState.type === 'presentation' && !presentationState.isEditMode;
   const widgetApi = useWidgetApi();
   const { handleDrop } = useImageUpload();
@@ -87,7 +87,7 @@ export function ClipboardShortcuts() {
         return;
       }
 
-      if (isViewingPresentation || slideInstance.isLocked()) {
+      if (isOnlyViewingPresentation || slideInstance.isLocked()) {
         return;
       }
 
@@ -111,7 +111,7 @@ export function ClipboardShortcuts() {
     // the selected element is lost once we interact with other UI elements.
     document.addEventListener('copy', handler);
     return () => document.removeEventListener('copy', handler);
-  }, [enableShortcuts, isViewingPresentation, slideInstance]);
+  }, [enableShortcuts, isOnlyViewingPresentation, slideInstance]);
 
   // Cut event is triggered by the default keyboard shortcut for cutting in the
   // browser, usually Ctrl/Meta+X
@@ -121,7 +121,7 @@ export function ClipboardShortcuts() {
         return;
       }
 
-      if (isViewingPresentation || slideInstance.isLocked()) {
+      if (isOnlyViewingPresentation || slideInstance.isLocked()) {
         return;
       }
 
@@ -142,7 +142,7 @@ export function ClipboardShortcuts() {
 
     document.addEventListener('cut', handler);
     return () => document.removeEventListener('cut', handler);
-  }, [enableShortcuts, isViewingPresentation, slideInstance]);
+  }, [enableShortcuts, isOnlyViewingPresentation, slideInstance]);
 
   const handlePasteImages = useCallback(
     async (files: File[], imageSizes: Size[], centerPosition: Point) => {
@@ -172,7 +172,7 @@ export function ClipboardShortcuts() {
         return;
       }
 
-      if (isViewingPresentation || slideInstance.isLocked()) {
+      if (isOnlyViewingPresentation || slideInstance.isLocked()) {
         return;
       }
 
@@ -284,7 +284,7 @@ export function ClipboardShortcuts() {
   }, [
     enableShortcuts,
     handlePasteImages,
-    isViewingPresentation,
+    isOnlyViewingPresentation,
     slideInstance,
     widgetApi,
     viewportCanvasCenter,

--- a/packages/react-sdk/src/components/Shortcuts/ClipboardShortcuts/ClipboardShortcuts.tsx
+++ b/packages/react-sdk/src/components/Shortcuts/ClipboardShortcuts/ClipboardShortcuts.tsx
@@ -73,7 +73,8 @@ export function ClipboardShortcuts() {
   const enableShortcuts = activeScopes.includes(HOTKEY_SCOPE_WHITEBOARD);
   const slideInstance = useWhiteboardSlideInstance();
   const { state: presentationState } = usePresentationMode();
-  const isViewingPresentation = presentationState.type === 'presentation';
+  const isViewingPresentation =
+    presentationState.type === 'presentation' && !presentationState.isEditMode;
   const widgetApi = useWidgetApi();
   const { handleDrop } = useImageUpload();
   const { viewportCanvasCenter } = useSvgScaleContext();


### PR DESCRIPTION
allow participants to use clipboard shortcuts cut/copy/paste shapes during presentation mode when edit mode is enabled.

https://github.com/user-attachments/assets/50b5b899-d972-4a02-800b-9c2e830e68ab





<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
