### PR TITLE
Fix rotated element overlay display and frame attachment logic for rotation

### DIFF
--- a/.changeset/two-eyes-search.md
+++ b/.changeset/two-eyes-search.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+'@nordeck/matrix-neoboard-widget': patch
+---
+
+Fix the rotated element frame overlay to display correctly when attached. Update the attach logic to consider element rotation.

--- a/packages/react-sdk/src/components/elements/ElementFrameOverlay.tsx
+++ b/packages/react-sdk/src/components/elements/ElementFrameOverlay.tsx
@@ -17,6 +17,10 @@
 import { useTheme } from '@mui/material';
 import { BoundingRect } from '../../state';
 
+type ElementFrameOverlayProps = BoundingRect & {
+  transform?: string;
+};
+
 /**
  * An overlay that is shown when the element is moved over the frame.
  */
@@ -25,11 +29,13 @@ export function ElementFrameOverlay({
   offsetY,
   width,
   height,
-}: BoundingRect) {
+  transform,
+}: ElementFrameOverlayProps) {
   const theme = useTheme();
 
   return (
     <rect
+      transform={transform}
       x={offsetX}
       y={offsetY}
       fill={theme.palette.grey[500]}

--- a/packages/react-sdk/src/components/elements/block-arrow/Display.tsx
+++ b/packages/react-sdk/src/components/elements/block-arrow/Display.tsx
@@ -96,6 +96,7 @@ const BlockArrowDisplay = ({
           {renderedChild}
           {elementMovedHasFrame && (
             <ElementFrameOverlay
+              transform={transform}
               offsetX={shape.position.x}
               offsetY={shape.position.y}
               width={boundingRect.width}

--- a/packages/react-sdk/src/components/elements/ellipse/Display.tsx
+++ b/packages/react-sdk/src/components/elements/ellipse/Display.tsx
@@ -101,6 +101,7 @@ const EllipseDisplay = ({
           {renderedChild}
           {elementMovedHasFrame && (
             <ElementFrameOverlay
+              transform={transform}
               offsetX={shape.position.x}
               offsetY={shape.position.y}
               width={shape.width}

--- a/packages/react-sdk/src/components/elements/image/ImageDisplay.tsx
+++ b/packages/react-sdk/src/components/elements/image/ImageDisplay.tsx
@@ -220,6 +220,7 @@ function ImageDisplay({
             {renderedPlaceholder}
             {elementMovedHasFrame && (
               <ElementFrameOverlay
+                transform={transform}
                 offsetX={position.x}
                 offsetY={position.y}
                 width={width}

--- a/packages/react-sdk/src/components/elements/rectangle/Display.tsx
+++ b/packages/react-sdk/src/components/elements/rectangle/Display.tsx
@@ -116,6 +116,7 @@ const RectangleDisplay = ({
           {renderedChild}
           {elementMovedHasFrame && (
             <ElementFrameOverlay
+              transform={transform}
               offsetX={shape.position.x}
               offsetY={shape.position.y}
               width={shape.width}

--- a/packages/react-sdk/src/components/elements/triangle/Display.tsx
+++ b/packages/react-sdk/src/components/elements/triangle/Display.tsx
@@ -95,6 +95,7 @@ const TriangleDisplay = ({
           {renderedChild}
           {elementMovedHasFrame && (
             <ElementFrameOverlay
+              transform={transform}
               offsetX={shape.position.x}
               offsetY={shape.position.y}
               width={shape.width}

--- a/packages/react-sdk/src/state/crdt/documents/elements.test.ts
+++ b/packages/react-sdk/src/state/crdt/documents/elements.test.ts
@@ -891,7 +891,7 @@ describe('findFrameToAttach', () => {
     ).toEqual('frame-id-0');
   });
 
-  it('should find frame if rotated element bounding rect top left and bottom right corners are withing frame', () => {
+  it('should find frame if rotated element bounding rect top left and bottom right corners are within frame', () => {
     expect(
       findFrameToAttach(
         mockRectangleElement({

--- a/packages/react-sdk/src/state/crdt/documents/elements.test.ts
+++ b/packages/react-sdk/src/state/crdt/documents/elements.test.ts
@@ -24,6 +24,7 @@ import {
   mockRectangleElement,
 } from '../../../lib/testUtils';
 import {
+  calculateBoundingRectForElement,
   calculateBoundingRectForElements,
   calculateFittedElementSize,
   clampElementPosition,
@@ -659,6 +660,49 @@ describe('calculateBoundingRectForElements', () => {
   });
 });
 
+describe('calculateBoundingRectForElement', () => {
+  it('should calculate the bounding rect for element with shape element', () => {
+    const element = mockEllipseElement();
+    expect(calculateBoundingRectForElement(element)).toEqual({
+      offsetX: 0,
+      offsetY: 1,
+      width: 50,
+      height: 100,
+    });
+  });
+
+  it('should calculate the bounding rect for element with rotated shape element', () => {
+    const element = mockEllipseElement({
+      position: {
+        x: 200,
+        y: 201,
+      },
+      rotation: 30,
+    });
+    expect(calculateBoundingRectForElement(element)).toEqual({
+      offsetX: expect.closeTo(178.349),
+      offsetY: expect.closeTo(195.198),
+      width: expect.closeTo(93.301),
+      height: expect.closeTo(111.602),
+    });
+  });
+
+  it('should calculate the bounding rect for element with single path element', () => {
+    const element = mockLineElement({
+      points: [
+        { x: 0, y: 0 },
+        { x: 2, y: 2 },
+      ],
+    });
+    expect(calculateBoundingRectForElement(element)).toEqual({
+      offsetX: 0,
+      offsetY: 1,
+      width: 2,
+      height: 2,
+    });
+  });
+});
+
 describe('calculateFittedElementSize', () => {
   it('should return 0, 0 if everything is 0', () => {
     expect(
@@ -847,7 +891,29 @@ describe('findFrameToAttach', () => {
     ).toEqual('frame-id-0');
   });
 
-  it('should not find frame if element top left is not within the frame', () => {
+  it('should find frame if rotated element bounding rect top left and bottom right corners are withing frame', () => {
+    expect(
+      findFrameToAttach(
+        mockRectangleElement({
+          position: {
+            x: 11,
+            y: 12,
+          },
+          height: 50,
+          rotation: 45,
+        }),
+        {
+          'frame-id-0': mockFrameElement({
+            position: { x: 0, y: 1 },
+            width: 100,
+            height: 100,
+          }),
+        },
+      ),
+    ).toEqual('frame-id-0');
+  });
+
+  it('should not find frame if element top left corner is not within the frame', () => {
     expect(
       findFrameToAttach(mockRectangleElement(), {
         'frame-id-0': mockFrameElement({
@@ -856,6 +922,28 @@ describe('findFrameToAttach', () => {
           height: 100,
         }),
       }),
+    ).toBeUndefined();
+  });
+
+  it('should not find frame if rotated element bounding rect top left corner is not within the frame', () => {
+    expect(
+      findFrameToAttach(
+        mockRectangleElement({
+          position: {
+            x: 10,
+            y: 12,
+          },
+          height: 50,
+          rotation: 45,
+        }),
+        {
+          'frame-id-0': mockFrameElement({
+            position: { x: 0, y: 1 },
+            width: 100,
+            height: 100,
+          }),
+        },
+      ),
     ).toBeUndefined();
   });
 
@@ -868,6 +956,28 @@ describe('findFrameToAttach', () => {
           height: 50,
         }),
       }),
+    ).toBeUndefined();
+  });
+
+  it('should not find frame if rotated element bounding rect bottom right corner is not within the frame', () => {
+    expect(
+      findFrameToAttach(
+        mockRectangleElement({
+          position: {
+            x: 11,
+            y: 42,
+          },
+          height: 50,
+          rotation: 45,
+        }),
+        {
+          'frame-id-0': mockFrameElement({
+            position: { x: 0, y: 1 },
+            width: 100,
+            height: 100,
+          }),
+        },
+      ),
     ).toBeUndefined();
   });
 

--- a/packages/react-sdk/src/state/crdt/documents/elements.ts
+++ b/packages/react-sdk/src/state/crdt/documents/elements.ts
@@ -229,6 +229,12 @@ export function calculateBoundingRectForElements(
   );
 }
 
+export function calculateBoundingRectForElement(
+  element: Element,
+): BoundingRect {
+  return calculateBoundingRectForPoints(getElementBoundingPoints(element));
+}
+
 function getElementBoundingPoints(element: Element): Point[] {
   if (isRotatableElement(element) && element.rotation) {
     const {
@@ -432,11 +438,8 @@ export function findFrameToAttach(
   element: ShapeElement | PathElement | ImageElement,
   frameElements: Elements<FrameElement>,
 ): string | undefined {
-  const { position } = element;
-  const { width, height } =
-    element.type === 'path'
-      ? calculateBoundingRectForPoints(element.points)
-      : element;
+  const { offsetX, offsetY, width, height } =
+    calculateBoundingRectForElement(element);
 
   const entry = Object.entries(frameElements)
     .reverse()
@@ -448,11 +451,17 @@ export function findFrameToAttach(
         height: frameElement.height,
       };
       return (
-        isPointWithinBoundingRect(position, frameBoundingRect) &&
         isPointWithinBoundingRect(
           {
-            x: position.x + width,
-            y: position.y + height,
+            x: offsetX,
+            y: offsetY,
+          },
+          frameBoundingRect,
+        ) &&
+        isPointWithinBoundingRect(
+          {
+            x: offsetX + width,
+            y: offsetY + height,
           },
           frameBoundingRect,
         )

--- a/packages/react-sdk/src/state/crdt/documents/index.ts
+++ b/packages/react-sdk/src/state/crdt/documents/index.ts
@@ -15,7 +15,6 @@
  */
 
 export {
-  calculateBoundingRectForElement,
   calculateBoundingRectForElements,
   calculateFittedElementSize,
   clampElementPosition,

--- a/packages/react-sdk/src/state/crdt/documents/index.ts
+++ b/packages/react-sdk/src/state/crdt/documents/index.ts
@@ -15,6 +15,7 @@
  */
 
 export {
+  calculateBoundingRectForElement,
   calculateBoundingRectForElements,
   calculateFittedElementSize,
   clampElementPosition,


### PR DESCRIPTION
The rotated element frame overlay is not shown correctly when the element is attached to frame, fixed.

The logic to attach to frame did not consider the rotation, fixed.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
