### PR TITLE
[NEO-1715] optimize arrow keys navigations when HelpMenu / SettingsMenu are open

### DIFF
--- a/.changeset/ninety-ants-doubt.md
+++ b/.changeset/ninety-ants-doubt.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+Pause whiteboard keyboard shortcuts while the Settings or Help menu is open, and stop the menu button from regaining focus after closing the menu with Escape.

--- a/packages/react-sdk/src/components/BoardBar/BoardBar.test.tsx
+++ b/packages/react-sdk/src/components/BoardBar/BoardBar.test.tsx
@@ -20,6 +20,7 @@ import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axe from 'axe-core';
 import { ComponentType, PropsWithChildren } from 'react';
+import { useHotkeysContext } from 'react-hotkeys-hook';
 import {
   Mocked,
   afterEach,
@@ -33,7 +34,7 @@ import {
   WhiteboardTestingContextProvider,
   mockFrameElement,
   mockWhiteboardManager,
-} from '../../lib/testUtils/documentTestUtils';
+} from '../../lib/testUtils';
 import { mockPowerLevelsEvent } from '../../lib/testUtils/matrixTestUtils';
 import {
   WhiteboardDocumentExport,
@@ -43,9 +44,21 @@ import {
 } from '../../state';
 import { ImageUploadProvider } from '../ImageUpload';
 import { ImportWhiteboardDialogProvider } from '../ImportWhiteboardDialog/ImportWhiteboardDialogProvider';
-import { LayoutStateProvider } from '../Layout/useLayoutState';
+import { LayoutStateProvider } from '../Layout';
 import { SnackbarProvider } from '../Snackbar';
+import {
+  HOTKEY_SCOPE_GLOBAL,
+  HOTKEY_SCOPE_WHITEBOARD,
+  WhiteboardHotkeysProvider,
+} from '../WhiteboardHotkeysProvider';
 import { BoardBar } from './BoardBar';
+
+// Exposes the hotkeys scopes that are currently active, so tests can assert
+// on them without depending on any concrete hotkey being bound to the scope.
+function EnabledScopes() {
+  const { activeScopes } = useHotkeysContext();
+  return <div data-testid="enabled-scopes">{activeScopes.join(',')}</div>;
+}
 
 vi.mock('@matrix-widget-toolkit/mui', async () => ({
   ...(await vi.importActual<typeof import('@matrix-widget-toolkit/mui')>(
@@ -78,18 +91,20 @@ describe('<BoardBar/>', () => {
     activeSlide = activeWhiteboard.getSlide('slide-0');
 
     Wrapper = ({ children }) => (
-      <WhiteboardTestingContextProvider
-        whiteboardManager={whiteboardManager}
-        widgetApi={widgetApi}
-      >
-        <SnackbarProvider>
-          <ImageUploadProvider>
-            <ImportWhiteboardDialogProvider>
-              <LayoutStateProvider>{children}</LayoutStateProvider>
-            </ImportWhiteboardDialogProvider>
-          </ImageUploadProvider>
-        </SnackbarProvider>
-      </WhiteboardTestingContextProvider>
+      <WhiteboardHotkeysProvider>
+        <WhiteboardTestingContextProvider
+          whiteboardManager={whiteboardManager}
+          widgetApi={widgetApi}
+        >
+          <SnackbarProvider>
+            <ImageUploadProvider>
+              <ImportWhiteboardDialogProvider>
+                <LayoutStateProvider>{children}</LayoutStateProvider>
+              </ImportWhiteboardDialogProvider>
+            </ImageUploadProvider>
+          </SnackbarProvider>
+        </WhiteboardTestingContextProvider>
+      </WhiteboardHotkeysProvider>
     );
   });
 
@@ -260,6 +275,67 @@ describe('<BoardBar/>', () => {
     await waitFor(() => {
       expect(settingsMenu).not.toBeInTheDocument();
     });
+  });
+
+  it('should pause the whiteboard hotkeys scope while the settings menu is open', async () => {
+    render(
+      <>
+        <BoardBar />
+        <EnabledScopes />
+      </>,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByTestId('enabled-scopes').textContent).toEqual(
+      `${HOTKEY_SCOPE_WHITEBOARD},${HOTKEY_SCOPE_GLOBAL}`,
+    );
+
+    const toolbar = screen.getByRole('toolbar', { name: 'Board' });
+
+    await userEvent.click(
+      within(toolbar).getByRole('button', { name: 'Settings' }),
+    );
+
+    const settingsMenu = screen.getByRole('menu', {
+      name: 'Settings',
+    });
+
+    await waitFor(() => {
+      expect(settingsMenu).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('enabled-scopes').textContent).toEqual(
+        HOTKEY_SCOPE_GLOBAL,
+      );
+    });
+
+    await userEvent.keyboard('[Escape]');
+
+    await waitFor(() => {
+      expect(settingsMenu).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('enabled-scopes').textContent).toEqual(
+        `${HOTKEY_SCOPE_GLOBAL},${HOTKEY_SCOPE_WHITEBOARD}`,
+      );
+    });
+  });
+
+  it('should not restore focus to the settings button after the settings menu is closed', async () => {
+    render(<BoardBar />, { wrapper: Wrapper });
+
+    const toolbar = screen.getByRole('toolbar', { name: 'Board' });
+
+    const menuSettingsMenu = within(toolbar).getByRole('button', {
+      name: 'Settings',
+    });
+
+    await userEvent.click(menuSettingsMenu);
+
+    await userEvent.keyboard('[Escape]');
+    expect(menuSettingsMenu).not.toHaveFocus();
   });
 
   it('should open the settings menu and show import button for user with the right power level and not show if no power level', async () => {

--- a/packages/react-sdk/src/components/BoardBar/SettingsMenu.tsx
+++ b/packages/react-sdk/src/components/BoardBar/SettingsMenu.tsx
@@ -23,6 +23,10 @@ import { useTranslation } from 'react-i18next';
 import { usePowerLevels } from '../../store/api/usePowerLevels';
 import { useImportWhiteboardDialog } from '../ImportWhiteboardDialog/useImportWhiteboardDialog';
 import { useLayoutState } from '../Layout';
+import {
+  HOTKEY_SCOPE_WHITEBOARD,
+  usePauseHotkeysScope,
+} from '../WhiteboardHotkeysProvider';
 import { MenuItemSwitch } from '../common/MenuItemSwitch';
 import { ToolbarSubMenu } from '../common/Toolbar';
 import { DotsGridIcon } from '../icons/DotsGridIcon';
@@ -55,6 +59,7 @@ export function SettingsMenu() {
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
+  usePauseHotkeysScope(HOTKEY_SCOPE_WHITEBOARD, open);
 
   const [openExportDialog, setOpenExportDialog] = useState(false);
   const { canImportWhiteboard } = usePowerLevels();
@@ -136,6 +141,7 @@ export function SettingsMenu() {
           [buttonId],
         )}
         id={menuId}
+        disableRestoreFocus={true}
       >
         {canImportWhiteboard && <ImportMenuItem onClose={handleClose} />}
         <MenuItem onClick={handleExportClick}>

--- a/packages/react-sdk/src/components/HelpCenterBar/HelpCenterBar.test.tsx
+++ b/packages/react-sdk/src/components/HelpCenterBar/HelpCenterBar.test.tsx
@@ -19,8 +19,14 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axe from 'axe-core';
 import { ComponentType, PropsWithChildren } from 'react';
+import { useHotkeysContext } from 'react-hotkeys-hook';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { GuidedTourProvider, useGuidedTour } from '../GuidedTour';
+import {
+  HOTKEY_SCOPE_GLOBAL,
+  HOTKEY_SCOPE_WHITEBOARD,
+  WhiteboardHotkeysProvider,
+} from '../WhiteboardHotkeysProvider';
 import { HelpCenterBar } from './HelpCenterBar';
 
 vi.mock('@matrix-widget-toolkit/mui', async () => ({
@@ -35,6 +41,11 @@ function TestComponent() {
   return <p>Tour running: {isRunning ? 'YES' : 'NO'}</p>;
 }
 
+function EnabledScopes() {
+  const { activeScopes } = useHotkeysContext();
+  return <div data-testid="enabled-scopes">{activeScopes.join(',')}</div>;
+}
+
 describe('<HelpCenterBar/>', () => {
   let Wrapper: ComponentType<PropsWithChildren<{}>>;
 
@@ -44,10 +55,12 @@ describe('<HelpCenterBar/>', () => {
     );
 
     Wrapper = ({ children }) => (
-      <GuidedTourProvider>
-        {children}
-        <TestComponent />
-      </GuidedTourProvider>
+      <WhiteboardHotkeysProvider>
+        <GuidedTourProvider>
+          {children}
+          <TestComponent />
+        </GuidedTourProvider>
+      </WhiteboardHotkeysProvider>
     );
   });
 
@@ -120,6 +133,65 @@ describe('<HelpCenterBar/>', () => {
     await waitFor(() => {
       expect(menu).not.toBeInTheDocument();
     });
+  });
+
+  it('should pause the whiteboard hotkeys scope while the help menu is open', async () => {
+    render(
+      <>
+        <HelpCenterBar />
+        <EnabledScopes />
+      </>,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByTestId('enabled-scopes').textContent).toEqual(
+      `${HOTKEY_SCOPE_WHITEBOARD},${HOTKEY_SCOPE_GLOBAL}`,
+    );
+
+    const toolbar = screen.getByRole('toolbar', { name: 'Help center' });
+
+    await userEvent.click(
+      within(toolbar).getByRole('button', { name: 'Help' }),
+    );
+
+    const menu = screen.getByRole('menu', { name: 'Help' });
+
+    await waitFor(() => {
+      expect(menu).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('enabled-scopes').textContent).toEqual(
+        HOTKEY_SCOPE_GLOBAL,
+      );
+    });
+
+    await userEvent.keyboard('[Escape]');
+
+    await waitFor(() => {
+      expect(menu).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('enabled-scopes').textContent).toEqual(
+        `${HOTKEY_SCOPE_GLOBAL},${HOTKEY_SCOPE_WHITEBOARD}`,
+      );
+    });
+  });
+
+  it('should not restore focus to the help button after the help menu is closed', async () => {
+    render(<HelpCenterBar />, { wrapper: Wrapper });
+
+    const toolbar = screen.getByRole('toolbar', { name: 'Help center' });
+
+    const menuHelpButton = within(toolbar).getByRole('button', {
+      name: 'Help',
+    });
+
+    await userEvent.click(menuHelpButton);
+
+    await userEvent.keyboard('[Escape]');
+    expect(menuHelpButton).not.toHaveFocus();
   });
 
   it('should open the about dialog and close the menu', async () => {

--- a/packages/react-sdk/src/components/HelpCenterBar/HelpMenu.tsx
+++ b/packages/react-sdk/src/components/HelpCenterBar/HelpMenu.tsx
@@ -21,6 +21,10 @@ import { unstable_useId as useId } from '@mui/utils';
 import { MouseEvent, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useGuidedTour } from '../GuidedTour';
+import {
+  HOTKEY_SCOPE_WHITEBOARD,
+  usePauseHotkeysScope,
+} from '../WhiteboardHotkeysProvider';
 import { ToolbarSubMenu } from '../common/Toolbar';
 import { InfoDialog } from './InfoDialog';
 import { ShortcutsDialog } from './ShortcutsDialog';
@@ -33,6 +37,7 @@ export function HelpMenu() {
   const embedded = getEnvironment('REACT_APP_EMBEDDED') === 'true';
 
   const open = Boolean(anchorEl);
+  usePauseHotkeysScope(HOTKEY_SCOPE_WHITEBOARD, open);
 
   const handleClick = useCallback((event: MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -121,6 +126,7 @@ export function HelpMenu() {
           ),
         }}
         id={menuId}
+        disableRestoreFocus={true}
       >
         {helpCenterUrl && (
           <MenuItem


### PR DESCRIPTION
Both menus (`SettingsMenu` and `HelpMenu`) when opened and closed they disrupt the keyboard shortcuts for moving shapes on the board (up/down) plus after opening a menu and navigate with the keyboard up down left right , the selected shape/frame on the board gets moved simultanusely.

in order to stop menus from being opened again after immidiate closing and pressing arrow down to move a shape, there is a parameter in MUI menus to disable the focus to be returned to the triggering bbutton (`disableRestoreFocus`)

and to stop the shapes/ frames from moving when a menu is open, the scope of keyboard shortcuts is paused untill the menu gets closed.

before:

https://github.com/user-attachments/assets/22534d6f-cbab-4125-bca0-02d27b42f47b

https://github.com/user-attachments/assets/46b37ff8-0037-4730-9f5b-35393de9844a




**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
