### PR TITLE
Remove Widget API metadata from the OpenID Token sent to lk-jwt service

### DIFF
--- a/.changeset/funny-clubs-heal.md
+++ b/.changeset/funny-clubs-heal.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+Fixes LiveKit JWT Service rejection of raw Widget API provided OpenID tokens

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,7 +62,10 @@ export default ts.config(
           templateFile: path.resolve(__dirname, './scripts/license-header.txt'),
           onNonMatchingHeader: 'replace',
           templateVars: { NAME: 'Nordeck IT + Consulting GmbH' },
-          varRegexps: { NAME: /.+/ },
+          varRegexps: {
+            NAME: /.+/,
+            YEAR: /\d{4}(\s?-\s?\d{4})?/,
+          },
         },
       ],
       'no-restricted-imports': [

--- a/packages/react-sdk/src/state/communication/discovery/autodiscovery.test.ts
+++ b/packages/react-sdk/src/state/communication/discovery/autodiscovery.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Nordeck IT + Consulting GmbH
+ * Copyright 2025-2026 Nordeck IT + Consulting GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,46 @@
  * limitations under the License.
  */
 
+import { MockedWidgetApi, mockWidgetApi } from '@matrix-widget-toolkit/testing';
+import { IOpenIDCredentials } from 'matrix-widget-api';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import AutoDiscovery from './autodiscovery';
+import { LivekitFocus } from './matrixRtcFocus';
 
 describe('AutoDiscovery', () => {
   let originalFetch: typeof globalThis.fetch;
+  let widgetApi: MockedWidgetApi;
+  let globalFetch: Mock;
+
+  const activeFocus: LivekitFocus = {
+    type: 'livekit',
+    livekit_service_url: 'https://livekit-jwt.example.org',
+    livekit_alias: '!room-id:example.com',
+  };
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
     const mockFetch = vi.fn();
     AutoDiscovery.setFetchFn(mockFetch);
+
+    widgetApi = mockWidgetApi();
+    // @ts-ignore forcefully set for tests
+    widgetApi.widgetParameters.deviceId = 'DEVICEID';
+
+    // getLiveKitJWT uses the global fetch, not AutoDiscovery.fetch
+    globalFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({ url: 'wss://livekit.example.org', jwt: 'jwt' }),
+    });
+    vi.stubGlobal('fetch', globalFetch);
   });
 
   afterEach(() => {
     AutoDiscovery.setFetchFn(originalFetch);
+    widgetApi.stop();
+    vi.unstubAllGlobals();
     vi.resetAllMocks();
   });
 
@@ -77,6 +103,69 @@ describe('AutoDiscovery', () => {
 
       const result = await AutoDiscovery.getRawClientConfig('example.org');
       expect(result).toEqual(mockWellKnown);
+    });
+  });
+
+  describe('getLiveKitJWT', () => {
+    it('should only forward the credential fields of the OpenID token', async () => {
+      // The widget API resolves the raw response data, which also carries
+      // request metadata that the LiveKit JWT Token Service rejects.
+      const openIdToken = {
+        access_token: 'access-token',
+        expires_in: 3600,
+        matrix_server_name: 'example.com',
+        token_type: 'Bearer',
+        state: 'allowed',
+        original_request_id: 'request-id',
+      } as IOpenIDCredentials;
+
+      await AutoDiscovery.getLiveKitJWT(
+        widgetApi,
+        'https://livekit-jwt.example.org',
+        '!room-id:example.com',
+        openIdToken,
+      );
+
+      const body = JSON.parse(globalFetch.mock.calls[0][1].body);
+      expect(body.openid_token).toEqual({
+        access_token: 'access-token',
+        expires_in: 3600,
+        matrix_server_name: 'example.com',
+        token_type: 'Bearer',
+      });
+    });
+  });
+
+  describe('getSFUConfigWithOpenID', () => {
+    it('should exchange the OpenID token of the widget API for an SFU config', async () => {
+      widgetApi.requestOpenIDConnectToken.mockResolvedValue({
+        access_token: 'access-token',
+        expires_in: 3600,
+        matrix_server_name: 'example.com',
+        token_type: 'Bearer',
+        // metadata added by the widget API that must not be forwarded
+        state: 'allowed',
+        original_request_id: 'request-id',
+      } as IOpenIDCredentials);
+
+      await expect(
+        AutoDiscovery.getSFUConfigWithOpenID(widgetApi, activeFocus),
+      ).resolves.toEqual({ url: 'wss://livekit.example.org', jwt: 'jwt' });
+
+      expect(globalFetch).toHaveBeenCalledWith(
+        'https://livekit-jwt.example.org/sfu/get',
+        expect.anything(),
+      );
+      expect(JSON.parse(globalFetch.mock.calls[0][1].body)).toEqual({
+        room: '!room-id:example.com',
+        openid_token: {
+          access_token: 'access-token',
+          expires_in: 3600,
+          matrix_server_name: 'example.com',
+          token_type: 'Bearer',
+        },
+        device_id: 'DEVICEID',
+      });
     });
   });
 });

--- a/packages/react-sdk/src/state/communication/discovery/autodiscovery.ts
+++ b/packages/react-sdk/src/state/communication/discovery/autodiscovery.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright 2018 New Vector Ltd
  * Copyright 2019 The Matrix.org Foundation C.I.C.
- * Copyright 2025 Nordeck IT + Consulting GmbH
+ * Copyright 2025-2026 Nordeck IT + Consulting GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,7 +178,15 @@ export default class AutoDiscovery {
         },
         body: JSON.stringify({
           room: roomName,
-          openid_token: openIDToken,
+          // Only forward the credential fields. The Widget API result carries
+          // identity request permissions metadata such as `state` that the
+          // LiveKit JWT Token Service rejects.
+          openid_token: {
+            access_token: openIDToken.access_token,
+            expires_in: openIDToken.expires_in,
+            matrix_server_name: openIDToken.matrix_server_name,
+            token_type: openIDToken.token_type,
+          },
           device_id: widgetApi.widgetParameters.deviceId,
         }),
       });


### PR DESCRIPTION
Since [version 0.4.0](https://github.com/element-hq/lk-jwt-service/releases/tag/v0.4.0), the LiveKit JWT Service does a [stricter validation](https://github.com/element-hq/lk-jwt-service/commit/6573de0d93a8a50dd9a07ba2c4c0ac806d7ad813#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R357) of the OpenID Token passed down to `/sfu/get`.

Because the Widget API carries around the Identity Verification request permission state and returns that on calls to `requestOpenIDConnectToken`, we need to strip the state out.

- [X] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [X] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
