### PR TITLE
Fix stylus drag-select getting stuck when pen hovers off the surface

### DIFF
--- a/.changeset/real-grapes-film.md
+++ b/.changeset/real-grapes-film.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': patch
+---
+
+Fixed getting stuck in the drag-select mode when using a pen or a drawing stylus that gets detected even when not touching the drawing surface.

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.test.tsx
@@ -33,6 +33,7 @@ import {
   mockWhiteboardManager,
   WhiteboardTestingContextProvider,
 } from '../../../../lib/testUtils/documentTestUtils';
+import { firePointerMoveEvent } from '../../../../lib/testUtils/domTestUtils';
 import {
   Point,
   WhiteboardManager,
@@ -165,7 +166,7 @@ describe('<DragSelect/>', () => {
     render(<DragSelect />, { wrapper: Wrapper });
 
     vi.mocked(svgUtils.calculateSvgCoords).mockReturnValue({ x: 50, y: 50 });
-    fireEvent.pointerMove(screen.getByTestId('drag-select-layer'), {
+    firePointerMoveEvent(screen.getByTestId('drag-select-layer'), {
       clientX: 50,
       clientY: 50,
     });
@@ -181,7 +182,7 @@ describe('<DragSelect/>', () => {
       setDragSelectStartCoords({ x: 0, y: 0 });
     });
     vi.mocked(svgUtils.calculateSvgCoords).mockReturnValue({ x: 50, y: 50 });
-    fireEvent.pointerMove(screen.getByTestId('drag-select-layer'), {
+    firePointerMoveEvent(screen.getByTestId('drag-select-layer'), {
       clientX: 50,
       clientY: 50,
     });
@@ -198,7 +199,7 @@ describe('<DragSelect/>', () => {
       setDragSelectStartCoords({ x: 60, y: 60 });
     });
     vi.mocked(svgUtils.calculateSvgCoords).mockReturnValue({ x: 70, y: 70 });
-    fireEvent.pointerMove(screen.getByTestId('drag-select-layer'), {
+    firePointerMoveEvent(screen.getByTestId('drag-select-layer'), {
       clientX: 70,
       clientY: 70,
     });
@@ -210,7 +211,7 @@ describe('<DragSelect/>', () => {
 
     // Now extend the selection to the corner where element-0 is located
     vi.mocked(svgUtils.calculateSvgCoords).mockReturnValue({ x: 0, y: 0 });
-    fireEvent.pointerMove(screen.getByTestId('drag-select-layer'), {
+    firePointerMoveEvent(screen.getByTestId('drag-select-layer'), {
       clientX: 0,
       clientY: 0,
     });
@@ -224,7 +225,7 @@ describe('<DragSelect/>', () => {
     expect(activeSlide.getActiveElementIds()).not.toContain('frame-0');
   });
 
-  it('should should select an element attached to active frame in infinite canvas mode in the presentation mode if edit mode is enabled', () => {
+  it('should select an element attached to active frame in infinite canvas mode in the presentation mode if edit mode is enabled', () => {
     vi.mocked(getEnvironment).mockImplementation((name, defaultValue) =>
       name === 'REACT_APP_INFINITE_CANVAS' ? 'true' : defaultValue,
     );
@@ -254,7 +255,7 @@ describe('<DragSelect/>', () => {
       setDragSelectStartCoords({ x: 60, y: 60 });
     });
     vi.mocked(svgUtils.calculateSvgCoords).mockReturnValue({ x: 70, y: 70 });
-    fireEvent.pointerMove(screen.getByTestId('drag-select-layer'), {
+    firePointerMoveEvent(screen.getByTestId('drag-select-layer'), {
       clientX: 70,
       clientY: 70,
     });
@@ -262,7 +263,7 @@ describe('<DragSelect/>', () => {
     expect(activeSlide.getActiveElementIds()).toEqual(['element-1']);
   });
 
-  it('should should not select an element without frame in infinite canvas mode in the presentation mode if edit mode is enabled', () => {
+  it('should not select an element without frame in infinite canvas mode in the presentation mode if edit mode is enabled', () => {
     vi.mocked(getEnvironment).mockImplementation((name, defaultValue) =>
       name === 'REACT_APP_INFINITE_CANVAS' ? 'true' : defaultValue,
     );
@@ -276,7 +277,7 @@ describe('<DragSelect/>', () => {
       setDragSelectStartCoords({ x: 60, y: 60 });
     });
     vi.mocked(svgUtils.calculateSvgCoords).mockReturnValue({ x: 70, y: 70 });
-    fireEvent.pointerMove(screen.getByTestId('drag-select-layer'), {
+    firePointerMoveEvent(screen.getByTestId('drag-select-layer'), {
       clientX: 70,
       clientY: 70,
     });
@@ -317,11 +318,28 @@ describe('<DragSelect/>', () => {
       setDragSelectStartCoords({ x: 60, y: 60 });
     });
     vi.mocked(svgUtils.calculateSvgCoords).mockReturnValue({ x: 70, y: 70 });
-    fireEvent.pointerMove(screen.getByTestId('drag-select-layer'), {
+    firePointerMoveEvent(screen.getByTestId('drag-select-layer'), {
       clientX: 70,
       clientY: 70,
     });
 
     expect(activeSlide.getActiveElementIds()).toEqual([]);
+  });
+
+  it('should immediately cancel drag select if pen is not touching the surface', () => {
+    render(<DragSelect />, { wrapper: Wrapper });
+    act(() => {
+      setDragSelectStartCoords({ x: 60, y: 60 });
+    });
+
+    firePointerMoveEvent(screen.getByTestId('drag-select-layer'), {
+      isPrimary: true,
+      pointerType: 'pen',
+      button: -1,
+      buttons: 0, // not touching the surface
+      clientX: 50,
+      clientY: 50,
+    });
+    expect(dragSelectStartCoords).toBeUndefined();
   });
 });

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/DragSelect.tsx
@@ -137,12 +137,18 @@ export function DragSelect() {
   const lastMoveRef = useRef(0);
   const handlePointerMove = useCallback(
     (event: PointerEvent<SVGRectElement>) => {
+      // If the pen isn't touhing the surface we should cancel the drag select mode immediately.
+      if (event.pointerType === 'pen' && event.buttons === 0) {
+        setDragSelectStartCoords();
+        return;
+      }
+
       const now = Date.now();
       if (now - lastMoveRef.current < POINTER_MOVE_THROTTLE_MS) return;
       lastMoveRef.current = now;
       setEndCoords(calculateSvgCoords({ x: event.clientX, y: event.clientY }));
     },
-    [calculateSvgCoords],
+    [calculateSvgCoords, setDragSelectStartCoords],
   );
 
   return (

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/UnSelectElementHandler.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/UnSelectElementHandler.test.tsx
@@ -33,9 +33,12 @@ import {
   mockEllipseElement,
   mockWhiteboardManager,
 } from '../../../../lib/testUtils/documentTestUtils';
+import { firePointerMoveEvent } from '../../../../lib/testUtils/domTestUtils';
 import { Point, WhiteboardSlideInstance } from '../../../../state';
 import { LayoutStateProvider, useLayoutState } from '../../../Layout';
+import * as constants from '../../constants';
 import { SvgCanvas } from '../../SvgCanvas';
+import { SvgScaleContextType, useSvgScaleContext } from '../../SvgScaleContext';
 import { UnSelectElementHandler } from './UnSelectElementHandler';
 
 vi.mock('@matrix-widget-toolkit/mui', async () => {
@@ -51,6 +54,7 @@ vi.mock('@matrix-widget-toolkit/mui', async () => {
 describe('<UnSelectElementHandler/>', () => {
   let activeSlide: WhiteboardSlideInstance;
   let dragSelectStartCoords: Point | undefined;
+  let contextState: SvgScaleContextType;
   let widgetApi: MockedWidgetApi;
   let Wrapper: ComponentType<PropsWithChildren<{}>>;
   let textElement: HTMLDivElement;
@@ -76,6 +80,11 @@ describe('<UnSelectElementHandler/>', () => {
       return null;
     }
 
+    const SvgContextExtractor = () => {
+      contextState = useSvgScaleContext();
+      return null;
+    };
+
     Wrapper = ({ children }) => (
       <LayoutStateProvider>
         <LayoutStateExtractor />
@@ -84,6 +93,7 @@ describe('<UnSelectElementHandler/>', () => {
           widgetApi={widgetApi}
         >
           <SvgCanvas viewportWidth={200} viewportHeight={200}>
+            <SvgContextExtractor />
             {children}
           </SvgCanvas>
         </WhiteboardTestingContextProvider>
@@ -129,6 +139,27 @@ describe('<UnSelectElementHandler/>', () => {
     await userEvent.pointer({ keys: '[MouseLeft>]', target: layer });
 
     expect(dragSelectStartCoords).toEqual({ x: 23, y: 42 });
+  });
+
+  it('should ignore pointer move events when pen is not touching the surface', async () => {
+    vi.spyOn(constants, 'infiniteCanvasMode', 'get').mockReturnValue(true);
+    render(<UnSelectElementHandler />, { wrapper: Wrapper });
+    const layer = screen.getByTestId('unselect-element-layer');
+    const translationBeforeMove = contextState.translation;
+
+    // Setup for the canvas pan
+    await userEvent.pointer({ keys: '[TouchA>]', target: layer });
+
+    // Should ignore when the pen is hovering above the surface
+    firePointerMoveEvent(layer, {
+      isPrimary: true,
+      pointerType: 'pen',
+      button: -1,
+      buttons: 0, // not touching the surface
+      clientX: 50,
+      clientY: 50,
+    });
+    expect(contextState.translation).toEqual(translationBeforeMove);
   });
 
   const selectText = () => {

--- a/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/UnSelectElementHandler.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/ElementBehaviors/Selection/UnSelectElementHandler.tsx
@@ -44,6 +44,8 @@ export function UnSelectElementHandler() {
 
   const positionRef = useRef<Point | undefined>();
 
+  const rectRef = useRef<SVGRectElement>(null);
+
   const unselectElement = useCallback(() => {
     if (activeElementId) {
       slideInstance.setActiveElementId(undefined);
@@ -72,6 +74,11 @@ export function UnSelectElementHandler() {
           });
 
           setDragSelectStartCoords(point);
+
+          if (event.pointerType === 'pen') {
+            // release the event capture, or the drag select layer won't get pointer move events
+            rectRef.current?.releasePointerCapture(event.pointerId);
+          }
         }
       } else if (event.button === 1 || event.button === 2) {
         event.preventDefault();
@@ -97,6 +104,11 @@ export function UnSelectElementHandler() {
 
   const handlePointerMove = useCallback(
     (event: PointerEvent<SVGRectElement>) => {
+      // ignore when pen isn't touching the surface
+      if (event.pointerType === 'pen' && event.buttons === 0) {
+        return;
+      }
+
       if (!infiniteCanvasMode || !positionRef.current || !isPanningEnabled)
         return;
 
@@ -140,6 +152,7 @@ export function UnSelectElementHandler() {
 
   return (
     <rect
+      ref={rectRef}
       fill="transparent"
       height={whiteboardHeight}
       onPointerDown={handlePointerDown}

--- a/packages/react-sdk/src/lib/testUtils/domTestUtils.ts
+++ b/packages/react-sdk/src/lib/testUtils/domTestUtils.ts
@@ -15,6 +15,7 @@
  */
 
 type DocumentVisibilityState = Document['visibilityState'];
+import { fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 
 export function mockDocumentVisibilityState(
@@ -22,4 +23,14 @@ export function mockDocumentVisibilityState(
 ): void {
   vi.spyOn(document, 'visibilityState', 'get').mockReturnValue(visibility);
   document.dispatchEvent(new Event('visibilitychange'));
+}
+
+// jsdom lacks proper pointer event support and fields such as pointerType, clientX
+// will be undefined in the event handlers if we use fireEvent.pointerMove
+export function firePointerMoveEvent(
+  element: Element | Node | Document | Window,
+  options?: {} | undefined,
+): boolean {
+  const event = new Event('pointermove', { bubbles: true, cancelable: true });
+  return fireEvent(element, Object.assign(event, options));
 }


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).

Fixes the problem when the user can get stuck in the drag-select mode when using a pen/stylus that sends pointer move events when hovering above the screen or the drawing surface.