### PR TITLE
"Line thickness" control added for selected polylines in the ElementBar

### DIFF
--- a/.changeset/true-snails-retire.md
+++ b/.changeset/true-snails-retire.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-react-sdk': minor
+---
+
+"Line thickness" control added for selected polyline elements in the Element Bar. The last changed thickness value will be used when adding a new polyline in the current browser session, the default line thickness is 4.

--- a/packages/react-sdk/src/components/ElementBar/ElementBar.tsx
+++ b/packages/react-sdk/src/components/ElementBar/ElementBar.tsx
@@ -24,6 +24,7 @@ import { DuplicateActiveElementButton } from './DuplicateActiveElementButton';
 import { FontFamilyButton } from './FontFamilyButton';
 import { FontSizeButton } from './FontSizeButton';
 import { LineMarkerButtons } from './LineMarkerButtons';
+import { PolylineThicknessSelect } from './PolylineThicknessSelect';
 import { TextAlignmentButtons } from './TextAlignmentButtons';
 import { TextBoldButton } from './TextBoldButton';
 import { TextItalicButton } from './TextItalicButton';
@@ -48,6 +49,7 @@ function ElementBar({
         </>
       )}
       <ElementColorPicker />
+      <PolylineThicknessSelect />
       <DuplicateActiveElementButton />
       <DeleteActiveElementButton />
     </Toolbar>

--- a/packages/react-sdk/src/components/ElementBar/PolylineThicknessSelect/PolylineThicknessSelect.test.tsx
+++ b/packages/react-sdk/src/components/ElementBar/PolylineThicknessSelect/PolylineThicknessSelect.test.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MockedWidgetApi, mockWidgetApi } from '@matrix-widget-toolkit/testing';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axe from 'axe-core';
+import { ComponentType, PropsWithChildren } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  WhiteboardTestingContextProvider,
+  mockEllipseElement,
+  mockPolylineElement,
+  mockWhiteboardManager,
+} from '../../../lib/testUtils/documentTestUtils';
+import { WhiteboardSlideInstance } from '../../../state';
+import { Toolbar } from '../../common/Toolbar';
+import { LayoutStateProvider } from '../../Layout';
+import { defaultStrokeWidth } from '../../Whiteboard/constants';
+import { PolylineThicknessSelect } from './PolylineThicknessSelect';
+
+let widgetApi: MockedWidgetApi;
+
+afterEach(() => widgetApi.stop());
+
+beforeEach(() => {
+  widgetApi = mockWidgetApi();
+});
+
+describe('<PolylineThicknessSelect/>', () => {
+  let Wrapper: ComponentType<PropsWithChildren<{}>>;
+  let slide: WhiteboardSlideInstance;
+
+  beforeEach(() => {
+    const { whiteboardManager } = mockWhiteboardManager({
+      slides: [
+        [
+          'slide-0',
+          [
+            ['element-0', mockPolylineElement({ strokeWidth: 8 })],
+            ['element-7', mockPolylineElement({ strokeWidth: 7 })],
+            [
+              'element-undefined',
+              mockPolylineElement({ strokeWidth: undefined }),
+            ],
+            ['ellipse', mockEllipseElement()],
+          ],
+        ],
+      ],
+    });
+    slide = whiteboardManager
+      .getActiveWhiteboardInstance()!
+      .getSlide('slide-0');
+    slide.setActiveElementIds(['element-0']);
+
+    Wrapper = ({ children }) => (
+      <WhiteboardTestingContextProvider
+        whiteboardManager={whiteboardManager}
+        widgetApi={widgetApi}
+      >
+        <LayoutStateProvider>
+          <Toolbar>{children}</Toolbar>
+        </LayoutStateProvider>
+      </WhiteboardTestingContextProvider>
+    );
+  });
+
+  it('should render without exploding', async () => {
+    render(<PolylineThicknessSelect />, { wrapper: Wrapper });
+
+    const select = screen.getByRole('combobox', {
+      name: 'Select Line Thickness',
+    });
+
+    expect(select).toBeInTheDocument();
+  });
+
+  it('should have no accessibility violations', async () => {
+    const { container } = render(<PolylineThicknessSelect />, {
+      wrapper: Wrapper,
+    });
+
+    expect(
+      screen.getByRole('combobox', { name: 'Select Line Thickness' }),
+    ).toBeInTheDocument();
+
+    expect(await axe.run(container)).toHaveNoViolations();
+  });
+
+  it('should show the stroke width of the active element', async () => {
+    slide.setActiveElementId('element-7');
+    render(<PolylineThicknessSelect />, { wrapper: Wrapper });
+
+    const select = screen.getByRole('combobox', {
+      name: 'Select Line Thickness',
+    });
+
+    expect(select).toHaveTextContent('7');
+  });
+
+  it('should show the default stroke width if the active element has none', async () => {
+    slide.setActiveElementId('element-undefined');
+    render(<PolylineThicknessSelect />, { wrapper: Wrapper });
+
+    const select = screen.getByRole('combobox', {
+      name: 'Select Line Thickness',
+    });
+
+    expect(select).toHaveTextContent('4');
+  });
+
+  it('should show the stroke width of the first selected element if several elements are active', async () => {
+    slide.setActiveElementIds(['element-7', 'element-0']);
+    render(<PolylineThicknessSelect />, { wrapper: Wrapper });
+
+    const select = screen.getByRole('combobox', {
+      name: 'Select Line Thickness',
+    });
+
+    expect(select).toHaveTextContent('7');
+  });
+
+  it('should always contain the default stroke width as an option', async () => {
+    slide.setActiveElementId('element-7');
+    render(<PolylineThicknessSelect />, { wrapper: Wrapper });
+
+    await userEvent.click(
+      screen.getByRole('combobox', { name: 'Select Line Thickness' }),
+    );
+
+    expect(
+      screen.getByRole('option', { name: `${defaultStrokeWidth}` }),
+    ).toBeInTheDocument();
+  });
+
+  it('should not render if the active element is not a polyline', async () => {
+    slide.setActiveElementId('ellipse');
+    render(<PolylineThicknessSelect />, { wrapper: Wrapper });
+
+    expect(
+      screen.queryByRole('combobox', { name: 'Select Line Thickness' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/react-sdk/src/components/ElementBar/PolylineThicknessSelect/PolylineThicknessSelect.tsx
+++ b/packages/react-sdk/src/components/ElementBar/PolylineThicknessSelect/PolylineThicknessSelect.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MenuItem, Select, Tooltip } from '@mui/material';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useActiveElements, useElements } from '../../../state';
+import { useLineThickness } from './useLineThickness';
+
+const STROKE_WIDTHS = [4, 6, 8, 10, 12, 14, 16];
+
+export function PolylineThicknessSelect() {
+  const { t } = useTranslation('neoboard');
+  const { lineThickness, applyLineThickness } = useLineThickness();
+
+  const { activeElementIds } = useActiveElements();
+  const elements = useElements(activeElementIds);
+
+  const strokeWidths = useMemo(
+    () =>
+      STROKE_WIDTHS.includes(lineThickness)
+        ? STROKE_WIDTHS
+        : [...STROKE_WIDTHS, lineThickness].sort((a, b) => a - b),
+    [lineThickness],
+  );
+
+  const hasPolylinePath = Object.values(elements).find(
+    (element) => element.type === 'path' && element.kind === 'polyline',
+  );
+
+  if (!hasPolylinePath) {
+    return null;
+  }
+
+  const label = t('elementBar.lineThickness', 'Select Line Thickness');
+
+  return (
+    <Select
+      size="small"
+      variant="standard"
+      disableUnderline={true}
+      value={lineThickness}
+      inputProps={{
+        'aria-label': label,
+      }}
+      SelectDisplayProps={{
+        style: {
+          textAlign: 'center',
+          paddingRight: '18px',
+          paddingTop: '4px',
+        },
+      }}
+      onChange={(event) => {
+        applyLineThickness(event.target.value as number);
+      }}
+      sx={{
+        // Set a min-width to prevent change of the select width depending on the value
+        minWidth: '64px',
+        padding: '0 5px 0 8px',
+      }}
+    >
+      {strokeWidths.map((value) => {
+        return (
+          <MenuItem value={value} key={value}>
+            {lineThickness === value && (
+              <Tooltip title={label}>
+                <div>{value}</div>
+              </Tooltip>
+            )}
+
+            {lineThickness !== value && value}
+          </MenuItem>
+        );
+      })}
+    </Select>
+  );
+}

--- a/packages/react-sdk/src/components/ElementBar/PolylineThicknessSelect/index.ts
+++ b/packages/react-sdk/src/components/ElementBar/PolylineThicknessSelect/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { PolylineThicknessSelect } from './PolylineThicknessSelect';
+export { useLineThickness } from './useLineThickness';

--- a/packages/react-sdk/src/components/ElementBar/PolylineThicknessSelect/useLineThickness.ts
+++ b/packages/react-sdk/src/components/ElementBar/PolylineThicknessSelect/useLineThickness.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback } from 'react';
+import {
+  Element,
+  ElementUpdate,
+  PathElement,
+  useActiveElements,
+  useElements,
+  useWhiteboardSlideInstance,
+} from '../../../state';
+import { useLayoutState } from '../../Layout';
+import { defaultStrokeWidth } from '../../Whiteboard/constants';
+
+type UseLineThicknessResult = {
+  /**
+   * The stroke width of the first selected polyline in the active elements, falling back to the
+   * last applied polyline thickness, or the default stroke width if neither
+   * is available.
+   */
+  lineThickness: number;
+  /**
+   * Apply the given stroke width to all selected polylines and remember it
+   * as the thickness to use for new polylines in the LayoutState.activePolylineThickness
+   *
+   * @param value - the stroke width to apply
+   */
+  applyLineThickness: (value: number) => void;
+};
+
+function isPolyline(element: Element): element is PathElement {
+  return element.type === 'path' && element.kind === 'polyline';
+}
+
+export const useLineThickness = (): UseLineThicknessResult => {
+  const slideInstance = useWhiteboardSlideInstance();
+  const { activeElementIds } = useActiveElements();
+  const { activePolylineThickness, setActivePolylineThickness } =
+    useLayoutState();
+  const activeElements = useElements(activeElementIds);
+  const elements = Object.values(activeElements);
+
+  const lineThickness: number =
+    elements.find(isPolyline)?.strokeWidth ??
+    activePolylineThickness ??
+    defaultStrokeWidth;
+
+  const applyLineThickness = useCallback(
+    (value: number) => {
+      const updates: ElementUpdate[] = [];
+      for (const [elementId, element] of Object.entries(activeElements)) {
+        if (isPolyline(element)) {
+          updates.push({ elementId, patch: { strokeWidth: value } });
+        }
+      }
+
+      if (updates.length > 0) {
+        slideInstance.updateElements(updates);
+        setActivePolylineThickness(value);
+      }
+    },
+    [activeElements, slideInstance, setActivePolylineThickness],
+  );
+
+  return {
+    lineThickness,
+    applyLineThickness,
+  };
+};

--- a/packages/react-sdk/src/components/Layout/useLayoutState.tsx
+++ b/packages/react-sdk/src/components/Layout/useLayoutState.tsx
@@ -60,6 +60,7 @@ type LayoutState = {
   activeShapeTextShade: number;
   activeStartLineMarker: LineMarker | undefined;
   activeEndLineMarker: LineMarker | undefined;
+  activePolylineThickness: number | undefined;
   isRotating: boolean;
   isPinchZooming: boolean;
 
@@ -81,6 +82,7 @@ type LayoutState = {
   setActiveEndLineMarker: (marker: LineMarker | undefined) => void;
   setIsRotating: (value: boolean) => void;
   setIsPinchZooming: (value: boolean) => void;
+  setActivePolylineThickness: (value: number | undefined) => void;
 
   /**
    * Whether the layout is displayed in fullscreen mode.
@@ -151,6 +153,10 @@ export function LayoutStateProvider({ children }: PropsWithChildren<{}>) {
   };
   const [isRotating, setIsRotating] = useState<boolean>(false);
 
+  const [activePolylineThickness, setActivePolylineThickness] = useState<
+    number | undefined
+  >();
+
   const value = useMemo(
     () => ({
       isSlideOverviewVisible,
@@ -170,6 +176,7 @@ export function LayoutStateProvider({ children }: PropsWithChildren<{}>) {
       activeShapeTextShade,
       activeStartLineMarker,
       activeEndLineMarker,
+      activePolylineThickness,
       setSlideOverviewVisible,
       setDeveloperToolsVisible,
       setShowCollaboratorsCursors,
@@ -184,6 +191,7 @@ export function LayoutStateProvider({ children }: PropsWithChildren<{}>) {
       setActiveShapeShade,
       setActiveShapeTextColor,
       setActiveShapeTextShade,
+      setActivePolylineThickness,
       isFullscreenMode,
       setFullscreenMode,
       dragSelectStartCoords,
@@ -221,6 +229,8 @@ export function LayoutStateProvider({ children }: PropsWithChildren<{}>) {
       setIsRotating,
       isPinchZooming,
       setIsPinchZooming,
+      activePolylineThickness,
+      setActivePolylineThickness,
     ],
   );
 

--- a/packages/react-sdk/src/components/Whiteboard/Draft/DraftLineChild.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/Draft/DraftLineChild.tsx
@@ -53,7 +53,8 @@ export const DraftLineChild = ({
   const [cursorPoints, setCursorPoints] = useState<Point[]>();
   const [connectedElementStart, setConnectedElementStart] = useState<string>();
   const [connectedElementEnd, setConnectedElementEnd] = useState<string>();
-  const { activeColor: strokeColor } = useLayoutState();
+  const { activeColor: strokeColor, activePolylineThickness } =
+    useLayoutState();
   const slideInstance = useWhiteboardSlideInstance();
   const { setActiveTool } = useLayoutState();
   const { calculateSvgCoords } = useSvgCanvasContext();
@@ -67,6 +68,8 @@ export const DraftLineChild = ({
             kind,
             cursorPoints,
             strokeColor,
+            strokeWidth:
+              kind === 'polyline' ? activePolylineThickness : undefined,
             frameElements: slideInstance.getFrameElements(),
             gridCellSize: isShowGrid ? gridCellSize : undefined,
             onlyStartAndEndPoints,
@@ -86,18 +89,19 @@ export const DraftLineChild = ({
       setConnectElementIds([]);
     }
   }, [
-    setActiveTool,
     cursorPoints,
+    setConnectElementIds,
     slideInstance,
     kind,
     strokeColor,
+    activePolylineThickness,
     isShowGrid,
     onlyStartAndEndPoints,
     startMarker,
     endMarker,
     connectedElementStart,
     connectedElementEnd,
-    setConnectElementIds,
+    setActiveTool,
   ]);
 
   const handlePointerMove = useCallback(
@@ -150,6 +154,8 @@ export const DraftLineChild = ({
             kind,
             cursorPoints,
             strokeColor,
+            strokeWidth:
+              kind === 'polyline' ? activePolylineThickness : undefined,
             gridCellSize: isShowGrid ? gridCellSize : undefined,
             onlyStartAndEndPoints,
             startMarker,
@@ -162,6 +168,7 @@ export const DraftLineChild = ({
       cursorPoints,
       kind,
       strokeColor,
+      activePolylineThickness,
       isShowGrid,
       onlyStartAndEndPoints,
       startMarker,

--- a/packages/react-sdk/src/components/Whiteboard/Draft/createShape.ts
+++ b/packages/react-sdk/src/components/Whiteboard/Draft/createShape.ts
@@ -135,6 +135,7 @@ export function createShapeFromPoints({
   kind,
   cursorPoints,
   strokeColor,
+  strokeWidth,
   frameElements = {},
   gridCellSize,
   onlyStartAndEndPoints = false,
@@ -146,6 +147,7 @@ export function createShapeFromPoints({
   kind: PathKind;
   cursorPoints: Point[];
   strokeColor: string;
+  strokeWidth?: number;
   frameElements?: Elements<FrameElement>;
   gridCellSize?: number;
   onlyStartAndEndPoints?: boolean;
@@ -183,6 +185,10 @@ export function createShapeFromPoints({
     connectedElementStart,
     connectedElementEnd,
   };
+
+  if (kind === 'polyline') {
+    pathElement.strokeWidth = strokeWidth;
+  }
 
   return copyElementWithAttachedFrame(pathElement, frameElements);
 }

--- a/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.test.tsx
+++ b/packages/react-sdk/src/components/Whiteboard/WhiteboardHost.test.tsx
@@ -34,6 +34,7 @@ import {
   mockEllipseElement,
   mockFrameElement,
   mockLineElement,
+  mockPolylineElement,
   mockTextElement,
   mockWhiteboardManager,
   WhiteboardTestingContextProvider,
@@ -1616,5 +1617,74 @@ describe('<WhiteboardHost/>', () => {
     render(<WhiteboardHost />, { wrapper: Wrapper });
 
     expect(screen.queryByTestId(`rotate-handle`)).not.toBeInTheDocument();
+  });
+
+  it('should change the thickness of a selected polyline without a stroke width', async () => {
+    const polylineId = activeSlide.addElement(
+      mockPolylineElement({ strokeWidth: undefined }),
+    );
+    activeSlide.setActiveElementId(polylineId);
+
+    render(<WhiteboardHost />, { wrapper: Wrapper });
+
+    const select = screen.getByRole('combobox', {
+      name: 'Select Line Thickness',
+    });
+
+    // verify that we show the default value of line thickness when it's undefined
+    expect(select).toHaveTextContent(`${constants.defaultStrokeWidth}`);
+
+    await userEvent.click(select);
+    await userEvent.click(screen.getByRole('option', { name: '8' }));
+
+    expect(activeSlide.getElement(polylineId)).toEqual(
+      expect.objectContaining({ strokeWidth: 8 }),
+    );
+  });
+
+  it('should use the last applied line thickness for a newly drawn polyline', async () => {
+    const polylineId = activeSlide.addElement(
+      mockPolylineElement({ strokeWidth: 8 }),
+    );
+    activeSlide.setActiveElementId(polylineId);
+
+    render(<WhiteboardHost />, { wrapper: Wrapper });
+
+    await userEvent.click(
+      screen.getByRole('combobox', { name: 'Select Line Thickness' }),
+    );
+    await userEvent.click(screen.getByRole('option', { name: '16' }));
+
+    act(() => setActiveTool('polyline'));
+
+    const draftHandler = screen.getByTestId('draft-pointer-handler');
+
+    await userEvent.pointer([
+      {
+        keys: '[MouseLeft>]',
+        target: draftHandler,
+        coords: { clientX: 50, clientY: 101 },
+      },
+      {
+        pointerName: 'mouse',
+        target: draftHandler,
+        coords: { clientX: 50 + 20, clientY: 100 + 20 },
+      },
+      {
+        keys: '[/MouseLeft]',
+        target: draftHandler,
+      },
+    ]);
+
+    expect(activeSlide.getActiveElementIds().length).toBe(1);
+
+    const newElementId = activeSlide.getActiveElementIds()[0];
+
+    expect(activeSlide.getElement(newElementId)).toEqual(
+      expect.objectContaining({
+        kind: 'polyline',
+        strokeWidth: 16,
+      }),
+    );
   });
 });

--- a/packages/react-sdk/src/components/Whiteboard/constants.ts
+++ b/packages/react-sdk/src/components/Whiteboard/constants.ts
@@ -43,3 +43,5 @@ export const stickyColor = '#ffefc1';
 export const zoomStep = 0.1;
 export const zoomMax = 4;
 export const zoomMin = 0.05;
+
+export const defaultStrokeWidth = 4;

--- a/packages/react-sdk/src/components/elements/line/getRenderProperties.ts
+++ b/packages/react-sdk/src/components/elements/line/getRenderProperties.ts
@@ -16,6 +16,7 @@
 
 import { PathElement, Point } from '../../../state';
 import { ElementRenderProperties } from '../../Whiteboard';
+import { defaultStrokeWidth } from '../../Whiteboard/constants';
 
 type PolylineRenderProperties = {
   points: { start: Point; end: Point };
@@ -29,7 +30,7 @@ export function getRenderProperties(
 
   return {
     strokeColor: element.strokeColor,
-    strokeWidth: 4,
+    strokeWidth: defaultStrokeWidth,
 
     points: {
       start: {

--- a/packages/react-sdk/src/components/elements/polyline/getRenderProperties.ts
+++ b/packages/react-sdk/src/components/elements/polyline/getRenderProperties.ts
@@ -16,6 +16,7 @@
 
 import { PathElement, Point } from '../../../state';
 import { ElementRenderProperties } from '../../Whiteboard';
+import { defaultStrokeWidth } from '../../Whiteboard/constants';
 
 type PolylineRenderProperties = {
   points: Point[];
@@ -26,7 +27,7 @@ export function getRenderProperties(
 ): ElementRenderProperties & PolylineRenderProperties {
   return {
     strokeColor: element.strokeColor,
-    strokeWidth: 4,
+    strokeWidth: element.strokeWidth || defaultStrokeWidth,
 
     points: element.points.map(({ x, y }) => ({
       x: element.position.x + x,

--- a/packages/react-sdk/src/locales/de/neoboard.json
+++ b/packages/react-sdk/src/locales/de/neoboard.json
@@ -164,6 +164,7 @@
     "lineEnd": "Linienende",
     "lineMarkerSwitch": "Linienmarkierung tauschen",
     "lineStart": "Linienanfang",
+    "lineThickness": "Linienstärke wählen",
     "textAlignment": "Textausrichtung",
     "textAlignmentCenter": "Zentriert",
     "textAlignmentLeft": "Links",

--- a/packages/react-sdk/src/locales/en/neoboard.json
+++ b/packages/react-sdk/src/locales/en/neoboard.json
@@ -164,6 +164,7 @@
     "lineEnd": "Line End",
     "lineMarkerSwitch": "Line Marker Switch",
     "lineStart": "Line Start",
+    "lineThickness": "Select Line Thickness",
     "textAlignment": "Text Alignment",
     "textAlignmentCenter": "Center",
     "textAlignmentLeft": "Left",

--- a/packages/react-sdk/src/state/crdt/documents/elements.ts
+++ b/packages/react-sdk/src/state/crdt/documents/elements.ts
@@ -118,6 +118,7 @@ export type PathElement = ElementBase & {
   kind: PathKind;
   points: Point[];
   strokeColor: string;
+  strokeWidth?: number;
   startMarker?: LineMarker;
   endMarker?: LineMarker;
   connectedElementStart?: string;


### PR DESCRIPTION


<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).


The last changed value will be used when adding a new polyline in the current browser session, the default line thickness is 4. The path rendering tech didn't change, the feature was already implemented using the strokeWidth field of the path element with the hardcoded value of 4. Changes only apply to elements of type = "path" and kind = "polylines" (added by the Pen tool)
